### PR TITLE
Fix .pc file for use under Windows

### DIFF
--- a/Source/Lib/pkg-config.pc.in
+++ b/Source/Lib/pkg-config.pc.in
@@ -8,5 +8,5 @@ Description: SVT (Scalable Video Technology) for JPEG XS library
 Version: @SVT_LIB_VERSION_MAJOR@.@SVT_LIB_VERSION_MINOR@.@SVT_LIB_VERSION_PATCH@
 Libs: -L${libdir} -lSvtJpegxs
 Libs.private: @LIBS_PRIVATE@
-Cflags: -I${includedir}/svt-jpegxs@DEC_PKG_CONFIG_EXTRA_CFLAGS@
-Cflags.private: -UEB_DLL
+Cflags: -I${includedir}/svt-jpegxs @LIB_PKG_CONFIG_EXTRA_CFLAGS@
+Cflags.private: -UDEF_DLL


### PR DESCRIPTION
Include LIB_PKG_CONFIG_EXTRA_CFLAGS as DEC_PKG_CONFIG_EXTRA_CFLAGS
does not exist. On Windows this will expand to "-DDEF_DLL" so that
"dllimport" is enabled in "SvtJpegxs.h".

Rename "EB_DLL" to "DEF_DLL" in Cflags.private. "EB_DLL" does not exist
and by unsetting "DEF_DLL" we make sure that "dllimport" is not used
when linking the static lib.