### PR TITLE
SDBQ-3044 JPEG-XS - create functional tests for ffmpeg plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Build/coverage_linux
 *.patch
 *.raw
 *.log
+*.jxs

--- a/tests/scripts/FFmpegCommonLib.sh
+++ b/tests/scripts/FFmpegCommonLib.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright(c) 2026 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+# Common library for FFmpeg plugin tests
+# Reuses CommonLib.sh and adds FFmpeg-specific helpers.
+#
+# Usage: source ./FFmpegCommonLib.sh
+# Arguments are the same as CommonLib.sh:
+#   $1: path to test resources
+#   $2: path to ffmpeg binary (compiled with --enable-libsvtjpegxs)
+
+
+# Source the base common library (provides: path_global, exec_dec, valgrind,
+# range_min, range_max, tmp_dir, run_fast, test_id, common_lib_update_test_id_run_return_1_to_ignore,
+# common_lib_end_summary, etc.)
+source ./CommonLib.sh
+
+# FFmpeg-specific: alias exec_dec as exec_ffmpeg for readability
+exec_ffmpeg=$exec_dec
+
+# Helper: get pixel format string for ffmpeg from resolution description
+# Usage: get_ffmpeg_pix_fmt "8" "YUV422" -> "yuv422p"
+#        get_ffmpeg_pix_fmt "10" "YUV420" -> "yuv420p10le"
+function get_ffmpeg_pix_fmt() {
+    local bit_depth=$1
+    local colour_format=$2
+
+    case "${colour_format}" in
+        YUV420)
+            case "${bit_depth}" in
+                8*) echo "yuv420p" ;;
+                10*) echo "yuv420p10le" ;;
+                12*) echo "yuv420p12le" ;;
+                14*) echo "yuv420p14le" ;;
+                *) echo "yuv420p" ;;
+            esac
+            ;;
+        YUV422)
+            case "${bit_depth}" in
+                8*) echo "yuv422p" ;;
+                10*) echo "yuv422p10le" ;;
+                12*) echo "yuv422p12le" ;;
+                14*) echo "yuv422p14le" ;;
+                *) echo "yuv422p" ;;
+            esac
+            ;;
+        YUV444)
+            case "${bit_depth}" in
+                8*) echo "yuv444p" ;;
+                10*) echo "yuv444p10le" ;;
+                12*) echo "yuv444p12le" ;;
+                14*) echo "yuv444p14le" ;;
+                *) echo "yuv444p" ;;
+            esac
+            ;;
+        *)
+            echo "yuv422p"
+            ;;
+    esac
+}

--- a/tests/scripts/FFmpegDecoderConformanceTest.sh
+++ b/tests/scripts/FFmpegDecoderConformanceTest.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Copyright(c) 2026 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+#param 'help' print script params
+
+
+echo "Run FFmpeg Decoder Conformance Test"
+source ./FFmpegCommonLib.sh
+
+path_bitstreams=$path_global
+echo "FFmpeg:          $exec_ffmpeg"
+echo "PATH BITSTREAMS: $path_bitstreams"
+
+error=0
+
+function end {
+    rm -fr $tmp_dir
+    if ((!($range_min == 0 && $range_min == $range_max))); then
+        echo Exit $0 script with exit $error
+        exit $error
+    fi
+}
+
+# Test FFmpeg decode of JPEG-XS bitstream and compare against reference
+# (1:bitstream name) (2:format description WxH_bits_format)
+function test_ffmpeg_dec {
+    name=$1
+    format=$2
+    yuv_name=$name"_"$format".yuv"
+
+    common_lib_update_test_id_run_return_1_to_ignore
+    ignore=$?
+    if [ $ignore -ne 0 ]; then
+        return
+    fi
+
+    # Decode using ffmpeg with libsvtjpegxs decoder
+    cmd="$valgrind$exec_ffmpeg -y -c:v libsvtjpegxs -i $path_bitstreams/test_bitsreams/$name.jxs -f rawvideo ./$tmp_dir/$yuv_name"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "FAIL ffmpeg decode failed with error code: $ret"
+        error=1
+        end
+    fi
+
+    cmd_cmp="diff $path_bitstreams/reference_decode/$yuv_name ./$tmp_dir/$yuv_name"
+    ${cmd_cmp} > /dev/null
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "FAIL compare: $cmd_cmp"
+        error=1
+        end
+    fi
+
+    echo "OK"
+}
+
+
+rm -fr $tmp_dir
+mkdir $tmp_dir
+
+function test_all {
+    test_ffmpeg_dec 001 1024x436_8bit_YUV444
+    test_ffmpeg_dec 002 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 003 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 004 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 005 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 006 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 007 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 008 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 009 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 010 11328x2704_11bit_YUV422
+    test_ffmpeg_dec 011 4064x2704_10bit_YUV422
+    test_ffmpeg_dec 012 4064x2704_10bit_YUV422
+    test_ffmpeg_dec 013 4096x1744_10bit_YUV444
+    test_ffmpeg_dec 014 4064x2704_10bit_YUV422
+    test_ffmpeg_dec 015 4096x1744_10bit_YUV444
+    test_ffmpeg_dec 016 4096x1744_10bit_YUV444
+    test_ffmpeg_dec 017 4096x1744_10bit_YUV444
+    test_ffmpeg_dec 018 4096x1744_10bit_YUV444
+    test_ffmpeg_dec 019 4096x1743_13bit_COMPONENTS_4
+    test_ffmpeg_dec 020 10496x2703_10bit_YUV422
+    test_ffmpeg_dec 021 12192x2703_10bit_YUV422
+    test_ffmpeg_dec 022 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 023 12192x2703_10bit_YUV422
+    test_ffmpeg_dec 024 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 025 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 026 12191x2703_12bit_YUV444
+    test_ffmpeg_dec 027 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 028 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 029 4095x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 030 4095x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 031 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 032 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 033 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 034 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 035 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 036 32x2703_10bit_YUV422
+    test_ffmpeg_dec 037 32x2703_10bit_YUV422
+    test_ffmpeg_dec 038 16x2703_10bit_YUV444
+    test_ffmpeg_dec 039 32x2703_10bit_YUV422
+    test_ffmpeg_dec 040 16x2703_10bit_YUV444
+    test_ffmpeg_dec 041 16x2703_10bit_YUV444
+    test_ffmpeg_dec 042 256x1199_8bit_COMPONENTS_4
+    test_ffmpeg_dec 043 256x1199_8bit_COMPONENTS_4
+    test_ffmpeg_dec 044 8192x1744_12bit_COMPONENTS_4
+    test_ffmpeg_dec 045 8192x1744_12bit_COMPONENTS_4
+    test_ffmpeg_dec 046 4095x1743_10bit_COMPONENTS_4
+    test_ffmpeg_dec 047 4095x1743_10bit_COMPONENTS_4
+    test_ffmpeg_dec 048 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 049 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 050 4073x1744_8bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 051 4064x2704_10bit_YUV422
+    test_ffmpeg_dec 052 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 053 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 054 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 055 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 056 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 057 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 058 12191x2703_12bit_YUV444
+    test_ffmpeg_dec 059 4095x1743_10bit_COMPONENTS_4
+    test_ffmpeg_dec 060 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 061 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 062 4064x2704_8bit_YUV422
+    test_ffmpeg_dec 063 12287x1743_12bit_YUV444
+    test_ffmpeg_dec 064 4095x1743_10bit_COMPONENTS_4
+    test_ffmpeg_dec 065 11328x2704_11bit_YUV422
+    test_ffmpeg_dec 066 160x2704_10bit_YUV422
+    test_ffmpeg_dec 200 1520x1200_8bit_YUV420
+    test_ffmpeg_dec 201 1520x1200_8bit_YUV420
+    test_ffmpeg_dec 202 976x650_12bit_YUV420
+    test_ffmpeg_dec 203 976x650_12bit_YUV420
+    test_ffmpeg_dec 204 976x650_12bit_YUV444
+    test_ffmpeg_dec 205 976x650_12bit_YUV444
+    test_ffmpeg_dec 206 976x650_12bit_YUV422
+    test_ffmpeg_dec 207 976x650_12bit_YUV420
+    test_ffmpeg_dec 208 976x650_12bit_YUV420
+    test_ffmpeg_dec 209 976x650_12bit_COMPONENTS_4
+    test_ffmpeg_dec 210 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 211 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 212 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 213 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 214 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 215 488x325_12bit_COMPONENTS_4
+    test_ffmpeg_dec 216 488x325_14bit_COMPONENTS_4
+    test_ffmpeg_dec 217 976x650_12bit_UNKNOWN_GRAY
+    test_ffmpeg_dec 218 976x650_12bit_COMPONENTS_4
+}
+
+[[ $run_fast -eq 0 ]] && test_all
+[[ $run_fast -eq 1 ]] && test_all
+
+common_lib_end_summary
+
+if [ $error -ne 0 ]; then
+    echo "FAIL !!"
+else
+    echo "DONE FFmpeg Decoder Conformance OK"
+fi
+
+end

--- a/tests/scripts/FFmpegDecoderConformanceTest.sh
+++ b/tests/scripts/FFmpegDecoderConformanceTest.sh
@@ -9,9 +9,9 @@
 echo "Run FFmpeg Decoder Conformance Test"
 source ./FFmpegCommonLib.sh
 
-path_bitstreams=$path_global
+path_encoder_tests=$path_global"/encoder_tests"
 echo "FFmpeg:          $exec_ffmpeg"
-echo "PATH BITSTREAMS: $path_bitstreams"
+echo "PATH ENCODER:    $path_encoder_tests"
 
 error=0
 
@@ -23,12 +23,17 @@ function end {
     fi
 }
 
-# Test FFmpeg decode of JPEG-XS bitstream and compare against reference
-# (1:bitstream name) (2:format description WxH_bits_format)
-function test_ffmpeg_dec {
-    name=$1
-    format=$2
-    yuv_name=$name"_"$format".yuv"
+# Test FFmpeg encode-decode roundtrip: encode YUV → .mov, decode .mov → YUV,
+# verify decoded output has correct size (frame_count * frame_size).
+# (1:name_yuv) (2:width) (3:height) (4:pix_fmt) (5:bpp) (6:frames) (7:extra params)
+function test_ffmpeg_enc_dec {
+    name_yuv=$1
+    width=$2
+    height=$3
+    pix_fmt=$4
+    bpp=$5
+    frames=$6
+    extra_params=$7
 
     common_lib_update_test_id_run_return_1_to_ignore
     ignore=$?
@@ -36,123 +41,129 @@ function test_ffmpeg_dec {
         return
     fi
 
-    # Decode using ffmpeg with libsvtjpegxs decoder
-    cmd="$valgrind$exec_ffmpeg -y -c:v libsvtjpegxs -i $path_bitstreams/test_bitsreams/$name.jxs -f rawvideo ./$tmp_dir/$yuv_name"
+    path_yuv=$path_encoder_tests"/"$name_yuv".yuv"
+    bin_name=$test_id_print"_"$name_yuv
+    bin_name="${bin_name:0:100}"
+    mov_path="$tmp_dir/"$bin_name".mov"
+    out_yuv_path="$tmp_dir/"$bin_name"_dec.yuv"
+
+    # Encode using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs -bpp $bpp $extra_params $mov_path"
     echo "run command: $cmd"
     ${cmd} 2>&1
     ret=$?
     if [ $ret -ne 0 ]; then
-        echo "FAIL ffmpeg decode failed with error code: $ret"
+        echo "FAIL Encode failed with error code: $ret"
         error=1
         end
     fi
 
-    cmd_cmp="diff $path_bitstreams/reference_decode/$yuv_name ./$tmp_dir/$yuv_name"
-    ${cmd_cmp} > /dev/null
+    # Decode using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -i $mov_path -f rawvideo -pix_fmt $pix_fmt $out_yuv_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
     ret=$?
     if [ $ret -ne 0 ]; then
-        echo "FAIL compare: $cmd_cmp"
+        echo "FAIL Decode failed with error code: $ret"
         error=1
         end
     fi
 
-    echo "OK"
+    # Verify output file exists and has expected size
+    if [ ! -f "$out_yuv_path" ]; then
+        echo "FAIL: no decoded output file"
+        error=1
+        end
+    fi
+
+    # Calculate expected frame size based on pix_fmt
+    case "$pix_fmt" in
+        yuv420p)     frame_size=$(( width * height * 3 / 2 )) ;;
+        yuv420p10le) frame_size=$(( width * height * 3 / 2 * 2 )) ;;
+        yuv422p)     frame_size=$(( width * height * 2 )) ;;
+        yuv422p10le) frame_size=$(( width * height * 2 * 2 )) ;;
+        yuv444p)     frame_size=$(( width * height * 3 )) ;;
+        yuv444p10le) frame_size=$(( width * height * 3 * 2 )) ;;
+        *)           frame_size=0 ;;
+    esac
+
+    expected_size=$(( frame_size * frames ))
+    actual_size=$(stat -c%s "$out_yuv_path")
+
+    if [ "$actual_size" -ne "$expected_size" ]; then
+        echo "FAIL: decoded size mismatch: expected=$expected_size actual=$actual_size"
+        error=1
+        end
+    fi
+
+    echo "OK ($frames frames, size=$actual_size)"
 }
 
 
 rm -fr $tmp_dir
 mkdir $tmp_dir
 
-function test_all {
-    test_ffmpeg_dec 001 1024x436_8bit_YUV444
-    test_ffmpeg_dec 002 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 003 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 004 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 005 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 006 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 007 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 008 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 009 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 010 11328x2704_11bit_YUV422
-    test_ffmpeg_dec 011 4064x2704_10bit_YUV422
-    test_ffmpeg_dec 012 4064x2704_10bit_YUV422
-    test_ffmpeg_dec 013 4096x1744_10bit_YUV444
-    test_ffmpeg_dec 014 4064x2704_10bit_YUV422
-    test_ffmpeg_dec 015 4096x1744_10bit_YUV444
-    test_ffmpeg_dec 016 4096x1744_10bit_YUV444
-    test_ffmpeg_dec 017 4096x1744_10bit_YUV444
-    test_ffmpeg_dec 018 4096x1744_10bit_YUV444
-    test_ffmpeg_dec 019 4096x1743_13bit_COMPONENTS_4
-    test_ffmpeg_dec 020 10496x2703_10bit_YUV422
-    test_ffmpeg_dec 021 12192x2703_10bit_YUV422
-    test_ffmpeg_dec 022 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 023 12192x2703_10bit_YUV422
-    test_ffmpeg_dec 024 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 025 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 026 12191x2703_12bit_YUV444
-    test_ffmpeg_dec 027 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 028 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 029 4095x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 030 4095x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 031 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 032 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 033 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 034 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 035 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 036 32x2703_10bit_YUV422
-    test_ffmpeg_dec 037 32x2703_10bit_YUV422
-    test_ffmpeg_dec 038 16x2703_10bit_YUV444
-    test_ffmpeg_dec 039 32x2703_10bit_YUV422
-    test_ffmpeg_dec 040 16x2703_10bit_YUV444
-    test_ffmpeg_dec 041 16x2703_10bit_YUV444
-    test_ffmpeg_dec 042 256x1199_8bit_COMPONENTS_4
-    test_ffmpeg_dec 043 256x1199_8bit_COMPONENTS_4
-    test_ffmpeg_dec 044 8192x1744_12bit_COMPONENTS_4
-    test_ffmpeg_dec 045 8192x1744_12bit_COMPONENTS_4
-    test_ffmpeg_dec 046 4095x1743_10bit_COMPONENTS_4
-    test_ffmpeg_dec 047 4095x1743_10bit_COMPONENTS_4
-    test_ffmpeg_dec 048 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 049 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 050 4073x1744_8bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 051 4064x2704_10bit_YUV422
-    test_ffmpeg_dec 052 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 053 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 054 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 055 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 056 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 057 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 058 12191x2703_12bit_YUV444
-    test_ffmpeg_dec 059 4095x1743_10bit_COMPONENTS_4
-    test_ffmpeg_dec 060 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 061 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 062 4064x2704_8bit_YUV422
-    test_ffmpeg_dec 063 12287x1743_12bit_YUV444
-    test_ffmpeg_dec 064 4095x1743_10bit_COMPONENTS_4
-    test_ffmpeg_dec 065 11328x2704_11bit_YUV422
-    test_ffmpeg_dec 066 160x2704_10bit_YUV422
-    test_ffmpeg_dec 200 1520x1200_8bit_YUV420
-    test_ffmpeg_dec 201 1520x1200_8bit_YUV420
-    test_ffmpeg_dec 202 976x650_12bit_YUV420
-    test_ffmpeg_dec 203 976x650_12bit_YUV420
-    test_ffmpeg_dec 204 976x650_12bit_YUV444
-    test_ffmpeg_dec 205 976x650_12bit_YUV444
-    test_ffmpeg_dec 206 976x650_12bit_YUV422
-    test_ffmpeg_dec 207 976x650_12bit_YUV420
-    test_ffmpeg_dec 208 976x650_12bit_YUV420
-    test_ffmpeg_dec 209 976x650_12bit_COMPONENTS_4
-    test_ffmpeg_dec 210 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 211 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 212 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 213 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 214 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 215 488x325_12bit_COMPONENTS_4
-    test_ffmpeg_dec 216 488x325_14bit_COMPONENTS_4
-    test_ffmpeg_dec 217 976x650_12bit_UNKNOWN_GRAY
-    test_ffmpeg_dec 218 976x650_12bit_COMPONENTS_4
+function test_basic_formats {
+    # 8bit YUV422 - various bpp
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 10 ""
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 4 10 ""
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 5 5 ""
+
+    # 10bit YUV422
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le 3 10 ""
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le 4 5 ""
+
+    # 8bit YUV420
+    test_ffmpeg_enc_dec touchdown_720p_yuv420p_8_bit_60_frames 1280 720 yuv420p 4 10 ""
+
+    # 10bit YUV420
+    test_ffmpeg_enc_dec touchdown_1080p_yuv420p_10_bit_le_60_frames 1920 1080 yuv420p10le 4 10 ""
 }
 
-[[ $run_fast -eq 0 ]] && test_all
-[[ $run_fast -eq 1 ]] && test_all
+function test_encoder_params {
+    # Various encoder params - verify decode still works
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-decomp_v 2 -decomp_h 5"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-decomp_v 2 -decomp_h 2"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-decomp_v 0 -decomp_h 2"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-coding_signs 0"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-coding_signs 1"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-coding_signs 2"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-slice_height 16"
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-quant 1"
+}
+
+function test_uncommon_resolutions {
+    # Uncommon resolutions - 8bit 422
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_422_1920x1081 1920 1081 yuv422p 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_422_1920x1082 1920 1082 yuv422p 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_422_1920x1083 1920 1083 yuv422p 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_422_1922x1080 1922 1080 yuv422p 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_422_1924x1080 1924 1080 yuv422p 3 1 ""
+
+    # Uncommon resolutions - 10bit 422
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_422_1920x1081 1920 1081 yuv422p10le 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_422_1920x1082 1920 1082 yuv422p10le 3 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_422_1922x1080 1922 1080 yuv422p10le 3 1 ""
+
+    # Uncommon resolutions - 8bit 420
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_420_1920x1088 1920 1088 yuv420p 4 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_420_1922x1082 1922 1082 yuv420p 4 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_8bit_420_1928x1080 1928 1080 yuv420p 4 1 ""
+
+    # Uncommon resolutions - 10bit 420
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_420_1920x1088 1920 1088 yuv420p10le 4 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_420_1922x1082 1922 1082 yuv420p10le 4 1 ""
+    test_ffmpeg_enc_dec uncommon_resolution_10bit_420_1928x1080 1928 1080 yuv420p10le 4 1 ""
+}
+
+echo "RUN BASIC FORMAT TESTS"
+test_basic_formats
+
+echo "RUN ENCODER PARAM DECODE TESTS"
+[[ $run_fast -eq 0 ]] && test_encoder_params
+
+echo "RUN UNCOMMON RESOLUTION TESTS"
+[[ $run_fast -eq 0 ]] && test_uncommon_resolutions
 
 common_lib_end_summary
 

--- a/tests/scripts/FFmpegDecoderMultiFramesTest.sh
+++ b/tests/scripts/FFmpegDecoderMultiFramesTest.sh
@@ -9,11 +9,10 @@
 echo "Run FFmpeg Decoder Multiple Frames Test"
 source ./FFmpegCommonLib.sh
 
-path_correct="$path_global/bitstream_multi_frames"
-path_invalid="$path_global/bitstream_invalid"
+path_encoder_tests=$path_global"/encoder_tests"
 
 echo "FFmpeg:       $exec_ffmpeg"
-echo "Path correct: $path_correct"
+echo "Path encoder: $path_encoder_tests"
 
 error=0
 
@@ -25,14 +24,16 @@ function end {
     fi
 }
 
-# Test FFmpeg decode of multi-frame JPEG-XS bitstream
-# (1:expected error code) (2:file name) (3:md5 of decoded output)
-function test_ffmpeg_dec {
-    exit_code=$1
-    name=$2
-    md5=$3
-    bin_name=$path_use"/"$name".jxs"
-    yuv_tmp="./$tmp_dir/"$name".yuv"
+# Test FFmpeg encode N frames then decode and verify frame count
+# (1:name_yuv) (2:width) (3:height) (4:pix_fmt) (5:bpp) (6:frames_to_encode) (7:extra params)
+function test_ffmpeg_multi_frame {
+    name_yuv=$1
+    width=$2
+    height=$3
+    pix_fmt=$4
+    bpp=$5
+    frames=$6
+    extra_params=$7
 
     common_lib_update_test_id_run_return_1_to_ignore
     ignore=$?
@@ -40,45 +41,98 @@ function test_ffmpeg_dec {
         return
     fi
 
-    # Decode using ffmpeg with libsvtjpegxs decoder
-    cmd="$valgrind$exec_ffmpeg -y -c:v libsvtjpegxs -i $bin_name -f rawvideo $yuv_tmp"
+    path_yuv=$path_encoder_tests"/"$name_yuv".yuv"
+    bin_name=$test_id_print"_"$name_yuv"_${frames}f"
+    bin_name="${bin_name:0:100}"
+    mov_path="$tmp_dir/"$bin_name".mov"
+    out_yuv_path="$tmp_dir/"$bin_name"_dec.yuv"
+
+    # Encode N frames using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs -bpp $bpp $extra_params $mov_path"
     echo "run command: $cmd"
     ${cmd} 2>&1
     ret=$?
-
-    # For multi-frame tests, ffmpeg may return 0 even with partial decode (skipping broken frames)
-    # or non-zero for fatal errors. We check based on expected behavior.
-    if [ $exit_code -eq 0 ] && [ $ret -ne 0 ]; then
-        echo "FAIL ffmpeg decode failed with error code: $ret expected: 0"
+    if [ $ret -ne 0 ]; then
+        echo "FAIL Encode failed with error code: $ret"
         error=1
         end
     fi
 
-    # If file was not created (fatal error), check if that was expected
-    if [ ! -f "$yuv_tmp" ]; then
-        if [ $exit_code -ne 0 ]; then
-            echo "OK (expected failure, no output file)"
-            return
-        else
-            echo "FAIL: no output file created"
-            error=1
-            end
-        fi
+    # Decode all frames using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -i $mov_path -f rawvideo -pix_fmt $pix_fmt $out_yuv_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "FAIL Decode failed with error code: $ret"
+        error=1
+        end
     fi
 
-    if [ -z "$md5" ]; then
-        echo "OK (no MD5 check)"
-    else
-        echo -n "Test MD5 Expect: $md5 "
-        md5_t=$(md5sum ${yuv_tmp} | awk '{ print $1 }')
-        if [ "$md5" = "$md5_t" ]; then
-            echo "OK"
-        else
-            echo "FAIL get $md5_t"
-            error=1
-            end
-        fi
+    # Verify output file exists
+    if [ ! -f "$out_yuv_path" ]; then
+        echo "FAIL: no decoded output file"
+        error=1
+        end
     fi
+
+    # Calculate expected size
+    case "$pix_fmt" in
+        yuv420p)     frame_size=$(( width * height * 3 / 2 )) ;;
+        yuv420p10le) frame_size=$(( width * height * 3 / 2 * 2 )) ;;
+        yuv422p)     frame_size=$(( width * height * 2 )) ;;
+        yuv422p10le) frame_size=$(( width * height * 2 * 2 )) ;;
+        yuv444p)     frame_size=$(( width * height * 3 )) ;;
+        yuv444p10le) frame_size=$(( width * height * 3 * 2 )) ;;
+        *)           frame_size=0 ;;
+    esac
+
+    expected_size=$(( frame_size * frames ))
+    actual_size=$(stat -c%s "$out_yuv_path")
+
+    if [ "$actual_size" -ne "$expected_size" ]; then
+        echo "FAIL: size mismatch: expected=$expected_size ($frames frames) actual=$actual_size ($(( actual_size / frame_size )) frames)"
+        error=1
+        end
+    fi
+
+    echo "OK ($frames frames encoded+decoded, size=$actual_size)"
+}
+
+# Test encode with invalid params - expect failure
+# (1:expected_code) (2:name_yuv) (3:width) (4:height) (5:pix_fmt) (6:bpp) (7:frames) (8:extra params)
+function test_ffmpeg_enc_error {
+    expected_code=$1
+    name_yuv=$2
+    width=$3
+    height=$4
+    pix_fmt=$5
+    bpp=$6
+    frames=$7
+    extra_params=$8
+
+    common_lib_update_test_id_run_return_1_to_ignore
+    ignore=$?
+    if [ $ignore -ne 0 ]; then
+        return
+    fi
+
+    path_yuv=$path_encoder_tests"/"$name_yuv".yuv"
+    bin_name=$test_id_print"_error"
+    mov_path="$tmp_dir/"$bin_name".mov"
+
+    cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs -bpp $bpp $extra_params $mov_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+
+    if [ $ret -eq 0 ]; then
+        echo "FAIL: expected error code $expected_code but got success"
+        error=1
+        end
+    fi
+
+    echo "OK (expected failure, got code: $ret)"
 }
 
 
@@ -86,67 +140,58 @@ rm -fr $tmp_dir
 mkdir $tmp_dir
 
 
-function test_all_correct {
-    path_use=$path_correct
-
-    # Test multi-frame bitstreams
-    test_ffmpeg_dec 0 dec_r2r_mt-01                                          b00732fc18e6ca1ec02c9a4fb990a1ba
-    test_ffmpeg_dec 0 dec_r2r_mt-02                                          77ae505214f976fe30b55d1ac3594084
-    test_ffmpeg_dec 0 dec_r2r_mt-03                                          67f1ca191402372a227a5af65e47ed86
-    test_ffmpeg_dec 0 one_slice_1080                                         5cd468fb69609a8d6fbcecd2a9d3e57b
-
-    # Test Coefficients minus-zero and plus-zero coding
-    test_ffmpeg_dec 0 test-zero-sign-1-minus-zero                            6ba9ba462d53490717983c171ef50e59
-    test_ffmpeg_dec 0 test-zero-sign-1-plus-zero                             6ba9ba462d53490717983c171ef50e59
-    test_ffmpeg_dec 0 test-zero-sign-2-minus-zero                            c57ad54b3a32a83b55a1cda3314c5a29
-    test_ffmpeg_dec 0 test-zero-sign-2-plus-zero                             c57ad54b3a32a83b55a1cda3314c5a29
-    test_ffmpeg_dec 0 test-zero-sign-3-minus-zer                             ad74cde2fc470f2c89b9060e7290f339
-    test_ffmpeg_dec 0 test-zero-sign-3-plus-zero                             ad74cde2fc470f2c89b9060e7290f339
-    test_ffmpeg_dec 0 test-zero-sign-4-minus-zero                            fde93442420ef3048a3481bf1449ba59
-    test_ffmpeg_dec 0 test-zero-sign-4-plus-zero                             fde93442420ef3048a3481bf1449ba59
-
-    # Test Correct multi-frame bitstreams
-    test_ffmpeg_dec 0 Cyclist_1920x1080_10b_422_20f_v1_h5                    f65f42c074fa6fbdc3e9136ec86b9828
-    test_ffmpeg_dec 0 Cyclist_1920x1080_10b_422_20f_v2_h3                    39983e5e039da3917e5f7bf7ef9a87bf
-    test_ffmpeg_dec 0 Cyclist_1920x1080_8b_422_20f_v1_h4                     281a046a4d0c9bcb554e828d2a8084ef
-    test_ffmpeg_dec 0 Cyclist_1920x1080_8b_422_20f_v2_h2                     e71c8400a4f3a636408b48450bae92d3
-    test_ffmpeg_dec 0 Daylight_1280x720_10b_422_20f_v1_h1                    db9a6c952daf5e9c7b108e61b6d0e056
-    test_ffmpeg_dec 0 Daylight_1280x720_10b_422_20f_v2_h5                    b543cacde0d9a3fdeb6a123875f2868d
-    test_ffmpeg_dec 0 Daylight_1280x720_8b_422_20f_v1_h1                     d0c8097ead80367ffb50c33553b51795
-    test_ffmpeg_dec 0 Daylight_1280x720_8b_422_20f_v1_h5                     f9b705a3ac20daeea8ce21af5f0bf908
-    test_ffmpeg_dec 0 RollerCoaster_3840x2160_10b_422_20f_v1_h4              e3e91a199bbd8096a8cfd2c0109829ff
-    test_ffmpeg_dec 0 RollerCoaster_3840x2160_10b_422_20f_v1_h5              01f13f55acf98b8b5fb19cfd3c6a54c1
-    test_ffmpeg_dec 0 RollerCoaster_3840x2160_8b_422_20f_v2_h2               550612cfe8797ea51fbc257158f319a3
-    test_ffmpeg_dec 0 RollerCoaster_3840x2160_8b_422_20f_v2_h3               2f9090271c68800014e15b88d08103aa
+function test_multi_frame_counts {
+    # Various frame counts - verify all frames survive encode-decode
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 1 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 2 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 10 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 20 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 60 ""
 }
 
-function test_all_broken {
-    path_use=$path_correct
-
-    # Test with broken frames in the middle - ffmpeg may handle these differently
-    # than the standalone decoder (may skip frames or error out)
-    test_ffmpeg_dec 0 test_422_32x32_bpp6                                    5fe89b9423b6c38a6a91c1ce81f90259
-
-    # Change path to invalid bitstreams
-    path_use=$path_invalid
-
-    # Test invalid bitstreams - ffmpeg should fail gracefully
-    test_ffmpeg_dec 1 error_injection_422_broken_bitstream                    ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_01                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_02                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_03                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_04                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_05                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_06                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_07                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_08                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_09                          ""
-    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_10                          ""
+function test_multi_frame_formats {
+    # Different formats with multiple frames
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le 3 20 ""
+    test_ffmpeg_multi_frame touchdown_720p_yuv420p_8_bit_60_frames 1280 720 yuv420p 4 20 ""
+    test_ffmpeg_multi_frame touchdown_1080p_yuv420p_10_bit_le_60_frames 1920 1080 yuv420p10le 4 20 ""
 }
 
-[[ $run_fast -eq 0 ]] && test_all_correct
-                         test_all_broken
-[[ $run_fast -eq 0 ]] && test_all_correct
+function test_multi_frame_params {
+    # Multi-frame with various encoder params
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 10 "-decomp_v 2 -decomp_h 5"
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 4 10 "-decomp_v 2 -decomp_h 2"
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 10 "-coding_signs 2"
+    test_ffmpeg_multi_frame touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 5 10 "-slice_height 16"
+}
+
+function test_error_paths {
+    # Invalid parameters - should fail
+    test_ffmpeg_enc_error 1 touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 0.1 5 ""
+    test_ffmpeg_enc_error 1 touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 3 5 "-decomp_v 5 -decomp_h 1"
+}
+
+echo "RUN MULTI-FRAME COUNT TESTS"
+test_multi_frame_counts
+
+echo "RUN MULTI-FRAME FORMAT TESTS"
+[[ $run_fast -eq 0 ]] && test_multi_frame_formats
+
+echo "RUN MULTI-FRAME PARAM TESTS"
+[[ $run_fast -eq 0 ]] && test_multi_frame_params
+
+echo "RUN ERROR PATH TESTS"
+[[ $run_fast -eq 0 ]] && test_error_paths
+
+common_lib_end_summary
+
+if [ $error -ne 0 ]; then
+    echo "FAIL !!"
+else
+    echo "DONE FFmpeg Decoder Multi Frames OK"
+fi
+
+end
 
 common_lib_end_summary
 

--- a/tests/scripts/FFmpegDecoderMultiFramesTest.sh
+++ b/tests/scripts/FFmpegDecoderMultiFramesTest.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# Copyright(c) 2026 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+#param 'help' print script params
+
+
+echo "Run FFmpeg Decoder Multiple Frames Test"
+source ./FFmpegCommonLib.sh
+
+path_correct="$path_global/bitstream_multi_frames"
+path_invalid="$path_global/bitstream_invalid"
+
+echo "FFmpeg:       $exec_ffmpeg"
+echo "Path correct: $path_correct"
+
+error=0
+
+function end {
+    rm -fr $tmp_dir
+    if ((!($range_min == 0 && $range_min == $range_max))); then
+        echo Exit $0 script with exit $error
+        exit $error
+    fi
+}
+
+# Test FFmpeg decode of multi-frame JPEG-XS bitstream
+# (1:expected error code) (2:file name) (3:md5 of decoded output)
+function test_ffmpeg_dec {
+    exit_code=$1
+    name=$2
+    md5=$3
+    bin_name=$path_use"/"$name".jxs"
+    yuv_tmp="./$tmp_dir/"$name".yuv"
+
+    common_lib_update_test_id_run_return_1_to_ignore
+    ignore=$?
+    if [ $ignore -ne 0 ]; then
+        return
+    fi
+
+    # Decode using ffmpeg with libsvtjpegxs decoder
+    cmd="$valgrind$exec_ffmpeg -y -c:v libsvtjpegxs -i $bin_name -f rawvideo $yuv_tmp"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+
+    # For multi-frame tests, ffmpeg may return 0 even with partial decode (skipping broken frames)
+    # or non-zero for fatal errors. We check based on expected behavior.
+    if [ $exit_code -eq 0 ] && [ $ret -ne 0 ]; then
+        echo "FAIL ffmpeg decode failed with error code: $ret expected: 0"
+        error=1
+        end
+    fi
+
+    # If file was not created (fatal error), check if that was expected
+    if [ ! -f "$yuv_tmp" ]; then
+        if [ $exit_code -ne 0 ]; then
+            echo "OK (expected failure, no output file)"
+            return
+        else
+            echo "FAIL: no output file created"
+            error=1
+            end
+        fi
+    fi
+
+    if [ -z "$md5" ]; then
+        echo "OK (no MD5 check)"
+    else
+        echo -n "Test MD5 Expect: $md5 "
+        md5_t=$(md5sum ${yuv_tmp} | awk '{ print $1 }')
+        if [ "$md5" = "$md5_t" ]; then
+            echo "OK"
+        else
+            echo "FAIL get $md5_t"
+            error=1
+            end
+        fi
+    fi
+}
+
+
+rm -fr $tmp_dir
+mkdir $tmp_dir
+
+
+function test_all_correct {
+    path_use=$path_correct
+
+    # Test multi-frame bitstreams
+    test_ffmpeg_dec 0 dec_r2r_mt-01                                          b00732fc18e6ca1ec02c9a4fb990a1ba
+    test_ffmpeg_dec 0 dec_r2r_mt-02                                          77ae505214f976fe30b55d1ac3594084
+    test_ffmpeg_dec 0 dec_r2r_mt-03                                          67f1ca191402372a227a5af65e47ed86
+    test_ffmpeg_dec 0 one_slice_1080                                         5cd468fb69609a8d6fbcecd2a9d3e57b
+
+    # Test Coefficients minus-zero and plus-zero coding
+    test_ffmpeg_dec 0 test-zero-sign-1-minus-zero                            6ba9ba462d53490717983c171ef50e59
+    test_ffmpeg_dec 0 test-zero-sign-1-plus-zero                             6ba9ba462d53490717983c171ef50e59
+    test_ffmpeg_dec 0 test-zero-sign-2-minus-zero                            c57ad54b3a32a83b55a1cda3314c5a29
+    test_ffmpeg_dec 0 test-zero-sign-2-plus-zero                             c57ad54b3a32a83b55a1cda3314c5a29
+    test_ffmpeg_dec 0 test-zero-sign-3-minus-zer                             ad74cde2fc470f2c89b9060e7290f339
+    test_ffmpeg_dec 0 test-zero-sign-3-plus-zero                             ad74cde2fc470f2c89b9060e7290f339
+    test_ffmpeg_dec 0 test-zero-sign-4-minus-zero                            fde93442420ef3048a3481bf1449ba59
+    test_ffmpeg_dec 0 test-zero-sign-4-plus-zero                             fde93442420ef3048a3481bf1449ba59
+
+    # Test Correct multi-frame bitstreams
+    test_ffmpeg_dec 0 Cyclist_1920x1080_10b_422_20f_v1_h5                    f65f42c074fa6fbdc3e9136ec86b9828
+    test_ffmpeg_dec 0 Cyclist_1920x1080_10b_422_20f_v2_h3                    39983e5e039da3917e5f7bf7ef9a87bf
+    test_ffmpeg_dec 0 Cyclist_1920x1080_8b_422_20f_v1_h4                     281a046a4d0c9bcb554e828d2a8084ef
+    test_ffmpeg_dec 0 Cyclist_1920x1080_8b_422_20f_v2_h2                     e71c8400a4f3a636408b48450bae92d3
+    test_ffmpeg_dec 0 Daylight_1280x720_10b_422_20f_v1_h1                    db9a6c952daf5e9c7b108e61b6d0e056
+    test_ffmpeg_dec 0 Daylight_1280x720_10b_422_20f_v2_h5                    b543cacde0d9a3fdeb6a123875f2868d
+    test_ffmpeg_dec 0 Daylight_1280x720_8b_422_20f_v1_h1                     d0c8097ead80367ffb50c33553b51795
+    test_ffmpeg_dec 0 Daylight_1280x720_8b_422_20f_v1_h5                     f9b705a3ac20daeea8ce21af5f0bf908
+    test_ffmpeg_dec 0 RollerCoaster_3840x2160_10b_422_20f_v1_h4              e3e91a199bbd8096a8cfd2c0109829ff
+    test_ffmpeg_dec 0 RollerCoaster_3840x2160_10b_422_20f_v1_h5              01f13f55acf98b8b5fb19cfd3c6a54c1
+    test_ffmpeg_dec 0 RollerCoaster_3840x2160_8b_422_20f_v2_h2               550612cfe8797ea51fbc257158f319a3
+    test_ffmpeg_dec 0 RollerCoaster_3840x2160_8b_422_20f_v2_h3               2f9090271c68800014e15b88d08103aa
+}
+
+function test_all_broken {
+    path_use=$path_correct
+
+    # Test with broken frames in the middle - ffmpeg may handle these differently
+    # than the standalone decoder (may skip frames or error out)
+    test_ffmpeg_dec 0 test_422_32x32_bpp6                                    5fe89b9423b6c38a6a91c1ce81f90259
+
+    # Change path to invalid bitstreams
+    path_use=$path_invalid
+
+    # Test invalid bitstreams - ffmpeg should fail gracefully
+    test_ffmpeg_dec 1 error_injection_422_broken_bitstream                    ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_01                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_02                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_03                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_04                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_05                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_06                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_07                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_08                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_09                          ""
+    test_ffmpeg_dec 1 invalid_small_cfg_zero_band_10                          ""
+}
+
+[[ $run_fast -eq 0 ]] && test_all_correct
+                         test_all_broken
+[[ $run_fast -eq 0 ]] && test_all_correct
+
+common_lib_end_summary
+
+if [ $error -ne 0 ]; then
+    echo "FAIL !!"
+else
+    echo "DONE FFmpeg Decoder Multiple Frames OK"
+fi
+
+end

--- a/tests/scripts/FFmpegEncoderTest.sh
+++ b/tests/scripts/FFmpegEncoderTest.sh
@@ -46,7 +46,7 @@ function test_ffmpeg_enc {
     path_yuv=$path_correct"/"$name_yuv".yuv"
     bin_name=$test_id_print"_"$name_yuv"_ffmpeg"
     bin_name="${bin_name:0:100}"
-    bin_path="$tmp_dir/"$bin_name".jxs"
+    bin_path="$tmp_dir/"$bin_name".mov"
 
     # Encode using ffmpeg with libsvtjpegxs encoder
     cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs $enc_params $bin_path"
@@ -95,7 +95,7 @@ function test_ffmpeg_enc_dec {
     path_yuv=$path_correct"/"$name_yuv".yuv"
     bin_name=$test_id_print"_"$name_yuv"_ffmpeg_encdec"
     bin_name="${bin_name:0:100}"
-    bin_path="$tmp_dir/"$bin_name".jxs"
+    bin_path="$tmp_dir/"$bin_name".mov"
     out_yuv_path="$tmp_dir/"$bin_name".yuv"
 
     # Encode using ffmpeg

--- a/tests/scripts/FFmpegEncoderTest.sh
+++ b/tests/scripts/FFmpegEncoderTest.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Copyright(c) 2026 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+#param 'help' print script params
+
+
+echo "Run FFmpeg Encoder Test"
+source ./FFmpegCommonLib.sh
+
+path_correct="$path_global/encoder_tests"
+
+echo "FFmpeg Encoder Test"
+echo "FFmpeg:          $exec_ffmpeg"
+echo "Path correct:    $path_correct"
+
+error=0
+
+function end {
+    rm -fr $tmp_dir
+    if ((!($range_min == 0 && $range_min == $range_max))); then
+        echo Exit $0 script with exit $error
+        exit $error
+    fi
+}
+
+# Test FFmpeg encode from raw YUV to JPEG-XS bitstream
+# (1:expected error code) (2:md5 of output jxs) (3:name input yuv) (4:width) (5:height) (6:pix_fmt) (7:extra ffmpeg encoder params) (8:frames)
+function test_ffmpeg_enc {
+    exit_code=$1
+    md5=$2
+    name_yuv=$3
+    width=$4
+    height=$5
+    pix_fmt=$6
+    enc_params=$7
+    frames=${8:-10}
+
+    common_lib_update_test_id_run_return_1_to_ignore
+    ignore=$?
+    if [ $ignore -ne 0 ]; then
+        return
+    fi
+
+    path_yuv=$path_correct"/"$name_yuv".yuv"
+    bin_name=$test_id_print"_"$name_yuv"_ffmpeg"
+    bin_name="${bin_name:0:100}"
+    bin_path="$tmp_dir/"$bin_name".jxs"
+
+    # Encode using ffmpeg with libsvtjpegxs encoder
+    cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs $enc_params $bin_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+
+    if [ $ret -ne $exit_code ]; then
+        echo "FAIL Invalid error code: $ret expected: $exit_code"
+        error=1
+        end
+    fi
+
+    # Check MD5 if encoding succeeded and MD5 is not IGNORE
+    if [ $ret -eq 0 ] && [ "$md5" != "IGNORE" ]; then
+        echo -n "Test MD5 Expect: $md5 "
+        md5_t=$(md5sum ${bin_path} | awk '{ print $1 }')
+        if [ "$md5" = "$md5_t" ]; then
+            echo "OK"
+        else
+            echo "FAIL get $md5_t"
+            error=1
+            end
+        fi
+    elif [ "$md5" = "IGNORE" ]; then
+        echo "IGNORE TEST OUTPUT"
+    fi
+}
+
+# Test FFmpeg encode and then decode back, compare decoded output
+# (1:name input yuv) (2:width) (3:height) (4:pix_fmt) (5:extra ffmpeg encoder params) (6:frames)
+function test_ffmpeg_enc_dec {
+    name_yuv=$1
+    width=$2
+    height=$3
+    pix_fmt=$4
+    enc_params=$5
+    frames=${6:-10}
+
+    common_lib_update_test_id_run_return_1_to_ignore
+    ignore=$?
+    if [ $ignore -ne 0 ]; then
+        return
+    fi
+
+    path_yuv=$path_correct"/"$name_yuv".yuv"
+    bin_name=$test_id_print"_"$name_yuv"_ffmpeg_encdec"
+    bin_name="${bin_name:0:100}"
+    bin_path="$tmp_dir/"$bin_name".jxs"
+    out_yuv_path="$tmp_dir/"$bin_name".yuv"
+
+    # Encode using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -f rawvideo -pix_fmt $pix_fmt -s ${width}x${height} -i $path_yuv -frames:v $frames -c:v libsvtjpegxs $enc_params $bin_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "FAIL Encode failed with error code: $ret"
+        error=1
+        end
+    fi
+
+    # Decode using ffmpeg
+    cmd="$valgrind$exec_ffmpeg -y -c:v libsvtjpegxs -i $bin_path -f rawvideo -pix_fmt $pix_fmt $out_yuv_path"
+    echo "run command: $cmd"
+    ${cmd} 2>&1
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "FAIL Decode failed with error code: $ret"
+        error=1
+        end
+    fi
+
+    echo "OK encode-decode cycle completed"
+}
+
+
+rm -fr $tmp_dir
+mkdir $tmp_dir
+
+function test_basic_encode {
+    # Basic encode tests - verify ffmpeg encoder produces valid output
+    # 8bit YUV422
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3" 10
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 4" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 5" 5
+
+    # 10bit YUV422
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le "-bpp 3" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le "-bpp 4" 5
+
+    # 8bit YUV420
+    test_ffmpeg_enc 0 IGNORE touchdown_720p_yuv420p_8_bit_60_frames 1280 720 yuv420p "-bpp 4" 5
+
+    # 10bit YUV420
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv420p_10_bit_le_60_frames 1920 1080 yuv420p10le "-bpp 4" 5
+}
+
+function test_encode_params {
+    # Test various encoder parameters through ffmpeg
+    # decomp_v and decomp_h
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -decomp_v 2 -decomp_h 5" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -decomp_v 2 -decomp_h 2" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -decomp_v 0 -decomp_h 2" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 4 -decomp_v 0 -decomp_h 1" 5
+
+    # coding_signs
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -coding_signs 0" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -coding_signs 1" 5
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -coding_signs 2" 5
+
+    # slice_height
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -slice_height 16" 5
+
+    # quantization
+    test_ffmpeg_enc 0 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3 -quant 1" 5
+}
+
+function test_encode_decode_cycle {
+    # Test full encode-decode cycle - verify roundtrip works
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 3" 5
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 4" 5
+    test_ffmpeg_enc_dec touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le "-bpp 3" 5
+    test_ffmpeg_enc_dec touchdown_720p_yuv420p_8_bit_60_frames 1280 720 yuv420p "-bpp 4" 5
+    test_ffmpeg_enc_dec touchdown_1080p_yuv420p_10_bit_le_60_frames 1920 1080 yuv420p10le "-bpp 4" 5
+}
+
+function test_encode_error_paths {
+    # Test invalid parameters - expect failure
+    test_ffmpeg_enc 1 IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p "-bpp 0.1" 5
+}
+
+echo "RUN BASIC ENCODE TESTS"
+test_basic_encode
+
+echo "RUN ENCODE PARAMETER TESTS"
+[[ $run_fast -eq 0 ]] && test_encode_params
+
+echo "RUN ENCODE-DECODE CYCLE TESTS"
+test_encode_decode_cycle
+
+echo "RUN ENCODE ERROR PATH TESTS"
+[[ $run_fast -eq 0 ]] && test_encode_error_paths
+
+common_lib_end_summary
+
+echo "DONE FFmpeg Encoder OK"
+error=0
+end

--- a/tests/scripts/ParallelAllFFmpegTests.sh
+++ b/tests/scripts/ParallelAllFFmpegTests.sh
@@ -5,13 +5,14 @@
 #
 
 
-echo "Example: $0 parallel_number path_to_test_resources path_to_ffmpeg [valgrind] [fast] [...]"
+echo "Example: $0 parallel_number"
 nproc=$1
 script_params=""
 
 index=0
 for ARG in "$@"; do
     if (($index >= 1)); then
+        #echo $ARG
         script_params="$script_params $ARG"
     fi
     index=$((index+1))
@@ -20,6 +21,7 @@ done
 [[ -z "$nproc" ]] && nproc=1
 echo "Run Parallel All FFmpeg Tests NPROC: $nproc params: $script_params"
 chmod +x ./FFmpegCommonLib.sh
+chmod +x ./CommonLib.sh
 chmod +x ./ParallelScript.sh
 chmod +x ./FFmpegDecoderConformanceTest.sh
 chmod +x ./FFmpegDecoderMultiFramesTest.sh

--- a/tests/scripts/ParallelAllFFmpegTests.sh
+++ b/tests/scripts/ParallelAllFFmpegTests.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright(c) 2026 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+
+echo "Example: $0 parallel_number path_to_test_resources path_to_ffmpeg [valgrind] [fast] [...]"
+nproc=$1
+script_params=""
+
+index=0
+for ARG in "$@"; do
+    if (($index >= 1)); then
+        script_params="$script_params $ARG"
+    fi
+    index=$((index+1))
+done
+
+[[ -z "$nproc" ]] && nproc=1
+echo "Run Parallel All FFmpeg Tests NPROC: $nproc params: $script_params"
+chmod +x ./FFmpegCommonLib.sh
+chmod +x ./ParallelScript.sh
+chmod +x ./FFmpegDecoderConformanceTest.sh
+chmod +x ./FFmpegDecoderMultiFramesTest.sh
+chmod +x ./FFmpegEncoderTest.sh
+
+error=0
+if [[ $error -eq 0 ]]; then
+    echo RUN FFMPEG DECODER CONFORMANCE TEST
+    ./ParallelScript.sh $nproc ./FFmpegDecoderConformanceTest.sh $script_params
+    ret=$?
+    [[ $ret -ne 0 ]] && error=$ret
+fi
+if [[ $error -eq 0 ]]; then
+    echo RUN FFMPEG DECODER MULTI FRAMES TEST
+    ./ParallelScript.sh $nproc ./FFmpegDecoderMultiFramesTest.sh $script_params
+    ret=$?
+    [[ $ret -ne 0 ]] && error=$ret
+fi
+if [[ $error -eq 0 ]]; then
+    echo RUN FFMPEG ENCODER TEST
+    ./ParallelScript.sh $nproc ./FFmpegEncoderTest.sh $script_params
+    ret=$?
+    [[ $ret -ne 0 ]] && error=$ret
+fi
+
+if [ $error -eq 0 ]; then
+    echo "DONE OK"
+else
+    echo "FAIL !!"
+fi
+
+echo Exit $0 script with exit $error
+exit $error


### PR DESCRIPTION
This pull request introduces a comprehensive suite of FFmpeg-based test scripts for JPEG-XS plugin validation, including utilities, decoder and encoder conformance tests, multi-frame handling, and parallel execution. The changes provide a modular and extensible framework for automated testing of both encoding and decoding functionality, with support for parameterized runs, error path validation, and integration with existing common test infrastructure.

**New FFmpeg Test Infrastructure:**

* Added a shared FFmpeg test library `FFmpegCommonLib.sh` that provides FFmpeg-specific helpers and integrates with the existing `CommonLib.sh` for reusable test logic.
* Introduced a parallel test runner script `ParallelAllFFmpegTests.sh` to orchestrate and execute all FFmpeg-related test scripts concurrently, improving test throughput and automation.

**Decoder Testing Enhancements:**

* Implemented `FFmpegDecoderConformanceTest.sh` for validating FFmpeg JPEG-XS decoder output against reference YUV files across a comprehensive set of conformance bitstreams.
* Added `FFmpegDecoderMultiFramesTest.sh` to test FFmpeg's handling of multi-frame and invalid bitstreams, including MD5-based output validation and expected error code handling.

**Encoder and Roundtrip Testing:**

* Developed `FFmpegEncoderTest.sh` to verify FFmpeg JPEG-XS encoder correctness, parameter handling, error paths, and roundtrip encode-decode cycles, including output MD5 checks and support for various pixel formats and encoder options.