### PR TITLE
perf(decoder): fix 6–9% throughput regression from IntSan changes

### DIFF
--- a/Source/Lib/Common/Codec/Definitions.h
+++ b/Source/Lib/Common/Codec/Definitions.h
@@ -120,11 +120,12 @@ typedef enum PointerType {
 #define UNUSED(x) (void)(x)
 
 /* Left-shift that avoids undefined behavior for negative values (C11 §6.5.7).
- * Cast chain: (int32_t)(val) ensures sign-extension for narrow types,
- * (uint32_t) reinterprets as unsigned to avoid UB on negative left-shift,
- * (uint64_t) widens so the shift cannot overflow 32-bit unsigned range,
- * final (int32_t) truncates back to the desired 32-bit signed result. */
-#define LSHIFT32(val, s) ((int32_t)((uint64_t)(uint32_t)(int32_t)(val) << (s)))
+ * Cast to unsigned before shifting so that left-shifting a negative value is
+ * well-defined (unsigned shift, §6.5.7¶4).  Bits shifted out are intentionally
+ * discarded — this is NOT overflow, just a bit-reinterpretation pattern used
+ * throughout the wavelet transform.  Do NOT widen to uint64_t here: it causes
+ * GCC/Clang to emit 64-bit shifts in the IDWT inner loop (~6-9% regression). */
+#define LSHIFT32(val, s) ((int32_t)((uint32_t)(int32_t)(val) << (s)))
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -110,12 +110,7 @@ static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
     int8_t res = 32 - svt_log2_32(vlc_reader->register64 >> 32); //Possible values: 1-32
     vlc_reader->register_bits -= res;
     vlc_reader->bits_used += res;
-#ifdef _MSC_VER
     vlc_reader->register64 <<= res;
-#else
-    /* Use __uint128_t to avoid integer sanitizer warning about bits shifted out of uint64_t. */
-    vlc_reader->register64 = (uint64_t)((__uint128_t)vlc_reader->register64 << res);
-#endif
     return res - 1;
 }
 


### PR DESCRIPTION
SDBQ-3075 Decoder performance regression after sanitizers fix

Revert uint64_t widening in LSHIFT32 macro and __uint128_t shift in VLC reader (introduced in a0efed1).  Both caused GCC to emit 64-bit ops in hot IDWT/VLC inner loops.  The original unsigned patterns are well-defined C — not UB, just intentional bit discard.