### PR TITLE
feat(encoder): add legacy-decoder CAP and raw-mode compat knobs

### DIFF
--- a/.github/workflows/base_build.yaml
+++ b/.github/workflows/base_build.yaml
@@ -97,6 +97,7 @@ jobs:
         ls -l
         sudo chmod +x ${{ github.workspace }}/tests/scripts/parrallelUT.sh
         sudo chmod +x ${{ github.workspace }}/Bin/Release/*
+        export LD_LIBRARY_PATH=$(pwd)
         ${{ github.workspace }}/tests/scripts/parrallelUT.sh ./SvtJpegxsUnitTests ${{ env.JOBS_NUM }}
 
   linux-unit-tests-debug:
@@ -126,6 +127,7 @@ jobs:
         ls -l
         sudo chmod +x ${{ github.workspace }}/tests/scripts/parrallelUT.sh
         sudo chmod +x ${{ github.workspace }}/Bin/Debug/*
+        export LD_LIBRARY_PATH=$(pwd)
         ${{ github.workspace }}/tests/scripts/parrallelUT.sh ./SvtJpegxsUnitTests ${{ env.JOBS_NUM }}
 
   linux-unit-tests-valgrind:

--- a/Source/API/SvtJpegxsEnc.h
+++ b/Source/API/SvtJpegxsEnc.h
@@ -84,12 +84,29 @@ typedef struct svt_jpeg_xs_encoder_api {
 
     void* private_ptr; /*Private encoder pointer, do not touch!!! */
 
+    /* Disable packet-based raw-mode coding.
+     * 0 = raw-mode enabled (default, current behavior): picture header Rl=1, raw packet packing allowed,
+     *     and the raw-mode capability bit is signalled in the CAP marker.
+     * 1 = raw-mode disabled: picture header Rl=0, raw packet packing never selected,
+     *     and the raw-mode capability bit is cleared.
+     * Optional, default 0 */
+    uint8_t coding_raw_disable;
+
+    /* Legacy decoder capabilities-marker compatibility.
+     * 0 = full CAP marker (default, current behavior).
+     * 1 = emit an empty CAP marker (Lcap=2) when no capability bit is set. Some legacy/strict decoders
+     *     reject a non-empty CAP marker; an empty CAP is accepted by those decoders.
+     *     Note: when the stream genuinely requires a capability bit (e.g. 4:2:0 sub-sampling), a full CAP
+     *     marker is still written to remain conformant.
+     * Optional, default 0 */
+    uint8_t cap_compat;
+
     /* This padding is used to avoid changing the size of the public configuration struct
      * when new parameters are added in the future please follow these steps:
      * 1. Insert the new parameter as a member of this structure before the padding array.
      * 2. Decrease the size of the padding array by the size of the new parameter to keep the struct size unchanged.
      */
-    uint8_t padding[64];
+    uint8_t padding[62];
 } svt_jpeg_xs_encoder_api_t;
 
 /* STEP 0 (Optional): Set default encoder parameters.

--- a/Source/App/EncApp/EncAppConfig.c
+++ b/Source/App/EncApp/EncAppConfig.c
@@ -65,6 +65,8 @@ static void strncpy_local(char *dest, const char *src, size_t count) {
 #define CODING_SIGF_TOKEN   "--coding-sigf"
 #define CODING_PRED_TOKEN   "--coding-vpred"
 #define CODING_RATE_CONTROL "--rc"
+#define CODING_RAW_TOKEN    "--coding-raw"
+#define CAP_COMPAT_TOKEN    "--cap-compat"
 #define SHOW_BANDS          "--show-bands"
 
 #define LIMIT_FPS_TOKEN "--limit-fps"
@@ -127,6 +129,15 @@ static void set_coding_vpred(const char *value, EncoderConfig_t *cfg) {
 
 static void set_rate_control_mode(const char *value, EncoderConfig_t *cfg) {
     cfg->encoder.rate_control_mode = strtoul(value, NULL, 0);
+}
+
+static void set_coding_raw(const char *value, EncoderConfig_t *cfg) {
+    /* CLI: 1 = raw-mode enabled (default), 0 = disabled. Internal field stores the inverse. */
+    cfg->encoder.coding_raw_disable = strtoul(value, NULL, 0) ? 0 : 1;
+}
+
+static void set_cap_compat(const char *value, EncoderConfig_t *cfg) {
+    cfg->encoder.cap_compat = (uint8_t)strtoul(value, NULL, 0);
 }
 
 static void set_encoder_colour_format(const char *value, EncoderConfig_t *cfg) {
@@ -315,6 +326,8 @@ ConfigEntry config_entry[] = {
     {CODING_OPTIONS, CODING_SIGF_TOKEN,     "Enable Significance coding (enabled:1, disable:0, default:1)", 0, 1, set_coding_significance},
     {CODING_OPTIONS, CODING_PRED_TOKEN,     "Enable Vertical Prediction coding (disable:0, zero prediction residuals:1, zero coefficients:2, default: 0)", 0, 1, set_coding_vpred},
     {CODING_OPTIONS, CODING_RATE_CONTROL,   "Rate Control mode (CBR: budget per precinct: 0, CBR: budget per precinct with padding movement: 1, CBR: budget per slice: 2, CBR: budget per slice with max size RATE: 3, default 0)", 0, 1, set_rate_control_mode},
+    {CODING_OPTIONS, CODING_RAW_TOKEN,      "Packet-based raw-mode coding (enabled:1, disabled:0, default:1). Disabling clears the raw-mode capability bit and never selects raw packet packing.", 0, 1, set_coding_raw},
+    {CODING_OPTIONS, CAP_COMPAT_TOKEN,      "Legacy decoder CAP-marker compatibility (full CAP:0, empty CAP when no capability bit set:1, default:0)", 0, 1, set_cap_compat},
     {THREAD_PERF_OPTIONS, ASM_TYPE_TOKEN,   "Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, "
                                             "ssse3, sse4_1, sse4_2,"
                                             " avx, avx2, avx512, max], by default highest level supported by CPU", 0, 1,

--- a/Source/Lib/Encoder/Codec/EncHandle.c
+++ b/Source/Lib/Encoder/Codec/EncHandle.c
@@ -255,7 +255,8 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     enc_common->picture_header_dynamic.hdr_Qpih = config_struct->quantization;
     enc_common->pi.use_short_header = (((config_struct->source_width * num_comp) < 32768) && (config_struct->ndecomp_v < 3));
 
-    enc_common->picture_header_dynamic.hdr_Rl = 1;
+    enc_common->picture_header_dynamic.hdr_Rl = config_struct->coding_raw_disable ? 0 : 1;
+    enc_common->cap_compat = config_struct->cap_compat ? 1 : 0;
 
     if (config_struct->coding_signs_handling > SIGN_HANDLING_STRATEGY_FULL) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {

--- a/Source/Lib/Encoder/Codec/Encoder.h
+++ b/Source/Lib/Encoder/Codec/Encoder.h
@@ -98,6 +98,7 @@ typedef struct svt_jpeg_xs_encoder_common {
     */
     uint32_t *slice_sizes;
     uint8_t slice_packetization_mode;
+    uint8_t cap_compat; /* Emit empty CAP marker (Lcap=2) when no capability bit is set (legacy decoder compatibility) */
 } svt_jpeg_xs_encoder_common_t;
 
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/Codec/PackHeaders.c
+++ b/Source/Lib/Encoder/Codec/PackHeaders.c
@@ -26,6 +26,21 @@ void write_capabilities_marker(bitstream_writer_t* bitstream, svt_jpeg_xs_encode
     capability[7] = 0;           //Unused
     capability[8] = enc_common->picture_header_dynamic.hdr_Rl; //Support for packet-based raw-mode switch required
 
+    /* Legacy decoder compatibility: when enabled and no capability bit is set, emit an empty CAP marker
+     * (Lcap=2). Some strict decoders reject a non-empty CAP marker. When the stream genuinely requires a
+     * capability bit (e.g. 4:2:0 sub-sampling), a full CAP marker is still written to remain conformant. */
+    if (enc_common->cap_compat) {
+        uint8_t any_capability = 0;
+        for (uint8_t i = 0; i < elements; ++i) {
+            any_capability |= capability[i];
+        }
+        if (!any_capability) {
+            uint16_t empty_size_bytes = BITS_TO_BYTE_WITH_ALIGN(16); //Lcap only, no flags
+            write_16_bits(bitstream, empty_size_bytes);
+            return;
+        }
+    }
+
     uint16_t size_bytes = BITS_TO_BYTE_WITH_ALIGN(16 + elements); //Lcap + flags
     write_16_bits(bitstream, size_bytes);
     for (uint8_t i = 0; i < elements; ++i) {

--- a/Source/Lib/Encoder/Codec/RateControl.c
+++ b/Source/Lib/Encoder/Codec/RateControl.c
@@ -707,7 +707,8 @@ static uint32_t precinct_get_budget_bytes(svt_jpeg_xs_encoder_common_t *enc_comm
     pi_t *pi = &enc_common->pi;
     /*For current implementation support only more complex implementation
       that 2 packages with that same band can have different ram mode flag.*/
-    assert(enc_common->picture_header_dynamic.hdr_Rl != 0);
+    /* Raw packet packing is only ever selected when raw-mode is enabled (hdr_Rl != 0).
+       When raw-mode is disabled (hdr_Rl == 0) the raw selection below is skipped, so this path is valid. */
     rate_control_calculate_band_best_method(pi, precinct, enc_common, coding_vertical_prediction_mode, coding_signs_handling);
     precinct_info_t *p_info = precinct->p_info;
 
@@ -761,7 +762,8 @@ static uint32_t precinct_get_budget_bytes(svt_jpeg_xs_encoder_common_t *enc_comm
         /*GCLI Pack Size:*/
         uint32_t packet_size_significance_bytes = BITS_TO_BYTE_WITH_ALIGN(packet_size_significance_bits);
         uint32_t packet_size_gcli_bytes = BITS_TO_BYTE_WITH_ALIGN(packet_size_gcli_bits);
-        if (packet_size_significance_bytes + packet_size_gcli_bytes > p_info->packet_size_gcli_raw_bytes[packet_idx]) {
+        if (enc_common->picture_header_dynamic.hdr_Rl &&
+            (packet_size_significance_bytes + packet_size_gcli_bytes > p_info->packet_size_gcli_raw_bytes[packet_idx])) {
             /*Set Pack RAW*/
             precinct->packet_methods_raw[packet_idx] = 1;
             precinct->packet_size_significance_bytes[packet_idx] = 0;


### PR DESCRIPTION
## SVT-JPEG-XS Encoder: Legacy-Decoder Compatibility Knobs

### Overview
Two new, opt-in encoder knobs fix interop with strict hardware decoders (e.g. **Appear TV**) that reject the standard SVT-JPEG-XS codestream header. They replace an earlier hardcoded patch with a clean, configurable, mergeable implementation. Defaults preserve current behavior exactly.

### What changed

| Knob (CLI) | API field | Default | Effect |
|---|---|---|---|
| `--coding-raw <0\|1>` | `coding_raw_disable` (inverted) | `1` (raw on) | `0` disables packet-based raw-mode coding and clears the corresponding CAP capability bit. |
| `--cap-compat <0\|1>` | `cap_compat` | `0` (full CAP) | `1` writes an **empty** CAP marker (`Lcap=2`) when no capability bit is set. |

### How to use it (Appear TV fix)
```
SvtJpegxsEncApp ... --coding-raw 0 --cap-compat 1
```
This produces a header that strict parsers accept:
- CAP marker becomes `ff 50 00 02` (empty, `Lcap=2`) instead of `ff 50 00 04 00 80`.
- Picture header `Rl` bit = 0 (raw-mode off).

### Defaults preserve current behavior
Both fields default to zero, and zero means **exactly today's behavior** — full CAP marker and raw-mode enabled. The new fields fit inside the existing reserved `padding[]`, so the **ABI is unchanged**. Existing callers (ffmpeg, IMTL, GStreamer plugins) are unaffected.

### Decoder
No decoder change required. The SVT-JPEG-XS decoder already accepts the empty CAP marker, and an encode→decode round-trip was verified working.

### Important 4:2:0 caveat (by design)
Implements the spec-honest "Option Y": the empty CAP marker is only emitted when **all** capability bits are zero.
- **4:2:2** → with `--coding-raw 0`, no capability bit is set → empty CAP → Appear TV works.
- **4:2:0** → the chroma-subsampling capability bit is still required, so a full CAP marker is still written. **Appear TV + 4:2:0 is therefore not fixed** by this knob — that would require misrepresenting the subsampling in the header, which we avoided to stay conformant and not break other strict decoders.

### Validation performed
- Full debug build (gcc) with tests: **success**.
- Encoder / rate-control / pack / API unit tests: **13/13 pass**.
- Round-trip: encoded 4:2:2 with the knobs → confirmed `ff 50 00 02` empty CAP and `Rl=0`; default encode confirmed `ff 50 00 04 00 80`; decoded the compat stream back to a full frame (rc=0).

### Not yet done (deferred)
- Exposing these knobs through the **ffmpeg / IMTL / GStreamer** plugins — to be added in a follow-up.
- **Evertz 670** still reports a generic decoder fault after the Appear fix; this is a *different* root cause (top suspect: `Ppih`/`Plev` = 0 in the picture header, possibly the TS transport path). Needs additional captures before a fix.

### Open questions
1. Is the Appear feed **4:2:2 or 4:2:0**? (Determines whether `--cap-compat` alone is sufficient.)
2. For Evertz: capture a rejected `.jxs` ES plus an IntoPix stream it accepts, so we can diff the picture header (`Ppih`/`Plev`/`Cpih`); confirm whether ev670 is fed real MPEG-TS or de-muxed ES over ST 2022-2 / 2110-22; firmware/APP variant; and whether the old `if(0)` raw-mode patch is still active.
3. Which frontend is in use (EncApp / ffmpeg / GStreamer / IMTL) — to scope the plugin patches.