### PR TITLE
feat(encoder): add legacy-decoder CAP and raw-mode compat knobs

### DIFF
--- a/.github/workflows/base_build.yaml
+++ b/.github/workflows/base_build.yaml
@@ -97,6 +97,7 @@ jobs:
         ls -l
         sudo chmod +x ${{ github.workspace }}/tests/scripts/parrallelUT.sh
         sudo chmod +x ${{ github.workspace }}/Bin/Release/*
+        export LD_LIBRARY_PATH=$(pwd)
         ${{ github.workspace }}/tests/scripts/parrallelUT.sh ./SvtJpegxsUnitTests ${{ env.JOBS_NUM }}
 
   linux-unit-tests-debug:
@@ -126,6 +127,7 @@ jobs:
         ls -l
         sudo chmod +x ${{ github.workspace }}/tests/scripts/parrallelUT.sh
         sudo chmod +x ${{ github.workspace }}/Bin/Debug/*
+        export LD_LIBRARY_PATH=$(pwd)
         ${{ github.workspace }}/tests/scripts/parrallelUT.sh ./SvtJpegxsUnitTests ${{ env.JOBS_NUM }}
 
   linux-unit-tests-valgrind:
@@ -188,6 +190,7 @@ jobs:
       run: |
         sudo chmod -R 755 ${GITHUB_WORKSPACE}/tests/scripts/
         sudo chmod -R 755 ${DEC_BIN_DIR}/
+        export LD_LIBRARY_PATH=${DEC_BIN_DIR}
         ./ParallelAllTests.sh ${{ env.JOBS_NUM }}  ${INPUT_FILES_PATH} ${DEC_BIN_DIR}/SvtJpegxsDecApp
       env:
         DEC_BIN_DIR: ${{ github.workspace }}/Bin/Release

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Coding features used during Rate Calculation (quality/speed tradeoff):
 [--coding-signs]           Enable Signs handling strategy (full:2, fast:1, disable:0, default:0)
 [--coding-sigf]            Enable signification coding (enabled:1, disable:0, default:1)
 [--coding-vpred]           Enable Vertical Prediction coding (disable:0, zero prediction residuals:1, zero coefficients:2, default: 0)
+[--coding-raw]             Enable packet-based raw-mode coding (enabled:1, disable for legacy-decoder compatibility:0, default:1)
+[--cap-compat]             Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required (enabled:1, disable:0, default:0)
 [--rc]                     Rate Control mode (
                             CBR: budget per precinct: 0,
                             CBR: budget per precinct with padding movement: 1,

--- a/Source/API/SvtJpegxsEnc.h
+++ b/Source/API/SvtJpegxsEnc.h
@@ -84,12 +84,29 @@ typedef struct svt_jpeg_xs_encoder_api {
 
     void* private_ptr; /*Private encoder pointer, do not touch!!! */
 
+    /* Disable packet-based raw-mode coding.
+     * 0 = raw-mode enabled (default, current behavior): picture header Rl=1, raw packet packing allowed,
+     *     and the raw-mode capability bit is signalled in the CAP marker.
+     * 1 = raw-mode disabled: picture header Rl=0, raw packet packing never selected,
+     *     and the raw-mode capability bit is cleared.
+     * Optional, default 0 */
+    uint8_t coding_raw_disable;
+
+    /* Legacy decoder capabilities-marker compatibility.
+     * 0 = full CAP marker (default, current behavior).
+     * 1 = emit an empty CAP marker (Lcap=2) when no capability bit is set. Some legacy/strict decoders
+     *     reject a non-empty CAP marker; an empty CAP is accepted by those decoders.
+     *     Note: when the stream genuinely requires a capability bit (e.g. 4:2:0 sub-sampling), a full CAP
+     *     marker is still written to remain conformant.
+     * Optional, default 0 */
+    uint8_t cap_compat;
+
     /* This padding is used to avoid changing the size of the public configuration struct
      * when new parameters are added in the future please follow these steps:
      * 1. Insert the new parameter as a member of this structure before the padding array.
      * 2. Decrease the size of the padding array by the size of the new parameter to keep the struct size unchanged.
      */
-    uint8_t padding[64];
+    uint8_t padding[62];
 } svt_jpeg_xs_encoder_api_t;
 
 /* STEP 0 (Optional): Set default encoder parameters.

--- a/Source/App/EncApp/EncAppConfig.c
+++ b/Source/App/EncApp/EncAppConfig.c
@@ -65,6 +65,8 @@ static void strncpy_local(char *dest, const char *src, size_t count) {
 #define CODING_SIGF_TOKEN   "--coding-sigf"
 #define CODING_PRED_TOKEN   "--coding-vpred"
 #define CODING_RATE_CONTROL "--rc"
+#define CODING_RAW_TOKEN    "--coding-raw"
+#define CAP_COMPAT_TOKEN    "--cap-compat"
 #define SHOW_BANDS          "--show-bands"
 
 #define LIMIT_FPS_TOKEN "--limit-fps"
@@ -127,6 +129,15 @@ static void set_coding_vpred(const char *value, EncoderConfig_t *cfg) {
 
 static void set_rate_control_mode(const char *value, EncoderConfig_t *cfg) {
     cfg->encoder.rate_control_mode = strtoul(value, NULL, 0);
+}
+
+static void set_coding_raw(const char *value, EncoderConfig_t *cfg) {
+    /* CLI: 1 = raw-mode enabled (default), 0 = disabled. Internal field stores the inverse. */
+    cfg->encoder.coding_raw_disable = strtoul(value, NULL, 0) ? 0 : 1;
+}
+
+static void set_cap_compat(const char *value, EncoderConfig_t *cfg) {
+    cfg->encoder.cap_compat = (uint8_t)strtoul(value, NULL, 0);
 }
 
 static void set_encoder_colour_format(const char *value, EncoderConfig_t *cfg) {
@@ -315,6 +326,8 @@ ConfigEntry config_entry[] = {
     {CODING_OPTIONS, CODING_SIGF_TOKEN,     "Enable Significance coding (enabled:1, disable:0, default:1)", 0, 1, set_coding_significance},
     {CODING_OPTIONS, CODING_PRED_TOKEN,     "Enable Vertical Prediction coding (disable:0, zero prediction residuals:1, zero coefficients:2, default: 0)", 0, 1, set_coding_vpred},
     {CODING_OPTIONS, CODING_RATE_CONTROL,   "Rate Control mode (CBR: budget per precinct: 0, CBR: budget per precinct with padding movement: 1, CBR: budget per slice: 2, CBR: budget per slice with max size RATE: 3, default 0)", 0, 1, set_rate_control_mode},
+    {CODING_OPTIONS, CODING_RAW_TOKEN,      "Packet-based raw-mode coding (enabled:1, disabled:0, default:1). Disabling clears the raw-mode capability bit and never selects raw packet packing.", 0, 1, set_coding_raw},
+    {CODING_OPTIONS, CAP_COMPAT_TOKEN,      "Legacy decoder CAP-marker compatibility (full CAP:0, empty CAP when no capability bit set:1, default:0)", 0, 1, set_cap_compat},
     {THREAD_PERF_OPTIONS, ASM_TYPE_TOKEN,   "Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, "
                                             "ssse3, sse4_1, sse4_2,"
                                             " avx, avx2, avx512, max], by default highest level supported by CPU", 0, 1,

--- a/Source/Lib/Encoder/Codec/EncHandle.c
+++ b/Source/Lib/Encoder/Codec/EncHandle.c
@@ -255,7 +255,8 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     enc_common->picture_header_dynamic.hdr_Qpih = config_struct->quantization;
     enc_common->pi.use_short_header = (((config_struct->source_width * num_comp) < 32768) && (config_struct->ndecomp_v < 3));
 
-    enc_common->picture_header_dynamic.hdr_Rl = 1;
+    enc_common->picture_header_dynamic.hdr_Rl = config_struct->coding_raw_disable ? 0 : 1;
+    enc_common->cap_compat = config_struct->cap_compat ? 1 : 0;
 
     if (config_struct->coding_signs_handling > SIGN_HANDLING_STRATEGY_FULL) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {

--- a/Source/Lib/Encoder/Codec/Encoder.h
+++ b/Source/Lib/Encoder/Codec/Encoder.h
@@ -98,6 +98,7 @@ typedef struct svt_jpeg_xs_encoder_common {
     */
     uint32_t *slice_sizes;
     uint8_t slice_packetization_mode;
+    uint8_t cap_compat; /* Emit empty CAP marker (Lcap=2) when no capability bit is set (legacy decoder compatibility) */
 } svt_jpeg_xs_encoder_common_t;
 
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/Codec/PackHeaders.c
+++ b/Source/Lib/Encoder/Codec/PackHeaders.c
@@ -26,6 +26,21 @@ void write_capabilities_marker(bitstream_writer_t* bitstream, svt_jpeg_xs_encode
     capability[7] = 0;           //Unused
     capability[8] = enc_common->picture_header_dynamic.hdr_Rl; //Support for packet-based raw-mode switch required
 
+    /* Legacy decoder compatibility: when enabled and no capability bit is set, emit an empty CAP marker
+     * (Lcap=2). Some strict decoders reject a non-empty CAP marker. When the stream genuinely requires a
+     * capability bit (e.g. 4:2:0 sub-sampling), a full CAP marker is still written to remain conformant. */
+    if (enc_common->cap_compat) {
+        uint8_t any_capability = 0;
+        for (uint8_t i = 0; i < elements; ++i) {
+            any_capability |= capability[i];
+        }
+        if (!any_capability) {
+            uint16_t empty_size_bytes = BITS_TO_BYTE_WITH_ALIGN(16); //Lcap only, no flags
+            write_16_bits(bitstream, empty_size_bytes);
+            return;
+        }
+    }
+
     uint16_t size_bytes = BITS_TO_BYTE_WITH_ALIGN(16 + elements); //Lcap + flags
     write_16_bits(bitstream, size_bytes);
     for (uint8_t i = 0; i < elements; ++i) {

--- a/Source/Lib/Encoder/Codec/RateControl.c
+++ b/Source/Lib/Encoder/Codec/RateControl.c
@@ -707,7 +707,8 @@ static uint32_t precinct_get_budget_bytes(svt_jpeg_xs_encoder_common_t *enc_comm
     pi_t *pi = &enc_common->pi;
     /*For current implementation support only more complex implementation
       that 2 packages with that same band can have different ram mode flag.*/
-    assert(enc_common->picture_header_dynamic.hdr_Rl != 0);
+    /* Raw packet packing is only ever selected when raw-mode is enabled (hdr_Rl != 0).
+       When raw-mode is disabled (hdr_Rl == 0) the raw selection below is skipped, so this path is valid. */
     rate_control_calculate_band_best_method(pi, precinct, enc_common, coding_vertical_prediction_mode, coding_signs_handling);
     precinct_info_t *p_info = precinct->p_info;
 
@@ -761,7 +762,8 @@ static uint32_t precinct_get_budget_bytes(svt_jpeg_xs_encoder_common_t *enc_comm
         /*GCLI Pack Size:*/
         uint32_t packet_size_significance_bytes = BITS_TO_BYTE_WITH_ALIGN(packet_size_significance_bits);
         uint32_t packet_size_gcli_bytes = BITS_TO_BYTE_WITH_ALIGN(packet_size_gcli_bits);
-        if (packet_size_significance_bytes + packet_size_gcli_bytes > p_info->packet_size_gcli_raw_bytes[packet_idx]) {
+        if (enc_common->picture_header_dynamic.hdr_Rl &&
+            (packet_size_significance_bytes + packet_size_gcli_bytes > p_info->packet_size_gcli_raw_bytes[packet_idx])) {
             /*Set Pack RAW*/
             precinct->packet_methods_raw[packet_idx] = 1;
             precinct->packet_size_significance_bytes[packet_idx] = 0;

--- a/documentation/encoder/EncoderSnippets.md
+++ b/documentation/encoder/EncoderSnippets.md
@@ -1,4 +1,6 @@
-### Encoder configuration parameters overview (svt_jpeg_xs_encoder_api_t)
+# Encoder Snippets
+
+## Encoder configuration parameters overview (svt_jpeg_xs_encoder_api_t)
 
 param | description | mandatory/optional | default | Accepted values
 -- | -- | -- | -- | --
@@ -6,7 +8,7 @@ source_width | Width of the image in sample grid positions | mandatory | N/A | <
 source_height | Height of the image in sample   grid positions | mandatory | N/A | <64; 65 535>
 input_bit_depth | Specifies the bit depth of input video. | mandatory | N/A | 8(8 bit), 10(10 bit)
 colour_format | Specifies the format of input video,   please refer to ColourFormat_t enum | mandatory | N/A | Tested: (COLOUR_FORMAT_PLANAR_YUV420, COLOUR_FORMAT_PLANAR_YUV422, COLOUR_FORMAT_PLANAR_YUV444_OR_RGB),   experimental: (COLOUR_FORMAT_YUV400)
-bpp_numerator | Bitrate: bits per pixel numerator,   BPP=(bpp_numerator/bpp_denominator), Per frame bitrate is equal to (width * height * bpp_numerator / bpp_denominator) | mandatory | N/A | <1;N/A>
+bpp_numerator | Bitrate: bits per pixel numerator,   BPP=(bpp_numerator/bpp_denominator), Per frame bitrate is equal to (width \* height \* bpp_numerator / bpp_denominator) | mandatory | N/A | <1;N/A>
 bpp_denominator | Bitrate: bits per pixel denominator, required if non-integer   BPP is required | optional | 1 | <1; N/A>
 use_cpu_flags | Performance: limit assembly instruction set used by encoder,   please refer to CPU_FLAGS | optional | CPU_FLAGS_ALL | CPU_FLAGS_C, CPU_FLAGS_MMX, CPU_FLAGS_SSE ,CPU_FLAGS_SSE2 ,CPU_FLAGS_SSE3 ,CPU_FLAGS_SSSE3 ,CPU_FLAGS_SSE4_1 ,CPU_FLAGS_SSE4_2 ,CPU_FLAGS_AVX ,CPU_FLAGS_AVX2 ,CPU_FLAGS_ALL (avx512)
 threads_num | Performance: Number of thread encoder can create, 0 mean   minimum number of threads is created | optional | 0 | <0;N/A>
@@ -21,17 +23,19 @@ coding_signs_handling | Coding feature: Sign handling strategy | optional | 0 (d
 coding_significance | Coding feature: Signification coding | optional | 1 (enable) | 0(disable), 1(enable)
 coding_vertical_prediction_mode | Coding feature: vertical prediction | optional | 0 (disable) | 0(disable), 1(zero prediction residuals), 2(zero   coefficients)
 rate_control_mode | Rate control type | optional | 0 | 0(CBR: budget per precinct), 1(CBR: budget per precinct with padding movement), 2(CBR: budget per slice), 3(CBR: budget per slice with nax size RATE)
-slice_packetization_mode | Specify how encoded stream is returned | optional| 0 | 1(multiple packets per frame), 0(single packet per frame)
-callback_send_data_available |   | optional | NULL | function pointer
-callback_send_data_available_context |   | optional | NULL |  
-callback_get_data_available |   | optional | NULL | function pointer
-callback_get_data_available_context |   | optional | NULL |  
+slice_packetization_mode | Specify how encoded stream is returned | optional | 0 | 1(multiple packets per frame), 0(single packet per frame)
+coding_raw_disable | Disable packet-based raw-mode coding (disable for legacy-decoder compatibility) | optional | 0 (raw-mode enabled) | 0(raw-mode enabled), 1(raw-mode disabled)
+cap_compat | Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required | optional | 0 (full CAP marker) | 0(full CAP marker), 1(empty CAP marker when no capability bit is set)
+callback_send_data_available | Callback called when the next input element is taken from the queue | optional | NULL | function pointer
+callback_send_data_available_context | Context pointer passed to callback_send_data_available | optional | NULL | pointer
+callback_get_data_available | Callback called when a new encoded frame is ready to get | optional | NULL | function pointer
+callback_get_data_available_context | Context pointer passed to callback_get_data_available | optional | NULL | pointer
 
-### Encoder simplified usage
+## Encoder simplified usage
 
-Code listed below is also kept [here](../../Source/App/SampleEncoder/main.c)
+Code listed below is also kept in [Source/App/SampleEncoder/main.c](../../Source/App/SampleEncoder/main.c)
 
-```
+```c
 #include <SvtJpegxsEnc.h>
 
 int32_t main(int32_t argc, char* argv[]) {
@@ -140,6 +144,6 @@ int32_t main(int32_t argc, char* argv[]) {
 
 ## Notes
 
-The information in this document was compiled at <mark>v0.10</mark> of the code and may not
+The information in this document was compiled at **v0.10** of the code and may not
 reflect the latest status of the design. For the most up-to-date
 settings and implementation, it's recommended to visit the specific section of the code.

--- a/ffmpeg-plugin/8.1/0005-Add-coding-raw-and-cap-comp.patch
+++ b/ffmpeg-plugin/8.1/0005-Add-coding-raw-and-cap-comp.patch
@@ -1,0 +1,61 @@
+From 0dcc5ecd55427c727e4244c6db5e22eab3b428b2 Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Thu, 9 Jul 2026 12:00:00 +0200
+Subject: [PATCH] avcodec/libsvtjpegxsenc: add coding-raw and cap-compat
+ options
+
+Add two AVOptions mirroring the SVT-JPEG-XS 0.10 encoder API fields
+coding_raw_disable and cap_compat:
+
+ - coding-raw: enable/disable packet-based raw-mode coding. Disabling
+   clears the raw-mode capability bit and never selects raw packet
+   packing, which some strict/legacy decoders require.
+ - cap-compat: emit an empty CAP marker (Lcap=2) when no capability
+   bit is set. Some legacy/strict decoders reject a non-empty CAP
+   marker. When the stream genuinely requires a capability bit (e.g.
+   4:2:0 sub-sampling) a full CAP marker is still written to remain
+   conformant.
+
+Both options default to unset (-1), leaving the library default
+behaviour in place.
+---
+ libavcodec/libsvtjpegxsenc.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index cddc09a90b..2e3123bdac 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -46,6 +46,8 @@ typedef struct SvtJpegXsEncodeContext {
+     int coding_signs_handling;
+     int coding_significance;
+     int coding_vpred;
++    int coding_raw;
++    int cap_compat;
+
+     svt_jpeg_xs_encoder_api_t encoder;
+     int bitstream_frame_size;
+@@ -256,6 +258,12 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     if (svt_enc->coding_vpred != -1) {
+         svt_enc->encoder.coding_vertical_prediction_mode = svt_enc->coding_vpred;
+     }
++    if (svt_enc->coding_raw != -1) {
++        svt_enc->encoder.coding_raw_disable = svt_enc->coding_raw ? 0 : 1;
++    }
++    if (svt_enc->cap_compat != -1) {
++        svt_enc->encoder.cap_compat = svt_enc->cap_compat ? 1 : 0;
++    }
+     if (svt_enc->slice_height > 0) {
+         svt_enc->encoder.slice_height = svt_enc->slice_height;
+     }
+@@ -291,6 +299,8 @@ static const AVOption svtjpegxs_enc_options[] = {
+       { "disable",      NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_residuals", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 1}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_coeffs",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
++    { "coding-raw",   "Enable packet-based raw-mode coding (disable for legacy-decoder compatibility)", OFFSET(coding_raw),   AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
++    { "cap-compat",   "Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required", OFFSET(cap_compat), AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
+     {NULL},
+ };
+
+--
+2.43.0

--- a/ffmpeg-plugin/libsvtjpegxsenc.c
+++ b/ffmpeg-plugin/libsvtjpegxsenc.c
@@ -26,6 +26,8 @@ typedef struct SvtJpegXsEncodeContext {
     int coding_signs_handling;
     int coding_significance;
     int coding_vpred;
+    int coding_raw;
+    int cap_compat;
 
     svt_jpeg_xs_encoder_api_t encoder;
     int bitstream_frame_size;
@@ -236,6 +238,12 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
     if (svt_enc->coding_vpred != -1) {
         svt_enc->encoder.coding_vertical_prediction_mode = svt_enc->coding_vpred;
     }
+    if (svt_enc->coding_raw != -1) {
+        svt_enc->encoder.coding_raw_disable = svt_enc->coding_raw ? 0 : 1;
+    }
+    if (svt_enc->cap_compat != -1) {
+        svt_enc->encoder.cap_compat = svt_enc->cap_compat ? 1 : 0;
+    }
     if (svt_enc->slice_height > 0) {
         svt_enc->encoder.slice_height = svt_enc->slice_height;
     }
@@ -295,6 +303,22 @@ static const AVOption svtjpegxs_enc_options[] = {
     {"disable", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred"},
     {"no_residuals", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 1}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred"},
     {"no_coeffs", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred"},
+    {"coding-raw",
+     "Enable packet-based raw-mode coding (disable for legacy-decoder compatibility)",
+     OFFSET(coding_raw),
+     AV_OPT_TYPE_BOOL,
+     {.i64 = -1},
+     -1,
+     1,
+     VE},
+    {"cap-compat",
+     "Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required",
+     OFFSET(cap_compat),
+     AV_OPT_TYPE_BOOL,
+     {.i64 = -1},
+     -1,
+     1,
+     VE},
     {NULL},
 };
 

--- a/ffmpeg-plugin/readme.md
+++ b/ffmpeg-plugin/readme.md
@@ -209,6 +209,8 @@ quantization|optional|(default:deadzone), 0(deadzone), 1(uniform)|Coding feature
 coding-signs|optional|(default:off), 0(off), 1(fast), 2(full)|Coding feature: Sign handling strategy
 coding-sigf|optional|(default:on), 0(off), 1(on)|Coding feature: Significance coding
 coding-vpred|optional|(default:off), 0(off), 1(on)|Coding feature: Vertical-prediction
+coding-raw|optional|(default:auto/enabled), true(enabled), false(disable for legacy-decoder compatibility)|Coding feature: packet-based raw-mode coding
+cap-compat|optional|(default:auto/disabled), true(enabled), false(disabled)|Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required
 
 ## libsvtjpegxs decoder available params
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; border-bottom: 1px solid rgba(209, 217, 224, 0.7); padding-bottom: 0.3em; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">SVT-JPEG-XS Encoder: Legacy-Decoder Compatibility Knobs</h2><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Overview</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Two new, opt-in encoder knobs fix interop with strict hardware decoders (e.g.<span> </span><strong style="box-sizing: border-box; font-weight: 600;">Appear TV</strong>) that reject the standard SVT-JPEG-XS codestream header. They replace an earlier hardcoded patch with a clean, configurable, mergeable implementation. Defaults preserve current behavior exactly.</p><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What changed</h3><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Knob (CLI) | API field | Default | Effect
-- | -- | -- | --
--coding-raw <0\|1> | coding_raw_disable (inverted) | 1 (raw on) | 0 disables packet-based raw-mode coding and clears the corresponding CAP capability bit.
--cap-compat <0\|1> | cap_compat | 0 (full CAP) | 1 writes an empty CAP marker (Lcap=2) when no capability bit is set.

</markdown-accessiblity-table><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to use it (Appear TV fix)</h3><div class="snippet-clipboard-content notranslate position-relative overflow-auto" style="box-sizing: border-box; overflow: auto !important; position: relative !important; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><pre class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; margin-top: 0px; margin-bottom: 16px; tab-size: 4; overflow-wrap: normal; padding: 16px; color: rgb(31, 35, 40); background-color: rgb(246, 248, 250); border-radius: 6px; line-height: 1.45; overflow: auto;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: pre; background: 0px 0px rgba(0, 0, 0, 0); border-radius: 6px; margin: 0px; padding: 0px; word-break: normal; border: 0px; line-height: inherit; overflow-wrap: normal; display: inline; overflow: visible;">SvtJpegxsEncApp ... --coding-raw 0 --cap-compat 1
</code></pre><div class="zeroclipboard-container position-absolute right-0 top-0" style="box-sizing: border-box; position: absolute !important; top: 0px !important; right: 0px !important;"><clipboard-copy aria-label="Copy code to clipboard" class="ClipboardButton btn js-clipboard-copy m-2 p-0" data-copy-feedback="Copied!" data-tooltip-direction="w" value="SvtJpegxsEncApp ... --coding-raw 0 --cap-compat 1" tabindex="0" role="button" style="box-sizing: border-box; margin: 8px !important; padding: 0px !important; font-size: 14px; font-weight: 500; white-space: nowrap; vertical-align: middle; cursor: pointer; user-select: none; appearance: none; border: 1px solid rgb(209, 217, 224); border-radius: 6px; line-height: 20px; display: inline-block; position: relative; color: rgb(37, 41, 46); background-color: rgb(246, 248, 250); box-shadow: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color 80ms cubic-bezier(0.33, 1, 0.68, 1), box-shadow 80ms cubic-bezier(0.33, 1, 0.68, 1), border-color 80ms cubic-bezier(0.33, 1, 0.68, 1);"><svg aria-hidden="true" data-component="Octicon" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2 tmp-m-2"></svg></clipboard-copy></div></div><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This produces a header that strict parsers accept:</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">CAP marker becomes<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ff 50 00 02</code><span> </span>(empty,<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Lcap=2</code>) instead of<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ff 50 00 04 00 80</code>.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Picture header<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Rl</code><span> </span>bit = 0 (raw-mode off).</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Defaults preserve current behavior</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Both fields default to zero, and zero means<span> </span><strong style="box-sizing: border-box; font-weight: 600;">exactly today's behavior</strong><span> </span>— full CAP marker and raw-mode enabled. The new fields fit inside the existing reserved<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">padding[]</code>, so the<span> </span><strong style="box-sizing: border-box; font-weight: 600;">ABI is unchanged</strong>. Existing callers (ffmpeg, MTL, GStreamer plugins) are unaffected.</p><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Decoder</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">No decoder change required. The SVT-JPEG-XS decoder already accepts the empty CAP marker, and an encode→decode round-trip was verified working.</p><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Important 4:2:0 caveat (by design)</h3><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Implements the spec-honest "Option Y": the empty CAP marker is only emitted when<span> </span><strong style="box-sizing: border-box; font-weight: 600;">all</strong><span> </span>capability bits are zero.</p><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">4:2:2</strong><span> </span>→ with<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--coding-raw 0</code>, no capability bit is set → empty CAP → Appear TV works.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">4:2:0</strong><span> </span>→ the chroma-subsampling capability bit is still required, so a full CAP marker is still written.<span> </span><strong style="box-sizing: border-box; font-weight: 600;">Appear TV + 4:2:0 is therefore not fixed</strong><span> </span>by this knob — that would require misrepresenting the subsampling in the header, which we avoided to stay conformant and not break other strict decoders.</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Validation performed</h3><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">Full debug build (gcc) with tests:<span> </span><strong style="box-sizing: border-box; font-weight: 600;">success</strong>.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Encoder / rate-control / pack / API unit tests:<span> </span><strong style="box-sizing: border-box; font-weight: 600;">13/13 pass</strong>.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Round-trip: encoded 4:2:2 with the knobs → confirmed<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ff 50 00 02</code><span> </span>empty CAP and<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Rl=0</code>; default encode confirmed<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">ff 50 00 04 00 80</code>; decoded the compat stream back to a full frame (rc=0).</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Not yet done (deferred)</h3><ul dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">Exposing these knobs through the<span> </span><strong style="box-sizing: border-box; font-weight: 600;">ffmpeg / MTL / GStreamer</strong><span> </span>plugins — to be added in a follow-up.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Evertz 670</strong><span> </span>still reports a generic decoder fault after the Appear fix; this is a<span> </span><em style="box-sizing: border-box;">different</em><span> </span>root cause (top suspect:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Ppih</code>/<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Plev</code><span> </span>= 0 in the picture header, possibly the TS transport path). Needs additional captures before a fix.</li></ul><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Open questions</h3><ol dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; padding: 0px; position: relative; color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;">Is the Appear feed<span> </span><strong style="box-sizing: border-box; font-weight: 600;">4:2:2 or 4:2:0</strong>? (Determines whether<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">--cap-compat</code><span> </span>alone is sufficient.)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">For Evertz: capture a rejected<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.jxs</code><span> </span>ES plus an IntoPix stream it accepts, so we can diff the picture header (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Ppih</code>/<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Plev</code>/<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">Cpih</code>); confirm whether ev670 is fed real MPEG-TS or de-muxed ES over ST 2022-2 / 2110-22; firmware/APP variant; and whether the old<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">if(0)</code><span> </span>raw-mode patch is still active.</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;">Which frontend is in use (EncApp / ffmpeg / GStreamer / MTL) — to scope the plugin patches.</li></ol><!--EndFragment-->
</body>
</html>