### PR TITLE
feat(ffmpeg-plugin): add FFmpeg 9.0 support

### DIFF
--- a/.github/scripts/build_ffmpeg_plugin.sh
+++ b/.github/scripts/build_ffmpeg_plugin.sh
@@ -10,20 +10,24 @@ FFMPEG_VERSION=${1:-6.1}
 INSTALL_FMPEG=${2:-"n"}
 COPY_FILES=${3:-"y"}
 
-if [[ "$FFMPEG_VERSION" != "6.1" && "$FFMPEG_VERSION" != "7.0" && "$FFMPEG_VERSION" != "7.1" && "$FFMPEG_VERSION" != "8.0" && "$FFMPEG_VERSION" != "8.1" ]]; then
+if [[ "$FFMPEG_VERSION" != "6.1" && "$FFMPEG_VERSION" != "7.0" && "$FFMPEG_VERSION" != "7.1" && "$FFMPEG_VERSION" != "8.0" && "$FFMPEG_VERSION" != "8.1" && "$FFMPEG_VERSION" != "9.0" ]]; then
     echo "Usage: $0  <ffmpeg-version> <install-ffmpeg>"
-    echo "ffmpeg-version: 6.1|7.0|7.1|8.0|8.1 (required)"
-    echo "install-ffmpeg: y|n (default: n)"
+    echo "ffmpeg-version: 6.1|7.0|7.1|8.0|8.1|9.0 (required)"
     echo "Example: $0 6.1 y"
     exit 1
 fi
 
 if [[ "$COPY_FILES" != "y" && "$COPY_FILES" != "n" ]]; then
-    echo "Usage: $0  <ffmpeg-version> <install-ffmpeg> <copy-files>"
-    echo "copy-files: y|n (default: y)"
+    echo "Usage: $0  <ffmpeg-version: 6.1|7.0|7.1|8.0|8.1|9.0> <copy-files: y|n>"
     echo "Example: $0 6.1 y y"
     exit 1
 fi
+
+if [[ ("$FFMPEG_VERSION" == "8.1" || "$FFMPEG_VERSION" == "9.0") && "$COPY_FILES" == "y" ]]; then
+    echo "ffmpeg $FFMPEG_VERSION already ships libsvtjpegxs* upstream, forcing copy-files=n"
+    COPY_FILES="n"
+fi
+
 echo "=== 0. Create installation directory and export env variable ==="
 export INSTALL_DIR="$PWD/install-dir"
 mkdir -p "$INSTALL_DIR"

--- a/.github/scripts/build_ffmpeg_plugin_msys.sh
+++ b/.github/scripts/build_ffmpeg_plugin_msys.sh
@@ -6,17 +6,23 @@ JPEGXS_REPO="${PWD}"
 FFMPEG_VERSION="${1:-6.1}"
 COPY_FILES="${2:-y}"
 
-if [[ "$FFMPEG_VERSION" != "6.1" && "$FFMPEG_VERSION" != "7.0" && "$FFMPEG_VERSION" != "7.1" && "$FFMPEG_VERSION" != "8.0" && "$FFMPEG_VERSION" != "8.1" ]]; then
-    echo "Usage: $0  <ffmpeg-version: 6.1|7.0|7.1|8.0|8.1> <copy-files: y|n>"
-    echo "Example: $0 8.1 y"
+if [[ "$FFMPEG_VERSION" != "6.1" && "$FFMPEG_VERSION" != "7.0" && "$FFMPEG_VERSION" != "7.1" && "$FFMPEG_VERSION" != "8.0" && "$FFMPEG_VERSION" != "8.1" && "$FFMPEG_VERSION" != "9.0" ]]; then
+    echo "Usage: $0  <ffmpeg-version: 6.1|7.0|7.1|8.0|8.1|9.0> <copy-files: y|n>"
+    echo "Example: $0 6.1 y"
     exit 1
 fi
 
 if [[ "$COPY_FILES" != "y" && "$COPY_FILES" != "n" ]]; then
-    echo "Usage: $0  <ffmpeg-version: 6.1|7.0|7.1|8.0|8.1> <copy-files: y|n>"
-    echo "Example: $0 8.1 y"
+    echo "Usage: $0  <ffmpeg-version: 6.1|7.0|7.1|8.0|8.1|9.0> <copy-files: y|n>"
+    echo "Example: $0 6.1 y"
     exit 1
 fi
+
+if [[ ("$FFMPEG_VERSION" == "8.1" || "$FFMPEG_VERSION" == "9.0") && "$COPY_FILES" == "y" ]]; then
+    echo "ffmpeg $FFMPEG_VERSION already ships libsvtjpegxs* upstream, forcing copy-files=n"
+    COPY_FILES="n"
+fi
+
 pacman -S --noconfirm make mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-yasm mingw-w64-x86_64-diffutils mingw-w64-x86_64-winpthreads mingw-w64-x86_64-toolchain
 INSTALL_DIR="$PWD/install-dir"
 mkdir -p "$INSTALL_DIR"

--- a/.github/workflows/ffmpeg_plugin_build.yaml
+++ b/.github/workflows/ffmpeg_plugin_build.yaml
@@ -22,11 +22,13 @@ env:
   LINUX_ARTIFACTS_7_1: linux-ffmpeg-7-1-build-${{ github.run_number }}
   LINUX_ARTIFACTS_8_0: linux-ffmpeg-8-0-build-${{ github.run_number }}
   LINUX_ARTIFACTS_8_1: linux-ffmpeg-8-1-build-${{ github.run_number }}
+  LINUX_ARTIFACTS_9_0: linux-ffmpeg-9-0-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_6_1: windows-ffmpeg-6-1-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_7_0: windows-ffmpeg-7-0-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_7_1: windows-ffmpeg-7-1-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_8_0: windows-ffmpeg-8-0-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_8_1: windows-ffmpeg-8-1-build-${{ github.run_number }}
+  WINDOWS_ARTIFACTS_9_0: windows-ffmpeg-9-0-build-${{ github.run_number }}
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -187,6 +189,36 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: "${{ env.LINUX_ARTIFACTS_8_1 }}"
+          retention-days: 30
+          path: |
+            install-dir/bin/
+
+  ffmpeg-9-0-linux-build:
+      needs: changes
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      runs-on: 'ubuntu-22.04'
+      timeout-minutes: 120
+      steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Setup:  Install dependencies'
+        run: |
+            sudo apt-get update
+            sudo apt-get -y install nasm
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: 'install ffmpeg plugin'
+        run: .github/scripts/build_ffmpeg_plugin.sh 9.0 n n
+
+      - name: "Archive: upload artifacts"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "${{ env.LINUX_ARTIFACTS_9_0 }}"
           retention-days: 30
           path: |
             install-dir/bin/
@@ -388,6 +420,46 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: "${{ env.WINDOWS_ARTIFACTS_8_1 }}"
+          retention-days: 30
+          path: |
+            install-dir/bin/
+
+  ffmpeg-9-0-windows-build:
+      needs: changes
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      runs-on: 'windows-2022'
+      timeout-minutes: 120
+      steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: 'Install dependencies'
+        working-directory: "${{ github.workspace }}"
+        shell: pwsh
+        run: ./.github/scripts/configure.ps1
+
+      - name: 'install msys2 shell'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm nasm
+      - name: 'install ffmpeg plugin'
+        working-directory: "${{ github.workspace }}"
+        shell: msys2 {0}
+        run: |
+          export ASM_NASM="${{ env.ASM_NASM }}"
+          ./.github/scripts/build_ffmpeg_plugin_msys.sh 9.0 n
+
+      - name: "Archive: upload artifacts"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "${{ env.WINDOWS_ARTIFACTS_9_0 }}"
           retention-days: 30
           path: |
             install-dir/bin/

--- a/ffmpeg-plugin/9.0/0001-Add-JPEG-XS-muxing-support-for-mp4-mkv-mpegts.patch
+++ b/ffmpeg-plugin/9.0/0001-Add-JPEG-XS-muxing-support-for-mp4-mkv-mpegts.patch
@@ -1,0 +1,153 @@
+From dd450be0959eed920104c9a1ede77136fe9ddad7 Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Mon, 30 Oct 2023 06:49:02 +0100
+Subject: [PATCH] Allow JPEG XS to be stored in mp4, mkv and mpegts containers
+
+Write JXS_video_descriptor (EXTENSION_DESCRIPTOR 0x3f, ext tag 0x14)
+in the PMT for MPEG-TS muxing, as required by ISO/IEC 13818-1.
+
+schar field encodes colour_specification in bits [11:8] (Cs=1 for RGB/GBR)
+and subsampling in bits [3:0] (Ssub: 0=4:2:2, 1=4:4:4, 2=4:2:0)
+per ISO/IEC 21122-3.
+---
+ libavformat/isom_tags.c |  1 +
+ libavformat/movenc.c    |  1 +
+ libavformat/mpegtsenc.c | 91 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 93 insertions(+)
+
+diff --git a/libavformat/isom_tags.c b/libavformat/isom_tags.c
+index 1cd655b06c..43195efd3f 100644
+--- a/libavformat/isom_tags.c
++++ b/libavformat/isom_tags.c
+@@ -213,6 +213,7 @@ const AVCodecTag ff_codec_movvideo_tags[] = {
+     { AV_CODEC_ID_MPEG2VIDEO, MKTAG('m', 'p', '2', 'v') }, /* FCP5 */
+ 
+     { AV_CODEC_ID_JPEG2000, MKTAG('m', 'j', 'p', '2') }, /* JPEG 2000 produced by FCP */
++    { AV_CODEC_ID_JPEGXS,   MKTAG('j', 'x', 's', 'm') }, /* JPEGXS */
+ 
+     { AV_CODEC_ID_TARGA, MKTAG('t', 'g', 'a', ' ') }, /* Truevision Targa */
+     { AV_CODEC_ID_TIFF,  MKTAG('t', 'i', 'f', 'f') }, /* TIFF embedded in MOV */
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index fe6b259561..e4be9644f4 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -8898,6 +8898,7 @@ static const AVCodecTag codec_mp4_tags[] = {
+     { AV_CODEC_ID_MJPEG,           MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_PNG,             MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_JPEG2000,        MKTAG('m', 'p', '4', 'v') },
++    { AV_CODEC_ID_JPEGXS,          MKTAG('j', 'x', 's', 'm') },
+     { AV_CODEC_ID_VC1,             MKTAG('v', 'c', '-', '1') },
+     { AV_CODEC_ID_DIRAC,           MKTAG('d', 'r', 'a', 'c') },
+     { AV_CODEC_ID_TSCC2,           MKTAG('m', 'p', '4', 'v') },
+diff --git a/libavformat/mpegtsenc.c b/libavformat/mpegtsenc.c
+index 96cdea955e..32eb97a637 100644
+--- a/libavformat/mpegtsenc.c
++++ b/libavformat/mpegtsenc.c
+@@ -387,6 +387,9 @@ static int get_dvb_stream_type(AVFormatContext *s, AVStream *st)
+     case AV_CODEC_ID_DIRAC:
+         stream_type = STREAM_TYPE_VIDEO_DIRAC;
+         break;
++    case AV_CODEC_ID_JPEGXS:
++        stream_type = STREAM_TYPE_VIDEO_JPEGXS;
++        break;
+     case AV_CODEC_ID_VC1:
+         stream_type = STREAM_TYPE_VIDEO_VC1;
+         break;
+@@ -811,6 +814,94 @@ static int mpegts_write_pmt(AVFormatContext *s, MpegTSService *service)
+             } else if (stream_type == STREAM_TYPE_VIDEO_CAVS || stream_type == STREAM_TYPE_VIDEO_AVS2 ||
+                        stream_type == STREAM_TYPE_VIDEO_AVS3) {
+                 put_registration_descriptor(&q, MKTAG('A', 'V', 'S', 'V'));
++            } else if (stream_type == STREAM_TYPE_VIDEO_JPEGXS) {
++                /* Write JXS_video_descriptor per ISO/IEC 13818-1 Table 2-109.
++                 * Carried as EXTENSION_DESCRIPTOR (0x3f) with
++                 * ext tag JXS_VIDEO_DESCRIPTOR (0x14).
++                 * Total descriptor_length = 1 (ext tag) + 28 (payload) = 29 */
++                int vertical_size = st->codecpar->height;
++                int interlace_mode = 0;
++                uint32_t frat = 0, brat = 0;
++                uint16_t schar = 0;
++                uint8_t vfr_flags;
++
++                switch (st->codecpar->field_order) {
++                case AV_FIELD_TT:
++                case AV_FIELD_TB:
++                    interlace_mode = 1;
++                    vertical_size = st->codecpar->height / 2;
++                    break;
++                case AV_FIELD_BB:
++                case AV_FIELD_BT:
++                    interlace_mode = 2;
++                    vertical_size = st->codecpar->height / 2;
++                    break;
++                default:
++                    break;
++                }
++
++                if (st->codecpar->bit_rate > 0)
++                    brat = (uint32_t)((st->codecpar->bit_rate + (1 << 16) - 1) >> 16);
++
++                if (st->codecpar->framerate.num > 0 && st->codecpar->framerate.den > 0) {
++                    int frat_num, frat_den;
++                    if (st->codecpar->framerate.den == 1001) {
++                        frat_den = 2;
++                        frat_num = (st->codecpar->framerate.num + 500) / 1000;
++                    } else {
++                        frat_den = 1;
++                        frat_num = st->codecpar->framerate.num / st->codecpar->framerate.den;
++                    }
++                    frat = ((uint32_t)interlace_mode << 30) |
++                           ((uint32_t)(frat_den & 0x3f) << 24) |
++                           (frat_num & 0xFFFF);
++                }
++
++                switch (st->codecpar->format) {
++                case AV_PIX_FMT_GBRP:
++                case AV_PIX_FMT_GBRP10LE:
++                case AV_PIX_FMT_GBRP12LE:
++                case AV_PIX_FMT_GBRP14LE:
++                    schar = 0x0101; /* Cs=1 (RGB), Ssub=1 (4:4:4) */
++                    break;
++                case AV_PIX_FMT_YUV444P:
++                case AV_PIX_FMT_YUV444P10LE:
++                case AV_PIX_FMT_YUV444P12LE:
++                case AV_PIX_FMT_YUV444P14LE:
++                    schar = 0x0001; /* Cs=0 (YCbCr), Ssub=1 (4:4:4) */
++                    break;
++                case AV_PIX_FMT_YUV420P:
++                case AV_PIX_FMT_YUV420P10LE:
++                case AV_PIX_FMT_YUV420P12LE:
++                case AV_PIX_FMT_YUV420P14LE:
++                    schar = 0x0002; /* Cs=0 (YCbCr), Ssub=2 (4:2:0) */
++                    break;
++                default:
++                    schar = 0x0000; /* Cs=0 (YCbCr), Ssub=0 (4:2:2) */
++                    break;
++                }
++
++                vfr_flags = 0x1f; /* reserved bits [4:0] set to 1 */
++                if (st->codecpar->color_range == AVCOL_RANGE_JPEG)
++                    vfr_flags |= 0x80; /* video_full_range_flag */
++
++                *q++ = EXTENSION_DESCRIPTOR;      /* descriptor_tag */
++                *q++ = 29;                        /* descriptor_length */
++                *q++ = JXS_VIDEO_DESCRIPTOR;      /* descriptor_tag_extension */
++                *q++ = 0;                         /* descriptor_version */
++                put16(&q, st->codecpar->width);   /* horizontal_size */
++                put16(&q, vertical_size);         /* vertical_size */
++                AV_WB32(q, brat); q += 4;        /* brat */
++                AV_WB32(q, frat); q += 4;        /* frat */
++                put16(&q, schar);                 /* schar */
++                put16(&q, 0);                     /* Ppih */
++                put16(&q, 0);                     /* Plev */
++                AV_WB32(q, 0); q += 4;           /* max_buffer_size */
++                *q++ = 0;                         /* buffer_model_type */
++                *q++ = st->codecpar->color_primaries;
++                *q++ = st->codecpar->color_trc;
++                *q++ = st->codecpar->color_space;
++                *q++ = vfr_flags;
+             }
+             break;
+         case AVMEDIA_TYPE_DATA:
+-- 
+2.53.0
+

--- a/ffmpeg-plugin/9.0/0002-Add-GBR-format-detection-to-JPEG-XS-parser.patch
+++ b/ffmpeg-plugin/9.0/0002-Add-GBR-format-detection-to-JPEG-XS-parser.patch
@@ -1,0 +1,148 @@
+From a0518227f4ccdc004f7cd332cf00dd1101b38fbf Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Thu, 2 Apr 2026 11:03:44 +0200
+Subject: [PATCH 2/3] Update jpegxs_parse_frame with GBR formats
+
+Signed-off-by: Grzegorz Rys <grzegorz.rys@intel.com>
+---
+ libavcodec/jpegxs_parser.c | 102 +++++++++++++++++++++++++++++++-------------
+ 1 file changed, 60 insertions(+), 42 deletions(-)
+
+--- a/libavcodec/jpegxs_parser.c
++++ b/libavcodec/jpegxs_parser.c
+@@ -106,6 +106,7 @@
+     GetBitContext gb;
+     int8_t bpc[3], log2_chroma_w[3], log2_chroma_h[3];
+     int size, marker, components;
++    int has_cdt = 0, has_cts = 0, is_rgb = 0;
+ 
+     s->key_frame = 1;
+     s->pict_type = AV_PICTURE_TYPE_I;
+@@ -170,42 +171,101 @@
+                                log2_chroma_w[2] != log2_chroma_w[1]))
+                     return 0;
+             }
++            has_cdt = 1;
++            bytestream2_skip(&gbc, FFMAX(size - 2, 0));
++            break;
++        case JPEGXS_MARKER_CTS:
++            size = bytestream2_get_be16(&gbc);
++            if (size >= 3) {
++                int colour_spec = bytestream2_get_byte(&gbc);
++
++                has_cts = 1;
++                is_rgb = colour_spec == 1;
++            }
++            bytestream2_skip(&gbc, FFMAX(size - 3, 0));
++            break;
++        default:
++            size = bytestream2_get_be16(&gbc);
++            bytestream2_skip(&gbc, FFMAX(size - 2, 0));
++            break;
++        }
++
++        if (!has_cdt)
++            continue;
+ 
+-            switch (bpc[0]) {
+-            case 8:
+-                if (components == 1)                                     s->format = AV_PIX_FMT_GRAY8;
+-                else if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P;
++        if (components == 3 &&
++            log2_chroma_w[1] == 1 &&
++            log2_chroma_h[1] == 1 &&
++            !has_cts)
++            continue;
++
++        switch (bpc[0]) {
++        case 8:
++            if (components == 1) {
++                s->format = AV_PIX_FMT_GRAY8;
++            } else if (is_rgb) {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) {
++                    s->format = AV_PIX_FMT_GBRP;
++                } else {
++                    s->format = AV_PIX_FMT_NONE;
++                }
++            } else {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P;
+                 else if (log2_chroma_w[1] == 2 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV422P;
+                 else                                                     s->format = AV_PIX_FMT_YUV420P;
+-                break;
+-            case 10:
+-                if (components == 1)                                     s->format = AV_PIX_FMT_GRAY10;
+-                else if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P10;
++            }
++            break;
++        case 10:
++            if (components == 1) {
++                s->format = AV_PIX_FMT_GRAY10;
++            } else if (is_rgb) {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) {
++                    s->format = AV_PIX_FMT_GBRP10LE;
++                } else {
++                    s->format = AV_PIX_FMT_NONE;
++                }
++            } else {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P10;
+                 else if (log2_chroma_w[1] == 2 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV422P10;
+                 else                                                     s->format = AV_PIX_FMT_YUV420P10;
+-                break;
+-            case 12:
+-                if (components == 1)                                     s->format = AV_PIX_FMT_GRAY12;
+-                else if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P12;
++            }
++            break;
++        case 12:
++            if (components == 1) {
++                s->format = AV_PIX_FMT_GRAY12;
++            } else if (is_rgb) {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) {
++                    s->format = AV_PIX_FMT_GBRP12LE;
++                } else {
++                    s->format = AV_PIX_FMT_NONE;
++                }
++            } else {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P12;
+                 else if (log2_chroma_w[1] == 2 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV422P12;
+                 else                                                     s->format = AV_PIX_FMT_YUV420P12;
+-                break;
+-            case 14:
+-                if (components == 1)                                     s->format = AV_PIX_FMT_GRAY14;
+-                else if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P14;
++            }
++            break;
++        case 14:
++            if (components == 1) {
++                s->format = AV_PIX_FMT_GRAY14;
++            } else if (is_rgb) {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) {
++                    s->format = AV_PIX_FMT_GBRP14LE;
++                } else {
++                    s->format = AV_PIX_FMT_NONE;
++                }
++            } else {
++                if (log2_chroma_w[1] == 1 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV444P14;
+                 else if (log2_chroma_w[1] == 2 && log2_chroma_h[1] == 1) s->format = AV_PIX_FMT_YUV422P14;
+                 else                                                     s->format = AV_PIX_FMT_YUV420P14;
+-                break;
+-            default:
+-                s->format = AV_PIX_FMT_NONE;
+-                break;
+             }
+-            return 0;
++            break;
+         default:
+-            size = bytestream2_get_be16(&gbc);
+-            bytestream2_skip(&gbc, FFMAX(size - 2, 0));
++            s->format = AV_PIX_FMT_NONE;
+             break;
+         }
++
++        return 0;
+     }
+ 
+     return 0;
+
+-- 
+2.51.0

--- a/ffmpeg-plugin/9.0/0003-Add-GBR-formats-and-chunk-decoding-to-SVT-JPEG-XS-codec.patch
+++ b/ffmpeg-plugin/9.0/0003-Add-GBR-formats-and-chunk-decoding-to-SVT-JPEG-XS-codec.patch
@@ -1,0 +1,796 @@
+From 52be2097ea204782ad08146c26f63c9497ce6e1e Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Thu, 2 Apr 2026 11:05:22 +0200
+Subject: [PATCH 3/3] Update JPEGXS decoder and ecoder with GBR formats
+
+Signed-off-by: Grzegorz Rys <grzegorz.rys@intel.com>
+---
+ libavcodec/libsvtjpegxsdec.c | 301 ++++++++++++++++++++++-------------
+ libavcodec/libsvtjpegxsenc.c | 240 ++++++++++++++++------------
+ 2 files changed, 328 insertions(+), 213 deletions(-)
+
+diff --git a/libavcodec/libsvtjpegxsdec.c b/libavcodec/libsvtjpegxsdec.c
+index 7a325c4446..325bef76f0 100644
+--- a/libavcodec/libsvtjpegxsdec.c
++++ b/libavcodec/libsvtjpegxsdec.c
+@@ -37,179 +37,261 @@
+ #include "profiles.h"
+ 
+ typedef struct SvtJpegXsDecodeContext {
++    AVClass* class;
+     svt_jpeg_xs_image_config_t config;
+     svt_jpeg_xs_decoder_api_t decoder;
+-    svt_jpeg_xs_frame_t input;
+-    svt_jpeg_xs_frame_t output;
+     uint32_t decoder_initialized;
+ 
++    /*0- AVPacket* avpkt have full frame*/
++    /*1- AVPacket* avpkt have chunk of frame, need another buffer to merge packets*/
++    uint32_t chunk_decoding;
++    uint32_t frame_size;
++    uint32_t buffer_filled_len;
++    uint8_t* bitstream_buffer;
+     int proxy_mode;
+ } SvtJpegXsDecodeContext;
+ 
+-static int set_pix_fmt(void *logctx, const svt_jpeg_xs_image_config_t *config)
+-{
+-    int ret = AVERROR_BUG;
+-
+-    switch (config->format) {
+-    case COLOUR_FORMAT_PLANAR_YUV420:
+-        if (config->bit_depth == 8)
+-            return AV_PIX_FMT_YUV420P;
+-        else if (config->bit_depth == 10)
+-            return AV_PIX_FMT_YUV420P10LE;
+-        else if (config->bit_depth == 12)
+-            return AV_PIX_FMT_YUV420P12LE;
+-        else
+-            return AV_PIX_FMT_YUV420P14LE;
+-        break;
+-    case COLOUR_FORMAT_PLANAR_YUV422:
+-        if (config->bit_depth == 8)
+-            return AV_PIX_FMT_YUV422P;
+-        else if (config->bit_depth == 10)
+-            return AV_PIX_FMT_YUV422P10LE;
+-        else if (config->bit_depth == 12)
+-            return AV_PIX_FMT_YUV422P12LE;
+-        else
+-            return AV_PIX_FMT_YUV422P14LE;
+-        break;
+-    case COLOUR_FORMAT_PLANAR_YUV444_OR_RGB:
+-        if (config->bit_depth == 8)
+-            return AV_PIX_FMT_YUV444P;
+-        else if (config->bit_depth == 10)
+-            return AV_PIX_FMT_YUV444P10LE;
+-        else if (config->bit_depth == 12)
+-            return AV_PIX_FMT_YUV444P12LE;
+-        else
+-            return AV_PIX_FMT_YUV444P14LE;
+-        break;
+-    default:
+-        av_log(logctx, AV_LOG_ERROR, "Unsupported pixel format.\n");
+-        ret = AVERROR_INVALIDDATA;
+-        break;
+-    }
+-
+-    return ret;
++
++static int set_pix_fmt(AVCodecContext* avctx, svt_jpeg_xs_image_config_t config) {
++    if (config.format == COLOUR_FORMAT_PLANAR_YUV420) {
++        if (config.bit_depth == 8) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV420P;
++        }
++        else if (config.bit_depth == 10) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV420P10LE;
++        }
++        else if (config.bit_depth == 12) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV420P12LE;
++        }
++        else {
++            avctx->pix_fmt = AV_PIX_FMT_YUV420P14LE;
++        }
++    }
++    else if (config.format == COLOUR_FORMAT_PLANAR_YUV422) {
++        if (config.bit_depth == 8) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV422P;
++        }
++        else if (config.bit_depth == 10) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
++        }
++        else if (config.bit_depth == 12) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV422P12LE;
++        }
++        else {
++            avctx->pix_fmt = AV_PIX_FMT_YUV422P14LE;
++        }
++    }
++    else if (config.format == COLOUR_FORMAT_PLANAR_YUV444_OR_RGB) {
++        if (config.bit_depth == 8) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV444P;
++        }
++        else if (config.bit_depth == 10) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV444P10LE;
++        }
++        else if (config.bit_depth == 12) {
++            avctx->pix_fmt = AV_PIX_FMT_YUV444P12LE;
++        }
++        else {
++            avctx->pix_fmt = AV_PIX_FMT_YUV444P14LE;
++        }
++    }
++    else {
++        av_log(avctx, AV_LOG_ERROR, "Unsupported pixel format.\n");
++        return AVERROR_INVALIDDATA;
++    }
++    return 0;
+ }
+ 
+-static int svt_jpegxs_dec_decode(AVCodecContext* avctx, AVFrame* picture, int* got_frame, AVPacket* avpkt)
+-{
++static int svt_jpegxs_dec_decode(AVCodecContext* avctx, AVFrame* picture, int* got_frame, AVPacket* avpkt) {
+     SvtJpegXsDecodeContext* svt_dec = avctx->priv_data;
++
+     SvtJxsErrorType_t err = SvtJxsErrorNone;
+-    uint32_t frame_size;
+     int ret;
++    svt_jpeg_xs_frame_t dec_input;
++    svt_jpeg_xs_frame_t dec_output;
++    uint32_t pixel_size;
+ 
+-    err = svt_jpeg_xs_decoder_get_single_frame_size_with_proxy(
+-        avpkt->data, avpkt->size, &svt_dec->config, &frame_size, 1 /*quick search*/, svt_dec->decoder.proxy_mode);
+-    if (err) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_decoder_get_single_frame_size_with_proxy failed, err=%d\n", err);
+-        return AVERROR_EXTERNAL;
+-    }
+-    if (avpkt->size < frame_size) {
+-        av_log(avctx, AV_LOG_ERROR, "Not enough data in a packet.\n");
+-        return AVERROR(EINVAL);
+-    }
+-    if (avpkt->size > frame_size) {
+-        av_log(avctx, AV_LOG_ERROR, "Single packet have data for more than one frame.\n");
+-        return AVERROR(EINVAL);
+-    }
+-
+-    ret = set_pix_fmt(avctx, &svt_dec->config);
+-    if (ret < 0)
+-        return ret;
++    if (!svt_dec->decoder_initialized) {
++        err = svt_jpeg_xs_decoder_get_single_frame_size_with_proxy(
++            avpkt->data, avpkt->size, NULL, &svt_dec->frame_size, 1 /*quick search*/, svt_dec->decoder.proxy_mode);
++        if (err) {
++            av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_decoder_get_single_frame_size_with_proxy failed, err=%d\n", err);
++            return err;
++        }
++        if (avpkt->size < svt_dec->frame_size) {
++            svt_dec->chunk_decoding = 1;
++            svt_dec->bitstream_buffer = av_malloc(svt_dec->frame_size);
++            if (!svt_dec->bitstream_buffer) {
++                av_log(avctx, AV_LOG_ERROR, "Failed to allocate svt_dec->bitstream_buffer.\n");
++                return AVERROR(ENOMEM);
++            }
++            av_log(NULL, AV_LOG_DEBUG, "svt_jpegxs_dec_decode, bitstream_size=%d, chunk = %d\n", svt_dec->frame_size, avpkt->size);
++        }
++        if (avpkt->size > svt_dec->frame_size) {
++            av_log(avctx, AV_LOG_ERROR, "Single packet have data for more than one frame.\n");
++            return AVERROR_UNKNOWN;
++        }
+ 
+-    if (!svt_dec->decoder_initialized || ret != avctx->pix_fmt ||
+-        avctx->width != svt_dec->config.width || avctx->height != svt_dec->config.height) {
+-        if (svt_dec->decoder_initialized)
+-            svt_jpeg_xs_decoder_close(&svt_dec->decoder);
+-        err = svt_jpeg_xs_decoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR,
+-                                       &svt_dec->decoder, avpkt->data, avpkt->size, &svt_dec->config);
++        err = svt_jpeg_xs_decoder_init(
++            SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_dec->decoder), avpkt->data, avpkt->size, &(svt_dec->config));
+         if (err) {
+-            av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_decoder_init failed, err=%d\n", err);
+-            return AVERROR_EXTERNAL;
++            av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_decoder_init failed, err=%d\n", err);
++            return err;
+         }
+ 
+-        avctx->pix_fmt = ret;
++        ret = set_pix_fmt(avctx, svt_dec->config);
++        if (ret < 0) {
++            av_log(NULL, AV_LOG_ERROR, "set_pix_fmt failed, err=%d\n", ret);
++            return ret;
++        }
+ 
+         ret = ff_set_dimensions(avctx, svt_dec->config.width, svt_dec->config.height);
+         if (ret < 0) {
+-            av_log(avctx, AV_LOG_ERROR, "ff_set_dimensions failed, err=%d\n", ret);
++            av_log(NULL, AV_LOG_ERROR, "ff_set_dimensions failed, err=%d\n", ret);
+             return ret;
+         }
+ 
+         svt_dec->decoder_initialized = 1;
+     }
+ 
+-    if (avctx->skip_frame == AVDISCARD_ALL)
+-        return 0;
++    if (svt_dec->chunk_decoding) {
++        uint8_t* bitstrream_addr = svt_dec->bitstream_buffer + svt_dec->buffer_filled_len;
++        int bytes_to_copy = avpkt->size;
++        //Do not copy more data than allocation
++        if ((bytes_to_copy + svt_dec->buffer_filled_len) > svt_dec->frame_size) {
++            bytes_to_copy = svt_dec->frame_size - svt_dec->buffer_filled_len;
++        }
+ 
+-    svt_dec->input.bitstream.buffer = avpkt->data;
+-    svt_dec->input.bitstream.allocation_size = avpkt->size;
+-    svt_dec->input.bitstream.used_size = avpkt->size;
+-    svt_dec->input.user_prv_ctx_ptr = avpkt;
++        memcpy(bitstrream_addr, avpkt->data, bytes_to_copy);
++        svt_dec->buffer_filled_len += avpkt->size;
++        if (svt_dec->buffer_filled_len >= svt_dec->frame_size) {
++            dec_input.bitstream.buffer = svt_dec->bitstream_buffer;
++            dec_input.bitstream.allocation_size = svt_dec->frame_size;
++            dec_input.bitstream.used_size = svt_dec->frame_size;
++        }
++        else {
++            *got_frame = 0;
++            return avpkt->size;
++        }
++    }
++    else {// svt_dec->chunk_decoding == 0
++        dec_input.bitstream.buffer = avpkt->data;
++        dec_input.bitstream.allocation_size = avpkt->size;
++        dec_input.bitstream.used_size = avpkt->size;
++    }
++    dec_input.user_prv_ctx_ptr = avpkt;
+ 
+     ret = ff_get_buffer(avctx, picture, 0);
+-    if (ret < 0)
++    if (ret < 0) {
++        av_log(NULL, AV_LOG_ERROR, "ff_get_buffer failed, err=%d\n", ret);
+         return ret;
++    }
+ 
+-    unsigned pixel_shift = svt_dec->config.bit_depth <= 8 ? 0 : 1;
++    pixel_size = svt_dec->config.bit_depth <= 8 ? 1 : 2;
+     for (int comp = 0; comp < svt_dec->config.components_num; comp++) {
+-        svt_dec->input.image.data_yuv[comp] = picture->data[comp];
+-        svt_dec->input.image.stride[comp] = picture->linesize[comp] >> pixel_shift;
+-        svt_dec->input.image.alloc_size[comp] = picture->linesize[comp] * svt_dec->config.components[comp].height;
++        dec_input.image.data_yuv[comp] = picture->data[comp];
++        dec_input.image.stride[comp] = picture->linesize[comp]/pixel_size;
++        dec_input.image.alloc_size[comp] = picture->linesize[comp] * svt_dec->config.components[comp].height;
+     }
+ 
+-    err = svt_jpeg_xs_decoder_send_frame(&svt_dec->decoder, &svt_dec->input, 1 /*blocking*/);
++    err = svt_jpeg_xs_decoder_send_frame(&(svt_dec->decoder), &dec_input, 1 /*blocking*/);
+     if (err) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_decoder_send_frame failed, err=%d\n", err);
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_decoder_send_frame failed, err=%d\n", err);
++        return err;
+     }
+ 
+-    err = svt_jpeg_xs_decoder_get_frame(&svt_dec->decoder, &svt_dec->output, 1 /*blocking*/);
++    err = svt_jpeg_xs_decoder_get_frame(&(svt_dec->decoder), &dec_output, 1 /*blocking*/);
++    if (err == SvtJxsErrorDecoderConfigChange) {
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_decoder_get_frame return SvtJxsErrorDecoderConfigChange\n");
++        return AVERROR_INPUT_CHANGED;
++    }
+     if (err) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_decoder_get_frame failed, err=%d\n", err);
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_decoder_get_frame failed, err=%d\n", err);
++        return err;
+     }
+ 
+-    if (svt_dec->output.user_prv_ctx_ptr != avpkt) {
+-        av_log(avctx, AV_LOG_ERROR, "Returned different user_prv_ctx_ptr than expected\n");
+-        return AVERROR_EXTERNAL;
++    if (dec_output.user_prv_ctx_ptr != avpkt) {
++        av_log(NULL, AV_LOG_ERROR, "Returned different user_prv_ctx_ptr than expected\n");
++        return AVERROR_UNKNOWN;
+     }
+ 
+     *got_frame = 1;
+ 
++    //Copy leftover from AVPacket if it contain data from two frames
++    if (svt_dec->chunk_decoding) {
++        int bytes_to_copy = svt_dec->buffer_filled_len % svt_dec->frame_size;
++        int packet_offset = avpkt->size - bytes_to_copy;
++        uint8_t* packet_addr = avpkt->data + packet_offset;
++        memcpy(svt_dec->bitstream_buffer, packet_addr, bytes_to_copy);
++        svt_dec->buffer_filled_len = bytes_to_copy;
++    }
++
+     return avpkt->size;
+ }
+ 
+-static av_cold int svt_jpegxs_dec_free(AVCodecContext* avctx)
+-{
++static av_cold int svt_jpegxs_dec_free(AVCodecContext* avctx) {
+     SvtJpegXsDecodeContext* svt_dec = avctx->priv_data;
++    svt_jpeg_xs_decoder_close(&(svt_dec->decoder));
++    av_log(NULL, AV_LOG_DEBUG, "svt_jpeg_xs_decoder_close called\n");
+ 
+-    svt_jpeg_xs_decoder_close(&svt_dec->decoder);
++    if (svt_dec->chunk_decoding) {
++        av_free(svt_dec->bitstream_buffer);
++    }
+ 
+     return 0;
+ }
+ 
+-static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx)
+-{
++static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
+     SvtJpegXsDecodeContext* svt_dec = avctx->priv_data;
+ 
+-    int log_level = av_log_get_level();
+-    svt_dec->decoder.verbose = log_level < AV_LOG_DEBUG ? VERBOSE_ERRORS :
+-                                  log_level == AV_LOG_DEBUG ? VERBOSE_SYSTEM_INFO : VERBOSE_WARNINGS;
++    svt_dec->decoder_initialized = 0;
++    svt_dec->chunk_decoding = 0;
++    svt_dec->buffer_filled_len = 0;
++    svt_dec->bitstream_buffer = NULL;
+ 
+-    if (avctx->lowres == 1)
++    if (av_log_get_level() < AV_LOG_DEBUG) {
++        svt_dec->decoder.verbose = VERBOSE_ERRORS;
++    }
++    else if (av_log_get_level() == AV_LOG_DEBUG) {
++        svt_dec->decoder.verbose = VERBOSE_SYSTEM_INFO;
++    }
++    else {
++        svt_dec->decoder.verbose = VERBOSE_WARNINGS;
++    }
++
++    if (svt_dec->proxy_mode == 1) {
+         svt_dec->decoder.proxy_mode = proxy_mode_half;
+-    else if (avctx->lowres == 2)
++    }
++    else if (svt_dec->proxy_mode == 2) {
+         svt_dec->decoder.proxy_mode = proxy_mode_quarter;
+-    else
++    }
++    else {
+         svt_dec->decoder.proxy_mode = proxy_mode_full;
++    }
+ 
+-    int thread_count = avctx->thread_count ? avctx->thread_count : av_cpu_count();
+-    svt_dec->decoder.threads_num = FFMIN(thread_count, 64);
++    svt_dec->decoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+     svt_dec->decoder.use_cpu_flags = CPU_FLAGS_ALL;
++    svt_dec->decoder.packetization_mode = 0;
++
++    av_log(NULL, AV_LOG_DEBUG, "svt_jpegxs_dec_init called\n");
+ 
+     return 0;
+ }
+ 
++#define OFFSET(x) offsetof(SvtJpegXsDecodeContext, x)
++#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
++static const AVOption svtjpegxs_dec_options[] = {
++    {"proxy-mode", "Resolution scaling mode: 0-full, 1-half, 2-quarter", OFFSET(proxy_mode), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 2, VE},
++    {NULL},
++};
++
++static const AVClass svtjpegxs_dec_class = {
++    .class_name = "libsvtjpegxsdec",
++    .item_name = av_default_item_name,
++    .option = svtjpegxs_dec_options,
++    .version = LIBAVUTIL_VERSION_INT,
++};
++
+ const FFCodec ff_libsvtjpegxs_decoder = {
+     .p.name         = "libsvtjpegxs",
+     CODEC_LONG_NAME("SVT JPEG XS(Scalable Video Technology for JPEG XS) decoder"),
+@@ -221,8 +303,7 @@ const FFCodec ff_libsvtjpegxs_decoder = {
+     FF_CODEC_DECODE_CB(svt_jpegxs_dec_decode),
+     .p.capabilities = AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_DR1,
+     .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE |
+-                      FF_CODEC_CAP_SKIP_FRAME_FILL_PARAM |
+                       FF_CODEC_CAP_AUTO_THREADS,
+-    .p.max_lowres   = 2,
+     .p.wrapper_name = "libsvtjpegxs",
++    .p.priv_class = &svtjpegxs_dec_class,
+ };
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index d8dbc93075..cddc09a90b 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -25,11 +25,9 @@
+ 
+ #include <SvtJpegxsEnc.h>
+ 
+-#include "libavutil/avassert.h"
+ #include "libavutil/common.h"
+ #include "libavutil/cpu.h"
+ #include "libavutil/imgutils.h"
+-#include "libavutil/rational.h"
+ 
+ #include "avcodec.h"
+ #include "codec_internal.h"
+@@ -39,6 +37,9 @@
+ typedef struct SvtJpegXsEncodeContext {
+     AVClass* class;
+ 
++    char *bpp_str;
++
++    int slice_height;
+     int decomp_v;
+     int decomp_h;
+     int quant;
+@@ -50,216 +51,232 @@ typedef struct SvtJpegXsEncodeContext {
+     int bitstream_frame_size;
+ } SvtJpegXsEncodeContext;
+ 
+-static int svt_jpegxs_enc_encode(AVCodecContext* avctx, AVPacket* pkt,
+-                                 const AVFrame* frame, int* got_packet)
+-{
++static int svt_jpegxs_enc_encode(AVCodecContext* avctx, AVPacket* pkt, const AVFrame* frame, int* got_packet) {
+     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
+ 
++    svt_jpeg_xs_bitstream_buffer_t out_buf;
++    svt_jpeg_xs_image_buffer_t in_buf;
+     svt_jpeg_xs_frame_t enc_input;
+-    svt_jpeg_xs_bitstream_buffer_t *const out_buf = &enc_input.bitstream;
+-    svt_jpeg_xs_image_buffer_t *const in_buf = &enc_input.image;
+     svt_jpeg_xs_frame_t enc_output;
+ 
+     SvtJxsErrorType_t err = SvtJxsErrorNone;
++    uint32_t pixel_size = svt_enc->encoder.input_bit_depth <= 8 ? 1 : 2;
+ 
+-    int ret = ff_get_encode_buffer(avctx, pkt, svt_enc->bitstream_frame_size, 0);
+-    if (ret < 0)
++    int ret = ff_alloc_packet(avctx, pkt, svt_enc->bitstream_frame_size);
++    if (ret < 0) {
+         return ret;
++    }
+ 
+-    out_buf->buffer = pkt->data;// output bitstream ptr
+-    out_buf->allocation_size = pkt->size;// output bitstream size
+-    out_buf->used_size = 0;
++    out_buf.buffer = pkt->data;// output bitstream ptr
++    out_buf.allocation_size = pkt->size;// output bitstream size
++    out_buf.used_size = 0;
+ 
+-    unsigned pixel_shift = svt_enc->encoder.input_bit_depth <= 8 ? 0 : 1;
+     for (int comp = 0; comp < 3; comp++) {
+         // svt-jpegxs require stride in pixel's not in bytes, this means that for 10 bit-depth, stride is half the linesize
+-        in_buf->stride[comp]     = frame->linesize[comp] >> pixel_shift;
+-        in_buf->data_yuv[comp]   = frame->data[comp];
+-        in_buf->alloc_size[comp] = frame->linesize[comp] * svt_enc->encoder.source_height;
++        in_buf.stride[comp] = frame->linesize[comp]/ pixel_size;
++        in_buf.data_yuv[comp] = frame->data[comp];
++        in_buf.alloc_size[comp] = in_buf.stride[comp] * svt_enc->encoder.source_height * pixel_size;
+     }
+ 
++    enc_input.bitstream = out_buf;
++    enc_input.image = in_buf;
+     enc_input.user_prv_ctx_ptr = pkt;
+ 
+-    err = svt_jpeg_xs_encoder_send_picture(&svt_enc->encoder, &enc_input, 1 /*blocking*/);
++    err = svt_jpeg_xs_encoder_send_picture(&(svt_enc->encoder), &enc_input, 1 /*blocking*/);
+     if (err != SvtJxsErrorNone) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_encoder_send_picture failed\n");
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_encoder_send_picture failed\n");
++        return AVERROR_UNKNOWN;
+     }
+ 
+-    err = svt_jpeg_xs_encoder_get_packet(&svt_enc->encoder, &enc_output, 1 /*blocking*/);
++    err = svt_jpeg_xs_encoder_get_packet(&(svt_enc->encoder), &enc_output, 1 /*blocking*/);
+     if (err != SvtJxsErrorNone) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_encoder_get_packet failed\n");
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_encoder_get_packet failed\n");
++        return AVERROR_UNKNOWN;
+     }
+ 
+     if (enc_output.user_prv_ctx_ptr != pkt) {
+-        av_log(avctx, AV_LOG_ERROR, "Returned different user_prv_ctx_ptr than expected\n");
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "Returned different user_prv_ctx_ptr than expected\n");
++        return AVERROR_UNKNOWN;
+     }
+ 
+     pkt->size = enc_output.bitstream.used_size;
+ 
+     *got_packet = 1;
+-
+     return 0;
+ }
+ 
+ static av_cold int svt_jpegxs_enc_free(AVCodecContext* avctx) {
+     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
+-
+-    svt_jpeg_xs_encoder_close(&svt_enc->encoder);
++    svt_jpeg_xs_encoder_close(&(svt_enc->encoder));
++    av_log(NULL, AV_LOG_DEBUG, "svt_jpeg_xs_encoder_close called\n");
+ 
+     return 0;
+ }
+ 
+-static void set_pix_fmt(AVCodecContext *avctx, svt_jpeg_xs_encoder_api_t *encoder)
++static int set_pix_fmt(AVCodecContext* avctx, svt_jpeg_xs_encoder_api_t *encoder)
+ {
+     switch (avctx->pix_fmt) {
+     case AV_PIX_FMT_YUV420P:
+         encoder->input_bit_depth = 8;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV422P:
+         encoder->input_bit_depth = 8;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV422;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV444P:
++    case AV_PIX_FMT_GBRP:
+         encoder->input_bit_depth = 8;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV444_OR_RGB;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV420P10LE:
+         encoder->input_bit_depth = 10;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV422P10LE:
+         encoder->input_bit_depth = 10;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV422;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV444P10LE:
++    case AV_PIX_FMT_GBRP10LE:
+         encoder->input_bit_depth = 10;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV444_OR_RGB;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV420P12LE:
+         encoder->input_bit_depth = 12;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV422P12LE:
+         encoder->input_bit_depth = 12;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV422;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV444P12LE:
++    case AV_PIX_FMT_GBRP12LE:
+         encoder->input_bit_depth = 12;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV444_OR_RGB;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV420P14LE:
+         encoder->input_bit_depth = 14;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV422P14LE:
+         encoder->input_bit_depth = 14;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV422;
+-        return;
++        return 0;
+     case AV_PIX_FMT_YUV444P14LE:
++    case AV_PIX_FMT_GBRP14LE:
+         encoder->input_bit_depth = 14;
+         encoder->colour_format = COLOUR_FORMAT_PLANAR_YUV444_OR_RGB;
+-        return;
++        return 0;
++    case AV_PIX_FMT_RGB24:
++    case AV_PIX_FMT_BGR24:
++        encoder->input_bit_depth = 8;
++        encoder->colour_format = COLOUR_FORMAT_PACKED_YUV444_OR_RGB;
++        return 0;
+     default:
+-        av_unreachable("Already checked via CODEC_PIXFMTS_ARRAY");
+         break;
+     }
++    av_log(avctx, AV_LOG_ERROR, "Unsupported pixel format.\n");
++    return AVERROR_INVALIDDATA;
++}
++
++static void set_bpp(const char* value, svt_jpeg_xs_encoder_api_t* encoder) {
++    char* end;
++    encoder->bpp_numerator = strtoul(value, &end, 0);
++    encoder->bpp_denominator = 1;
++    if (*end != '\0') {
++        while (*value) {
++            if (*value == '.' || *value == ',') {
++                value++;
++                break;
++            }
++            value++;
++        }
++        if (*value) {
++            uint32_t fraction = strtoul(value, &end, 0);
++            uint32_t chars = (uint32_t)(end - value);
++            for (uint32_t i = 0; i < chars; ++i) {
++                encoder->bpp_denominator *= 10;
++            }
++            encoder->bpp_numerator = encoder->bpp_numerator * encoder->bpp_denominator + fraction;
++        }
++    }
+ }
+ 
+ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
+-    AVRational bpp;
+-    SvtJxsErrorType_t err;
++    SvtJxsErrorType_t err = svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
+ 
+-    err = svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
+     if (err != SvtJxsErrorNone) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_encoder_load_default_parameters failed\n");
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_encoder_load_default_parameters failed\n");
++        return AVERROR_UNKNOWN;
+     }
++    av_log(NULL, AV_LOG_DEBUG, "svt_jpeg_xs_encoder_load_default_parameters ok\n");
+ 
+     svt_enc->encoder.source_width = avctx->width;
+     svt_enc->encoder.source_height = avctx->height;
+ 
+-    set_pix_fmt(avctx, &svt_enc->encoder);
++    set_pix_fmt(avctx, &(svt_enc->encoder));
+ 
+-    int thread_count = avctx->thread_count ? avctx->thread_count : av_cpu_count();
+-    svt_enc->encoder.threads_num = FFMIN(thread_count, 64);
++    svt_enc->encoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+ 
+-    int log_level = av_log_get_level();
+-    svt_enc->encoder.verbose = log_level < AV_LOG_DEBUG ? VERBOSE_ERRORS :
+-                                  log_level == AV_LOG_DEBUG ? VERBOSE_SYSTEM_INFO : VERBOSE_WARNINGS;
+-
+-    if (avctx->framerate.num <= 0 || avctx->framerate.den <= 0) {
+-        av_log(avctx, AV_LOG_ERROR, "framerate must be set\n");
+-        return AVERROR(EINVAL);
++    if (av_log_get_level() < AV_LOG_DEBUG) {
++        svt_enc->encoder.verbose = VERBOSE_ERRORS;
++    }
++    else if (av_log_get_level() == AV_LOG_DEBUG) {
++        svt_enc->encoder.verbose = VERBOSE_SYSTEM_INFO;
++    }
++    else {
++        svt_enc->encoder.verbose = VERBOSE_WARNINGS;
+     }
+-    if (avctx->bit_rate == 0) {
+-        const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(avctx->pix_fmt);
+-        // default to a 1.5 compression ratio
+-        avctx->bit_rate = (int64_t)avctx->width * avctx->height *
+-                          (av_get_bits_per_pixel(desc) * 2 / 3) * av_q2d(avctx->framerate);
+-        av_log(avctx, AV_LOG_WARNING, "No bitrate set, defaulting to %"PRId64"\n", avctx->bit_rate);
++
++    if (!svt_enc->bpp_str) {
++        //TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
++        av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
++        return AVERROR_OPTION_NOT_FOUND;
+     }
+ 
+-    av_reduce(&bpp.num, &bpp.den, avctx->bit_rate, (int64_t)avctx->width * avctx->height, INT_MAX);
+-    bpp = av_div_q(bpp, avctx->framerate);
+-    svt_enc->encoder.bpp_numerator   = bpp.num;
+-    svt_enc->encoder.bpp_denominator = bpp.den;
++    set_bpp(svt_enc->bpp_str ,&(svt_enc->encoder));
+ 
+-    if (svt_enc->decomp_v >= 0)
++    if (svt_enc->decomp_v != -1) {
+         svt_enc->encoder.ndecomp_v = svt_enc->decomp_v;
+-    if (svt_enc->decomp_h >= 0)
++    }
++    if (svt_enc->decomp_h != -1) {
+         svt_enc->encoder.ndecomp_h = svt_enc->decomp_h;
+-    if (svt_enc->quant >= 0)
++    }
++    if (svt_enc->quant != -1) {
+         svt_enc->encoder.quantization = svt_enc->quant;
+-    if (svt_enc->coding_signs_handling >= 0)
++    }
++    if (svt_enc->coding_signs_handling != -1) {
+         svt_enc->encoder.coding_signs_handling = svt_enc->coding_signs_handling;
+-    if (svt_enc->coding_significance >= 0)
++    }
++    if (svt_enc->coding_significance != -1) {
+         svt_enc->encoder.coding_significance = svt_enc->coding_significance;
+-    if (svt_enc->coding_vpred >= 0)
++    }
++    if (svt_enc->coding_vpred != -1) {
+         svt_enc->encoder.coding_vertical_prediction_mode = svt_enc->coding_vpred;
+-    if (avctx->slices > 0)
+-        svt_enc->encoder.slice_height = avctx->height / avctx->slices;
++    }
++    if (svt_enc->slice_height > 0) {
++        svt_enc->encoder.slice_height = svt_enc->slice_height;
++    }
+ 
+-    err = svt_jpeg_xs_encoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &svt_enc->encoder);
++    err = svt_jpeg_xs_encoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
+     if (err != SvtJxsErrorNone) {
+-        av_log(avctx, AV_LOG_ERROR, "svt_jpeg_xs_encoder_init failed\n");
+-        return AVERROR_EXTERNAL;
++        av_log(NULL, AV_LOG_ERROR, "svt_jpeg_xs_encoder_init failed\n");
++        return AVERROR_UNKNOWN;
+     }
++    av_log(NULL, AV_LOG_DEBUG, "svt_jpeg_xs_encoder_init ok\n");
+ 
+-    svt_enc->bitstream_frame_size = (((int64_t)avctx->width * avctx->height *
+-                                      svt_enc->encoder.bpp_numerator / svt_enc->encoder.bpp_denominator + 7) / 8);
++    svt_enc->bitstream_frame_size = ((avctx->width * avctx->height * svt_enc->encoder.bpp_numerator / svt_enc->encoder.bpp_denominator + 7) / 8);
+ 
+     return 0;
+ }
+ 
+-static const enum AVPixelFormat pix_fmts[] = {
+-    AV_PIX_FMT_YUV420P,
+-    AV_PIX_FMT_YUV422P,
+-    AV_PIX_FMT_YUV444P,
+-    AV_PIX_FMT_YUV420P10LE,
+-    AV_PIX_FMT_YUV422P10LE,
+-    AV_PIX_FMT_YUV444P10LE,
+-    AV_PIX_FMT_YUV420P12LE,
+-    AV_PIX_FMT_YUV422P12LE,
+-    AV_PIX_FMT_YUV444P12LE,
+-    AV_PIX_FMT_YUV420P14LE,
+-    AV_PIX_FMT_YUV422P14LE,
+-    AV_PIX_FMT_YUV444P14LE,
+-    AV_PIX_FMT_NONE
+-};
+-
+-static const FFCodecDefault svt_jpegxs_defaults[] = {
+-    { "b", "0" },
+-    { NULL },
+-};
+-
+ #define OFFSET(x) offsetof(SvtJpegXsEncodeContext, x)
+ #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
+ static const AVOption svtjpegxs_enc_options[] = {
++    { "bpp",          "Bits per pixel",                                   OFFSET(bpp_str),      AV_OPT_TYPE_STRING,{.str = NULL }, 0, 0, VE },
++    { "slice_height", "Specify number of lines calculated in one thread", OFFSET(slice_height), AV_OPT_TYPE_INT, {.i64 = 0 }, 0, 10000, VE },
+     { "decomp_v",     "vertical decomposition level",                              OFFSET(decomp_v),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 2, VE },
+     { "decomp_h",     "horizontal decomposition level",                            OFFSET(decomp_h),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 5, VE },
+     { "quantization", "Quantization algorithm",                                    OFFSET(quant),                 AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 1, VE, .unit = "quantization" },
+@@ -274,7 +291,7 @@ static const AVOption svtjpegxs_enc_options[] = {
+       { "disable",      NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_residuals", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 1}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_coeffs",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+-    { NULL },
++    {NULL},
+ };
+ 
+ static const AVClass svtjpegxs_enc_class = {
+@@ -292,12 +309,29 @@ const FFCodec ff_libsvtjpegxs_encoder = {
+     .priv_data_size = sizeof(SvtJpegXsEncodeContext),
+     .init           = svt_jpegxs_enc_init,
+     .close          = svt_jpegxs_enc_free,
+-    .defaults       = svt_jpegxs_defaults,
+     FF_CODEC_ENCODE_CB(svt_jpegxs_enc_encode),
+     .p.capabilities = AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_DR1,
+     .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE |
+                       FF_CODEC_CAP_AUTO_THREADS,
+-    CODEC_PIXFMTS_ARRAY(pix_fmts),
++    .p.pix_fmts = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,
++                                                AV_PIX_FMT_YUV422P,
++                                                AV_PIX_FMT_YUV444P,
++                                                AV_PIX_FMT_YUV420P10LE,
++                                                AV_PIX_FMT_YUV422P10LE,
++                                                AV_PIX_FMT_YUV444P10LE,
++                                                AV_PIX_FMT_YUV420P12LE,
++                                                AV_PIX_FMT_YUV422P12LE,
++                                                AV_PIX_FMT_YUV444P12LE,
++                                                AV_PIX_FMT_YUV420P14LE,
++                                                AV_PIX_FMT_YUV422P14LE,
++                                                AV_PIX_FMT_YUV444P14LE,
++                                                AV_PIX_FMT_GBRP,
++                                                AV_PIX_FMT_GBRP10LE,
++                                                AV_PIX_FMT_GBRP12LE,
++                                                AV_PIX_FMT_GBRP14LE,
++                                                AV_PIX_FMT_RGB24,
++                                                AV_PIX_FMT_BGR24,
++                                                AV_PIX_FMT_NONE },
+     .p.wrapper_name = "libsvtjpegxs",
+     .p.priv_class = &svtjpegxs_enc_class,
+ };
+-- 
+2.51.0
+

--- a/ffmpeg-plugin/9.0/0004-Fix-JPEG-XS-schar-descriptor-parsing-in-mpegts-demuxer.patch
+++ b/ffmpeg-plugin/9.0/0004-Fix-JPEG-XS-schar-descriptor-parsing-in-mpegts-demuxer.patch
@@ -1,0 +1,54 @@
+From e61c0f06f03396030bc1cca74b7226a564d1a75f Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Tue, 12 May 2026 10:19:10 +0200
+Subject: [PATCH] avformat/mpegts: fix JPEG XS schar descriptor parsing
+
+Fix JXS_video_descriptor schar field parsing in the MPEG-TS demuxer:
+ - Add 4:2:0 subsampling support (Ssub=2)
+ - Detect GBR/RGB pixel formats from colour_specification bits [11:8]
+ - Add comment clarifying bit depth comes from codestream, not descriptor
+
+The schar field per ISO/IEC 21122-3 encodes colour_specification in
+bits [11:8] (Cs: 0=YCbCr, 1=RGB/GBR) and subsampling in bits [3:0]
+(Ssub: 0=4:2:2, 1=4:4:4, 2=4:2:0). The previous code only handled
+Ssub 0 and 1, and did not check Cs bits for GBR detection.
+---
+ libavformat/mpegts.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/mpegts.c b/libavformat/mpegts.c
+index 4b326d309b..6b94ebd785 100644
+--- a/libavformat/mpegts.c
++++ b/libavformat/mpegts.c
+@@ -1901,11 +1901,25 @@ static int parse_mpeg2_extension_descriptor(AVFormatContext *fc, AVStream *st, i
+                 st->codecpar->framerate.den = framerate_den;
+             }
+ 
++            /* schar bits [11:8] = Cs (colour_specification), bits [3:0] = Ssub (subsampling).
++             * Bit depth is not carried in schar; it comes from the codestream.
++             * Set a reasonable default format per subsampling; the parser will
++             * refine it once the first frame is parsed. */
+             switch (schar & 0xf) {
+-            case 0: st->codecpar->format = AV_PIX_FMT_YUV422P10LE; break;
+-            case 1: st->codecpar->format = AV_PIX_FMT_YUV444P10LE; break;
++            case 0: /* 4:2:2 */
++                st->codecpar->format = AV_PIX_FMT_YUV422P10LE;
++                break;
++            case 1: /* 4:4:4 */
++                if (((schar >> 8) & 0xf) == 1)
++                    st->codecpar->format = AV_PIX_FMT_GBRP10LE;
++                else
++                    st->codecpar->format = AV_PIX_FMT_YUV444P10LE;
++                break;
++            case 2: /* 4:2:0 */
++                st->codecpar->format = AV_PIX_FMT_YUV420P10LE;
++                break;
+             default:
+-                av_log(fc, AV_LOG_WARNING, "Unknown JPEG XS sampling format");
++                av_log(fc, AV_LOG_WARNING, "Unknown JPEG XS sampling format %d\n", schar & 0xf);
+                 break;
+             }
+ 
+-- 
+2.53.0
+

--- a/ffmpeg-plugin/9.0/0005-Add-coding-raw-and-cap-comp.patch
+++ b/ffmpeg-plugin/9.0/0005-Add-coding-raw-and-cap-comp.patch
@@ -1,0 +1,61 @@
+From 0dcc5ecd55427c727e4244c6db5e22eab3b428b2 Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Thu, 9 Jul 2026 12:00:00 +0200
+Subject: [PATCH] avcodec/libsvtjpegxsenc: add coding-raw and cap-compat
+ options
+
+Add two AVOptions mirroring the SVT-JPEG-XS 0.10 encoder API fields
+coding_raw_disable and cap_compat:
+
+ - coding-raw: enable/disable packet-based raw-mode coding. Disabling
+   clears the raw-mode capability bit and never selects raw packet
+   packing, which some strict/legacy decoders require.
+ - cap-compat: emit an empty CAP marker (Lcap=2) when no capability
+   bit is set. Some legacy/strict decoders reject a non-empty CAP
+   marker. When the stream genuinely requires a capability bit (e.g.
+   4:2:0 sub-sampling) a full CAP marker is still written to remain
+   conformant.
+
+Both options default to unset (-1), leaving the library default
+behaviour in place.
+---
+ libavcodec/libsvtjpegxsenc.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index cddc09a90b..2e3123bdac 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -46,6 +46,8 @@ typedef struct SvtJpegXsEncodeContext {
+     int coding_signs_handling;
+     int coding_significance;
+     int coding_vpred;
++    int coding_raw;
++    int cap_compat;
+
+     svt_jpeg_xs_encoder_api_t encoder;
+     int bitstream_frame_size;
+@@ -256,6 +258,12 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     if (svt_enc->coding_vpred != -1) {
+         svt_enc->encoder.coding_vertical_prediction_mode = svt_enc->coding_vpred;
+     }
++    if (svt_enc->coding_raw != -1) {
++        svt_enc->encoder.coding_raw_disable = svt_enc->coding_raw ? 0 : 1;
++    }
++    if (svt_enc->cap_compat != -1) {
++        svt_enc->encoder.cap_compat = svt_enc->cap_compat ? 1 : 0;
++    }
+     if (svt_enc->slice_height > 0) {
+         svt_enc->encoder.slice_height = svt_enc->slice_height;
+     }
+@@ -291,6 +299,8 @@ static const AVOption svtjpegxs_enc_options[] = {
+       { "disable",      NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_residuals", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 1}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+       { "no_coeffs",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
++    { "coding-raw",   "Enable packet-based raw-mode coding (disable for legacy-decoder compatibility)", OFFSET(coding_raw),   AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
++    { "cap-compat",   "Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required", OFFSET(cap_compat), AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
+     {NULL},
+ };
+
+--
+2.43.0

--- a/ffmpeg-plugin/9.0/0006-Fix-build-with-FFCodec-pix_fmts-API-change.patch
+++ b/ffmpeg-plugin/9.0/0006-Fix-build-with-FFCodec-pix_fmts-API-change.patch
@@ -1,0 +1,68 @@
+From c5e4d947f5f2a1119cb2bb00d15ed86e76003b2e Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Mon, 13 Jul 2026 11:42:18 +0200
+Subject: [PATCH] avcodec/libsvtjpegxsenc: fix build with FFCodec pix_fmts API
+ change
+
+FFmpeg commit removed AVCodec.pix_fmts in favor of FFCodec.pix_fmts,
+set via the CODEC_PIXFMTS()/CODEC_PIXFMTS_ARRAY() helper macros
+(libavcodec/codec_internal.h). Update libsvtjpegxs encoder accordingly,
+fixing a release/9.0 build failure:
+
+  libavcodec/libsvtjpegxsenc.c:326:8: error: 'AVCodec' has no member
+  named 'pix_fmts'
+---
+ libavcodec/libsvtjpegxsenc.c | 37 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 19 deletions(-)
+
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index 2e3123bdac..75e3cc499a 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -323,25 +323,24 @@ const FFCodec ff_libsvtjpegxs_encoder = {
+     .p.capabilities = AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_DR1,
+     .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE |
+                       FF_CODEC_CAP_AUTO_THREADS,
+-    .p.pix_fmts = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,
+-                                                AV_PIX_FMT_YUV422P,
+-                                                AV_PIX_FMT_YUV444P,
+-                                                AV_PIX_FMT_YUV420P10LE,
+-                                                AV_PIX_FMT_YUV422P10LE,
+-                                                AV_PIX_FMT_YUV444P10LE,
+-                                                AV_PIX_FMT_YUV420P12LE,
+-                                                AV_PIX_FMT_YUV422P12LE,
+-                                                AV_PIX_FMT_YUV444P12LE,
+-                                                AV_PIX_FMT_YUV420P14LE,
+-                                                AV_PIX_FMT_YUV422P14LE,
+-                                                AV_PIX_FMT_YUV444P14LE,
+-                                                AV_PIX_FMT_GBRP,
+-                                                AV_PIX_FMT_GBRP10LE,
+-                                                AV_PIX_FMT_GBRP12LE,
+-                                                AV_PIX_FMT_GBRP14LE,
+-                                                AV_PIX_FMT_RGB24,
+-                                                AV_PIX_FMT_BGR24,
+-                                                AV_PIX_FMT_NONE },
++    CODEC_PIXFMTS(AV_PIX_FMT_YUV420P,
++                  AV_PIX_FMT_YUV422P,
++                  AV_PIX_FMT_YUV444P,
++                  AV_PIX_FMT_YUV420P10LE,
++                  AV_PIX_FMT_YUV422P10LE,
++                  AV_PIX_FMT_YUV444P10LE,
++                  AV_PIX_FMT_YUV420P12LE,
++                  AV_PIX_FMT_YUV422P12LE,
++                  AV_PIX_FMT_YUV444P12LE,
++                  AV_PIX_FMT_YUV420P14LE,
++                  AV_PIX_FMT_YUV422P14LE,
++                  AV_PIX_FMT_YUV444P14LE,
++                  AV_PIX_FMT_GBRP,
++                  AV_PIX_FMT_GBRP10LE,
++                  AV_PIX_FMT_GBRP12LE,
++                  AV_PIX_FMT_GBRP14LE,
++                  AV_PIX_FMT_RGB24,
++                  AV_PIX_FMT_BGR24),
+     .p.wrapper_name = "libsvtjpegxs",
+     .p.priv_class = &svtjpegxs_enc_class,
+ };
+-- 
+2.53.0
+

--- a/ffmpeg-plugin/readme.md
+++ b/ffmpeg-plugin/readme.md
@@ -39,10 +39,10 @@ git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 cd ffmpeg
 ```
 
-### b) Checkout to branch/tag (6.1, 7.0, 7.1, 8.0, 8.1)
+### b) Checkout to branch/tag (6.1, 7.0, 7.1, 8.0, 8.1, 9.0)
 
 ```text
-git checkout release/(6.1, 7.0, 7.1, 8.0, 8.1)
+git checkout release/(6.1, 7.0, 7.1, 8.0, 8.1, 9.0)
 ```
 
 ### c) copy files - ONLY for ffmpeg 6.0, 7.0, 7.1, 8.0
@@ -54,7 +54,7 @@ cp <jpeg-xs-repo>/ffmpeg-plugin/libsvtjpegxs* libavcodec/
 ### d) apply jpeg-xs plugin patches
 
 ```text
-git am --whitespace=fix <jpeg-xs-repo>/ffmpeg-plugin/(6.1, 7.0, 7.1, 8.0, 8.1)/*.patch
+git am --whitespace=fix <jpeg-xs-repo>/ffmpeg-plugin/(6.1, 7.0, 7.1, 8.0, 8.1, 9.0)/*.patch
 ```
 
 ### e) Configure
@@ -69,9 +69,6 @@ git am --whitespace=fix <jpeg-xs-repo>/ffmpeg-plugin/(6.1, 7.0, 7.1, 8.0, 8.1)/*
 make -j40
 make install
 ```
-
-Note: for ffmpeg 8.0, 7.1, 7.0, or 6.1 version, replace 8.1 with the
-corresponding version in the above commands.
 
 ## 4. Test executable
 
@@ -137,10 +134,10 @@ git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 cd ffmpeg
 ```
 
-### b) checkout to branch/tag (6.1, 7.0, 7.1, 8.0, 8.1)
+### b) checkout to branch/tag (6.1, 7.0, 7.1, 8.0, 8.1, 9.0)
 
 ```text
-git checkout release/(6.1, 7.0, 7.1, 8.0, 8.1)
+git checkout release/(6.1, 7.0, 7.1, 8.0, 8.1, 9.0)
 ```
 
 ### c) copy files - ONLY for ffmpeg 6.0, 7.0, 7.1, 8.0
@@ -152,7 +149,7 @@ cp <jpeg-xs-repo>/ffmpeg-plugin/libsvtjpegxs* libavcodec/
 ### d) apply plugin patches
 
 ```text
-git am --whitespace=fix <jpeg-xs-repo>/ffmpeg-plugin/(6.1, 7.0, 7.1, 8.0, 8.1)/*.patch
+git am --whitespace=fix <jpeg-xs-repo>/ffmpeg-plugin/(6.1, 7.0, 7.1, 8.0, 8.1, 9.0)/*.patch
 ```
 
 ### e) Export path for svt-jpeg-xs installation directory
@@ -190,9 +187,6 @@ install-dir
 ```text
 make -j10
 ```
-
-Note: for ffmpeg 8.0, 7.1, 7.0, or 6.1 version, replace 8.1 with the
-corresponding version in the above commands.
 
 # How to use ffmpeg with jpeg-xs
 


### PR DESCRIPTION
Add ffmpeg-plugin/9.0 patch set (identical to 8.1) plus a new patch fixing the release/9.0 build break caused by FFCodec.pix_fmts replacing AVCodec.pix_fmts.

Update build_ffmpeg_plugin.sh and build_ffmpeg_plugin_msys.sh to:
 - accept 9.0 as a valid ffmpeg-version argument
 - force copy-files=n for 8.1/9.0, since libsvtjpegxs* now ships upstream and no longer needs to be copied into libavcodec/
 - fix a pre-existing missing-space-before-]] syntax error in the version validation check

Add ffmpeg-9-0-linux-build and ffmpeg-9-0-windows-build CI jobs, and update readme.md instructions to include the 9.0 version.