### PR TITLE
feat(ffmpeg-plugin): add safe per-format default for -bpp

### DIFF
--- a/ffmpeg-plugin/8.1/0006-Add-safe-per-format-default-for-bpp.patch
+++ b/ffmpeg-plugin/8.1/0006-Add-safe-per-format-default-for-bpp.patch
@@ -1,0 +1,121 @@
+From c89ff6b11baec78a54d3b545ecb1ba14dc661b01 Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Tue, 14 Jul 2026 13:30:26 +0200
+Subject: [PATCH] avcodec/libsvtjpegxsenc: add safe per-format default for -bpp
+
+The encoder currently requires -bpp to be set explicitly and fails with
+AVERROR_OPTION_NOT_FOUND otherwise. Add a safe fallback: when -bpp is
+not set, derive a lossless-equivalent bpp from the already-resolved
+colour_format/input_bit_depth (set by set_pix_fmt()) instead of adding
+a separate pix_fmt table, so every currently supported pixel format
+(and any added to set_pix_fmt() in the future) is automatically
+covered. Log a warning stating the auto-selected value, and still
+fail loud with AVERROR_OPTION_NOT_FOUND if colour_format cannot be
+classified.
+
+Also check set_pix_fmt()'s return value, which was previously
+discarded, allowing an unsupported pixel format to fall through
+silently.
+---
+ libavcodec/libsvtjpegxsenc.c | 54 ++++++++++++++++++++++++++++++------
+ 1 file changed, 46 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index 2e3123bdac..93d64dc891 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -28,6 +28,7 @@
+ #include "libavutil/common.h"
+ #include "libavutil/cpu.h"
+ #include "libavutil/imgutils.h"
++#include "libavutil/pixdesc.h"
+ 
+ #include "avcodec.h"
+ #include "codec_internal.h"
+@@ -205,8 +206,29 @@ static void set_bpp(const char* value, svt_jpeg_xs_encoder_api_t* encoder) {
+     }
+ }
+ 
++/* Derive a lossless-equivalent bpp default from the already-resolved
++ * colour_format/input_bit_depth (set by set_pix_fmt()), used only when the
++ * user does not pass -bpp explicitly. This keeps a single source of truth
++ * for pixel-format support instead of a separate pix_fmt table, so it
++ * automatically covers every format set_pix_fmt() supports, present and
++ * future. Returns 0 if colour_format is not recognized. */
++static uint32_t default_bpp_numerator(const svt_jpeg_xs_encoder_api_t* encoder) {
++    switch (encoder->colour_format) {
++    case COLOUR_FORMAT_PLANAR_YUV420:
++        return encoder->input_bit_depth * 3 / 2;
++    case COLOUR_FORMAT_PLANAR_YUV422:
++        return encoder->input_bit_depth * 2;
++    case COLOUR_FORMAT_PLANAR_YUV444_OR_RGB:
++    case COLOUR_FORMAT_PACKED_YUV444_OR_RGB:
++        return encoder->input_bit_depth * 3;
++    default:
++        return 0;
++    }
++}
++
+ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
++    int ret;
+     SvtJxsErrorType_t err = svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
+ 
+     if (err != SvtJxsErrorNone) {
+@@ -218,7 +240,9 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     svt_enc->encoder.source_width = avctx->width;
+     svt_enc->encoder.source_height = avctx->height;
+ 
+-    set_pix_fmt(avctx, &(svt_enc->encoder));
++    if ((ret = set_pix_fmt(avctx, &(svt_enc->encoder))) < 0) {
++        return ret;
++    }
+ 
+     svt_enc->encoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+ 
+@@ -232,13 +256,25 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+         svt_enc->encoder.verbose = VERBOSE_WARNINGS;
+     }
+ 
+-    if (!svt_enc->bpp_str) {
+-        //TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
+-        av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
+-        return AVERROR_OPTION_NOT_FOUND;
++    if (svt_enc->bpp_str) {
++        set_bpp(svt_enc->bpp_str, &(svt_enc->encoder));
++    }
++    else {
++        uint32_t default_bpp = default_bpp_numerator(&(svt_enc->encoder));
++        if (!default_bpp) {
++            //TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
++            av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
++            return AVERROR_OPTION_NOT_FOUND;
++        }
++        av_log(avctx,
++               AV_LOG_WARNING,
++               "-bpp not set; defaulting to uncompressed-equivalent %u bpp for %s "
++               "(no compression will occur). Set -bpp explicitly to target a specific bitrate.\n",
++               default_bpp,
++               av_get_pix_fmt_name(avctx->pix_fmt));
++        svt_enc->encoder.bpp_numerator = default_bpp;
++        svt_enc->encoder.bpp_denominator = 1;
+     }
+-
+-    set_bpp(svt_enc->bpp_str ,&(svt_enc->encoder));
+ 
+     if (svt_enc->decomp_v != -1) {
+         svt_enc->encoder.ndecomp_v = svt_enc->decomp_v;
+@@ -283,7 +319,9 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+ #define OFFSET(x) offsetof(SvtJpegXsEncodeContext, x)
+ #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
+ static const AVOption svtjpegxs_enc_options[] = {
+-    { "bpp",          "Bits per pixel",                                   OFFSET(bpp_str),      AV_OPT_TYPE_STRING,{.str = NULL }, 0, 0, VE },
++    { "bpp",          "Bits per pixel, can be passed as integer or float (example: 0.5, 3, 3.75, 5 etc.). "
++                       "If not set, defaults to an uncompressed-equivalent value based on the input pixel format.",
++                                                                            OFFSET(bpp_str),      AV_OPT_TYPE_STRING,{.str = NULL }, 0, 0, VE },
+     { "slice_height", "Specify number of lines calculated in one thread", OFFSET(slice_height), AV_OPT_TYPE_INT, {.i64 = 0 }, 0, 10000, VE },
+     { "decomp_v",     "vertical decomposition level",                              OFFSET(decomp_v),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 2, VE },
+     { "decomp_h",     "horizontal decomposition level",                            OFFSET(decomp_h),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 5, VE },
+-- 
+2.53.0
+

--- a/ffmpeg-plugin/9.0/0007-Add-safe-per-format-default-for-bpp.patch
+++ b/ffmpeg-plugin/9.0/0007-Add-safe-per-format-default-for-bpp.patch
@@ -1,0 +1,121 @@
+From 65886fe6d9c7d3c1daa637c566a897fa0ff2bf99 Mon Sep 17 00:00:00 2001
+From: Grzegorz Rys <grzegorz.rys@intel.com>
+Date: Tue, 14 Jul 2026 13:27:02 +0200
+Subject: [PATCH] avcodec/libsvtjpegxsenc: add safe per-format default for -bpp
+
+The encoder currently requires -bpp to be set explicitly and fails with
+AVERROR_OPTION_NOT_FOUND otherwise. Add a safe fallback: when -bpp is
+not set, derive a lossless-equivalent bpp from the already-resolved
+colour_format/input_bit_depth (set by set_pix_fmt()) instead of adding
+a separate pix_fmt table, so every currently supported pixel format
+(and any added to set_pix_fmt() in the future) is automatically
+covered. Log a warning stating the auto-selected value, and still
+fail loud with AVERROR_OPTION_NOT_FOUND if colour_format cannot be
+classified.
+
+Also check set_pix_fmt()'s return value, which was previously
+discarded, allowing an unsupported pixel format to fall through
+silently.
+---
+ libavcodec/libsvtjpegxsenc.c | 54 ++++++++++++++++++++++++++++++------
+ 1 file changed, 46 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index 75e3cc499a..c1cb0ce796 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -28,6 +28,7 @@
+ #include "libavutil/common.h"
+ #include "libavutil/cpu.h"
+ #include "libavutil/imgutils.h"
++#include "libavutil/pixdesc.h"
+ 
+ #include "avcodec.h"
+ #include "codec_internal.h"
+@@ -205,8 +206,29 @@ static void set_bpp(const char* value, svt_jpeg_xs_encoder_api_t* encoder) {
+     }
+ }
+ 
++/* Derive a lossless-equivalent bpp default from the already-resolved
++ * colour_format/input_bit_depth (set by set_pix_fmt()), used only when the
++ * user does not pass -bpp explicitly. This keeps a single source of truth
++ * for pixel-format support instead of a separate pix_fmt table, so it
++ * automatically covers every format set_pix_fmt() supports, present and
++ * future. Returns 0 if colour_format is not recognized. */
++static uint32_t default_bpp_numerator(const svt_jpeg_xs_encoder_api_t* encoder) {
++    switch (encoder->colour_format) {
++    case COLOUR_FORMAT_PLANAR_YUV420:
++        return encoder->input_bit_depth * 3 / 2;
++    case COLOUR_FORMAT_PLANAR_YUV422:
++        return encoder->input_bit_depth * 2;
++    case COLOUR_FORMAT_PLANAR_YUV444_OR_RGB:
++    case COLOUR_FORMAT_PACKED_YUV444_OR_RGB:
++        return encoder->input_bit_depth * 3;
++    default:
++        return 0;
++    }
++}
++
+ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
++    int ret;
+     SvtJxsErrorType_t err = svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
+ 
+     if (err != SvtJxsErrorNone) {
+@@ -218,7 +240,9 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+     svt_enc->encoder.source_width = avctx->width;
+     svt_enc->encoder.source_height = avctx->height;
+ 
+-    set_pix_fmt(avctx, &(svt_enc->encoder));
++    if ((ret = set_pix_fmt(avctx, &(svt_enc->encoder))) < 0) {
++        return ret;
++    }
+ 
+     svt_enc->encoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+ 
+@@ -232,13 +256,25 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+         svt_enc->encoder.verbose = VERBOSE_WARNINGS;
+     }
+ 
+-    if (!svt_enc->bpp_str) {
+-        //TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
+-        av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
+-        return AVERROR_OPTION_NOT_FOUND;
++    if (svt_enc->bpp_str) {
++        set_bpp(svt_enc->bpp_str, &(svt_enc->encoder));
++    }
++    else {
++        uint32_t default_bpp = default_bpp_numerator(&(svt_enc->encoder));
++        if (!default_bpp) {
++            //TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
++            av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
++            return AVERROR_OPTION_NOT_FOUND;
++        }
++        av_log(avctx,
++               AV_LOG_WARNING,
++               "-bpp not set; defaulting to uncompressed-equivalent %u bpp for %s "
++               "(no compression will occur). Set -bpp explicitly to target a specific bitrate.\n",
++               default_bpp,
++               av_get_pix_fmt_name(avctx->pix_fmt));
++        svt_enc->encoder.bpp_numerator = default_bpp;
++        svt_enc->encoder.bpp_denominator = 1;
+     }
+-
+-    set_bpp(svt_enc->bpp_str ,&(svt_enc->encoder));
+ 
+     if (svt_enc->decomp_v != -1) {
+         svt_enc->encoder.ndecomp_v = svt_enc->decomp_v;
+@@ -283,7 +319,9 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+ #define OFFSET(x) offsetof(SvtJpegXsEncodeContext, x)
+ #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
+ static const AVOption svtjpegxs_enc_options[] = {
+-    { "bpp",          "Bits per pixel",                                   OFFSET(bpp_str),      AV_OPT_TYPE_STRING,{.str = NULL }, 0, 0, VE },
++    { "bpp",          "Bits per pixel, can be passed as integer or float (example: 0.5, 3, 3.75, 5 etc.). "
++                       "If not set, defaults to an uncompressed-equivalent value based on the input pixel format.",
++                                                                            OFFSET(bpp_str),      AV_OPT_TYPE_STRING,{.str = NULL }, 0, 0, VE },
+     { "slice_height", "Specify number of lines calculated in one thread", OFFSET(slice_height), AV_OPT_TYPE_INT, {.i64 = 0 }, 0, 10000, VE },
+     { "decomp_v",     "vertical decomposition level",                              OFFSET(decomp_v),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 2, VE },
+     { "decomp_h",     "horizontal decomposition level",                            OFFSET(decomp_h),              AV_OPT_TYPE_INT,  {.i64 = -1 }, -1, 5, VE },
+-- 
+2.53.0
+

--- a/ffmpeg-plugin/libsvtjpegxsenc.c
+++ b/ffmpeg-plugin/libsvtjpegxsenc.c
@@ -8,6 +8,7 @@
 #include "libavutil/common.h"
 #include "libavutil/cpu.h"
 #include "libavutil/imgutils.h"
+#include "libavutil/pixdesc.h"
 
 #include "avcodec.h"
 #include "codec_internal.h"
@@ -184,8 +185,29 @@ static void set_bpp(const char* value, svt_jpeg_xs_encoder_api_t* encoder) {
     }
 }
 
+/* Derive a lossless-equivalent bpp default from the already-resolved
+ * colour_format/input_bit_depth (set by set_pix_fmt()), used only when the
+ * user does not pass -bpp explicitly. This keeps a single source of truth
+ * for pixel-format support instead of a separate pix_fmt table, so it
+ * automatically covers every format set_pix_fmt() supports, present and
+ * future. Returns 0 if colour_format is not recognized. */
+static uint32_t default_bpp_numerator(const svt_jpeg_xs_encoder_api_t* encoder) {
+    switch (encoder->colour_format) {
+    case COLOUR_FORMAT_PLANAR_YUV420:
+        return encoder->input_bit_depth * 3 / 2;
+    case COLOUR_FORMAT_PLANAR_YUV422:
+        return encoder->input_bit_depth * 2;
+    case COLOUR_FORMAT_PLANAR_YUV444_OR_RGB:
+    case COLOUR_FORMAT_PACKED_YUV444_OR_RGB:
+        return encoder->input_bit_depth * 3;
+    default:
+        return 0;
+    }
+}
+
 static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
     SvtJpegXsEncodeContext* svt_enc = avctx->priv_data;
+    int ret;
     SvtJxsErrorType_t err = svt_jpeg_xs_encoder_load_default_parameters(
         SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &(svt_enc->encoder));
 
@@ -198,7 +220,9 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
     svt_enc->encoder.source_width = avctx->width;
     svt_enc->encoder.source_height = avctx->height;
 
-    set_pix_fmt(avctx, &(svt_enc->encoder));
+    if ((ret = set_pix_fmt(avctx, &(svt_enc->encoder))) < 0) {
+        return ret;
+    }
 
     svt_enc->encoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
 
@@ -212,13 +236,25 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
         svt_enc->encoder.verbose = VERBOSE_WARNINGS;
     }
 
-    if (!svt_enc->bpp_str) {
-        // TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
-        av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
-        return AVERROR_OPTION_NOT_FOUND;
+    if (svt_enc->bpp_str) {
+        set_bpp(svt_enc->bpp_str, &(svt_enc->encoder));
     }
-
-    set_bpp(svt_enc->bpp_str, &(svt_enc->encoder));
+    else {
+        uint32_t default_bpp = default_bpp_numerator(&(svt_enc->encoder));
+        if (!default_bpp) {
+            // TODO: Consider using avctx->bit_rate to specify bpp_num/bpp_denom in this case
+            av_log(NULL, AV_LOG_ERROR, "libsvtjpegxs Encoder require -bpp(bits per pixel) param\n");
+            return AVERROR_OPTION_NOT_FOUND;
+        }
+        av_log(avctx,
+               AV_LOG_WARNING,
+               "-bpp not set; defaulting to uncompressed-equivalent %u bpp for %s "
+               "(no compression will occur). Set -bpp explicitly to target a specific bitrate.\n",
+               default_bpp,
+               av_get_pix_fmt_name(avctx->pix_fmt));
+        svt_enc->encoder.bpp_numerator = default_bpp;
+        svt_enc->encoder.bpp_denominator = 1;
+    }
 
     if (svt_enc->decomp_v != -1) {
         svt_enc->encoder.ndecomp_v = svt_enc->decomp_v;
@@ -264,7 +300,15 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
 #define OFFSET(x) offsetof(SvtJpegXsEncodeContext, x)
 #define VE        AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
 static const AVOption svtjpegxs_enc_options[] = {
-    {"bpp", "Bits per pixel", OFFSET(bpp_str), AV_OPT_TYPE_STRING, {.str = NULL}, 0, 0, VE},
+    {"bpp",
+     "Bits per pixel, can be passed as integer or float (example: 0.5, 3, 3.75, 5 etc.). "
+     "If not set, defaults to an uncompressed-equivalent value based on the input pixel format.",
+     OFFSET(bpp_str),
+     AV_OPT_TYPE_STRING,
+     {.str = NULL},
+     0,
+     0,
+     VE},
     {"slice_height",
      "Specify number of lines calculated in one thread",
      OFFSET(slice_height),

--- a/ffmpeg-plugin/readme.md
+++ b/ffmpeg-plugin/readme.md
@@ -194,7 +194,7 @@ make -j10
 
 Name|mandatory/optional|Accepted values|description
 --|--|--|--
-bpp|mandatory|any integer/float greater than 0 (example: 0.5, 3, 3.75, 5 etc.)|Bits Per Pixel
+bpp|optional|any integer/float greater than 0 (example: 0.5, 3, 3.75, 5 etc.)|Bits Per Pixel. If not set, defaults to an uncompressed-equivalent value based on the input pixel format (a warning is logged with the auto-selected value)
 decomp_v|optional|0, 1, 2(default)|Number of Vertical decompositions
 decomp_h|optional|0, 1, 2, 3, 4, 5(default)|Number of Horizontal decompositions, have to be greater or equal to decomp_v
 threads|optional|Any integer in range< 1;64>|Number of threads encoder can create


### PR DESCRIPTION
The libsvtjpegxs encoder currently requires -bpp to be set explicitly and fails with AVERROR_OPTION_NOT_FOUND otherwise. Add a safe fallback: when -bpp is not set, derive a lossless-equivalent bpp from the already-resolved colour_format/input_bit_depth (set by set_pix_fmt()) instead of a separate pix_fmt table, so every currently supported pixel format (and any added to set_pix_fmt() in the future) is automatically covered. Log a warning stating the auto-selected value, and still fail loud with AVERROR_OPTION_NOT_FOUND if colour_format cannot be classified. Also check set_pix_fmt()'s return value, which was previously discarded.

Update ffmpeg-plugin/libsvtjpegxsenc.c (governs ffmpeg <= 8.0 builds) and add matching patches for ffmpeg 8.1/9.0, which ship libavcodec/libsvtjpegxsenc.c upstream instead of copying it from this repo. Update the -bpp AVOption description and readme.md to reflect that it is now optional.

Verified on all supported ffmpeg versions (6.1, 7.0, 7.1, 8.0, 8.1, 9.0): building without -bpp logs the expected default and produces output bit-for-bit identical to passing the equivalent -bpp value explicitly.