### PR TITLE
Add MSB-aligned 16-bit pixel format support to encoder input / decoder output

### DIFF
--- a/.github/scripts/build_ffmpeg_plugin.sh
+++ b/.github/scripts/build_ffmpeg_plugin.sh
@@ -44,7 +44,7 @@ echo "=== 3. Download/Compile FFmpeg ==="
 cd "$PWD"
 clone_attempt=1
 max_clone_attempts=5
-until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://git.ffmpeg.org/ffmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
+until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
     if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
         echo "git clone failed after $max_clone_attempts attempts, giving up."
         exit 1

--- a/.github/scripts/build_ffmpeg_plugin_msys.sh
+++ b/.github/scripts/build_ffmpeg_plugin_msys.sh
@@ -43,7 +43,7 @@ git config --global user.name "action-runner"
 
 clone_attempt=1
 max_clone_attempts=5
-until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://git.ffmpeg.org/ffmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
+until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
     if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
         echo "git clone failed after $max_clone_attempts attempts, giving up."
         exit 1

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Input Options:
 --colour-format            Set encoder colour format (yuv420, yuv422,  yuv444, rgb(planar), rgbp(packed))
                             (Experimental: yuv400)
 --input-depth              Input depth
+[--input-msb-aligned]      Non-standard: 10/12-bit input samples are MSB-aligned in each 16-bit
+                            word instead of LSB-aligned (enabled:1, disabled:0, default:0)
 --bpp                      Bits Per Pixel, can be passed as integer or float
                             (example: 0.5, 3, 3.75, 5 etc.)
 [-n]                       Number of frames to encode
@@ -262,6 +264,8 @@ Input Options:
 [--packetization-mode]     Specify how bitstream is passed to decoder
                             (multiple packets per frame:1, single packet per frame:0, default:0)
 [--proxy-mode]             Resolution scaling mode(disabled: 0, scale 1/2: 1, scale 1/4: 2, default: 0)
+[--output-msb-aligned]     Non-standard: 10/12-bit output samples are MSB-aligned in each 16-bit
+                            word instead of LSB-aligned (enabled:1, disabled:0, default:0)
 ```
 
 Output Options:

--- a/Source/API/SvtJpegxsDec.h
+++ b/Source/API/SvtJpegxsDec.h
@@ -48,12 +48,21 @@ typedef struct svt_jpeg_xs_decoder_api {
 
     void* private_ptr;
 
+    /* Non-standard, host-side buffer layout convention only - not signalled in the bitstream.
+     * Both encoder and decoder must be configured consistently by the caller.
+     * 0 = LSB-aligned (default, current behavior): 10/12-bit samples occupy the low bits of each
+     *     16-bit output word (value `v`), high bits are set to zero.
+     * 1 = MSB-aligned: 10/12-bit samples occupy the high bits of each 16-bit output word
+     *     (value `v << (16 - output_bit_depth)`), low bits are set to zero.
+     * Optional, default 0 */
+    uint8_t output_bit_depth_msb_aligned;
+
     /* This padding is used to avoid changing the size of the public configuration struct
      * when new parameters are added in the future please follow these steps:
      * 1. Insert the new parameter as a member of this structure before the padding array.
      * 2. Decrease the size of the padding array by the size of the new parameter to keep the struct size unchanged.
      */
-    uint8_t padding[64];
+    uint8_t padding[63];
 } svt_jpeg_xs_decoder_api_t;
 
 PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major, uint64_t version_api_minor,

--- a/Source/API/SvtJpegxsEnc.h
+++ b/Source/API/SvtJpegxsEnc.h
@@ -124,12 +124,21 @@ typedef struct svt_jpeg_xs_encoder_api {
      * Optional, default 0xFFFF (auto-derive) */
     uint16_t level_plev_override;
 
+    /* Non-standard, host-side buffer layout convention only - not signalled in the bitstream.
+     * Both encoder and decoder must be configured consistently by the caller.
+     * 0 = LSB-aligned (default, current behavior): 10/12-bit samples occupy the low bits of each
+     *     16-bit input word (value `v`), high bits are don't-care/masked off.
+     * 1 = MSB-aligned: 10/12-bit samples occupy the high bits of each 16-bit input word
+     *     (value `v << (16 - input_bit_depth)`), low bits must be zero. Only affects input_bit_depth > 8.
+     * Optional, default 0 */
+    uint8_t input_bit_depth_msb_aligned;
+
     /* This padding is used to avoid changing the size of the public configuration struct
      * when new parameters are added in the future please follow these steps:
      * 1. Insert the new parameter as a member of this structure before the padding array.
      * 2. Decrease the size of the padding array by the size of the new parameter to keep the struct size unchanged.
      */
-    uint8_t padding[58];
+    uint8_t padding[57];
 } svt_jpeg_xs_encoder_api_t;
 
 /* STEP 0 (Optional): Set default encoder parameters.

--- a/Source/App/DecApp/DecParamParser.c
+++ b/Source/App/DecApp/DecParamParser.c
@@ -30,6 +30,7 @@
 #define LIMIT_FPS_TOKEN              "--limit-fps"
 #define PACKETIZATION_MODE           "--packetization-mode"
 #define PROXY_MODE                   "--proxy-mode"
+#define OUTPUT_MSB_ALIGNED_TOKEN     "--output-msb-aligned"
 #define MAX_NUM_TOKENS               200
 
 static void strncpy_local(char* dest, const char* src, size_t count) {
@@ -128,6 +129,10 @@ static void set_packetization_mode(const char* value, DecoderConfig_t* cfg) {
     cfg->decoder.packetization_mode = (uint8_t)strtoul(value, NULL, 0);
 };
 
+static void set_output_msb_aligned(const char* value, DecoderConfig_t* cfg) {
+    cfg->decoder.output_bit_depth_msb_aligned = (uint8_t)strtoul(value, NULL, 0);
+};
+
 static void set_proxy_mode(const char* value, DecoderConfig_t* cfg) {
     uint8_t proxy_mode = (uint8_t)strtoul(value, NULL, 0);
     if (proxy_mode == 0) {
@@ -175,6 +180,7 @@ ConfigEntry config_entry[] = {
     {INPUT_OPTIONS, PACKETIZATION_MODE,          "Specify how bitstream is passed to decoder(multiple packets per frame:1, single packet per frame:0, default:0)", 0, 1, set_packetization_mode},
     {OUTPUT_OPTIONS, OUTPUT_FILE_TOKEN,         "Output Filename", 0, 1, set_cfg_output_file},
     {OUTPUT_OPTIONS, PROXY_MODE,                "Resolution scaling mode(disabled: 0, scale 1/2: 1, scale 1/4: 2, default: 0)", 0, 1, set_proxy_mode},
+    {OUTPUT_OPTIONS, OUTPUT_MSB_ALIGNED_TOKEN,  "Non-standard: 10/12-bit output samples are MSB-aligned in each 16-bit word instead of LSB-aligned (enabled:1, disabled:0, default:0)", 0, 1, set_output_msb_aligned},
     {THREAD_PERF_OPTIONS, ASM_TYPE_TOKEN,       "Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, "
                                                 "ssse3, sse4_1, sse4_2,"
                                                 " avx, avx2, avx512, max], by default highest level supported by CPU", 0, 1,

--- a/Source/App/EncApp/EncAppConfig.c
+++ b/Source/App/EncApp/EncAppConfig.c
@@ -49,6 +49,7 @@ static void strncpy_local(char *dest, const char *src, size_t count) {
 #define SLICE_HEIGHT_TOKEN      "--slice-height"
 #define ENCODER_COLOUR_FORMAT   "--colour-format"
 #define INPUT_DEPTH_TOKEN       "--input-depth"
+#define INPUT_MSB_ALIGNED_TOKEN "--input-msb-aligned"
 
 #define OUTPUT_BITSTREAM_TOKEN "-b"
 #define NO_PROGRESS_TOKEN      "--no-progress" // tbd if it should be removed
@@ -115,6 +116,10 @@ static void set_no_progress(const char *value, EncoderConfig_t *cfg) {
 
 static void set_input_bit_depth(const char *value, EncoderConfig_t *cfg) {
     cfg->encoder.input_bit_depth = (uint8_t)strtoul(value, NULL, 0);
+}
+
+static void set_input_msb_aligned(const char *value, EncoderConfig_t *cfg) {
+    cfg->encoder.input_bit_depth_msb_aligned = (uint8_t)strtoul(value, NULL, 0);
 }
 
 static void coding_signs_handling(const char *value, EncoderConfig_t *cfg) {
@@ -394,6 +399,7 @@ ConfigEntry config_entry[] = {
     {INPUT_OPTIONS, HEIGHT_TOKEN,           "Frame height", 1, 1, set_cfg_source_height},
     {INPUT_OPTIONS, ENCODER_COLOUR_FORMAT,  "Set encoder colour format (yuv420, yuv422) (Experimental: yuv400, yuv444, rgb(planar), rgbp(packed))", 1, 1, set_encoder_colour_format},
     {INPUT_OPTIONS, INPUT_DEPTH_TOKEN,      "Input depth", 1, 1, set_input_bit_depth},
+    {INPUT_OPTIONS, INPUT_MSB_ALIGNED_TOKEN,"Non-standard: 10/12-bit input samples are MSB-aligned in each 16-bit word instead of LSB-aligned (enabled:1, disabled:0, default:0)", 0, 1, set_input_msb_aligned},
     {INPUT_OPTIONS, COMPRESS_BPP_LONG_TOKEN,"Bits Per Pixel, can be passed as integer or float (example: 0.5, 3, 3.75, 5 etc.)", 1, 1, set_encoder_bpp},
     {INPUT_OPTIONS, FRAMES_COUNT_TOKEN,     "Number of frames to encode", 0, 1, set_cfg_frames_count},
     {INPUT_OPTIONS, LIMIT_FPS_TOKEN,        "Limit number of frames per second (disabled: 0, enabled [1-240])", 0, 1, set_limit_fps},

--- a/Source/Lib/Common/Codec/Pi.h
+++ b/Source/Lib/Common/Codec/Pi.h
@@ -87,6 +87,10 @@ typedef struct picture_header_dynamic {
 
     uint16_t hdr_Xcrg[MAX_COMPONENTS_NUM];
     uint16_t hdr_Ycrg[MAX_COMPONENTS_NUM];
+
+    /* Non-standard: not parsed from/written to the bitstream. Mirrors
+     * svt_jpeg_xs_encoder_api_t::input_bit_depth_msb_aligned, set once at encoder init. */
+    uint8_t hdr_input_msb_aligned;
 } picture_header_dynamic_t;
 
 typedef struct precinct_band_info {

--- a/Source/Lib/Decoder/ASM_AVX2/NltDec_AVX2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/NltDec_AVX2.c
@@ -177,3 +177,37 @@ void linear_output_scaling_16bit_line_avx2(int32_t* in, uint32_t bw, uint32_t de
         out[x] = (uint16_t)(v > m ? m : v < 0 ? 0 : v);
     }
 }
+
+void linear_output_scaling_16bit_line_msb_avx2(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w) {
+    int32_t x;
+    const int32_t dzeta = bw - depth;
+    const uint32_t round = ((1 << bw) >> 1) + ((1 << dzeta) >> 1);
+    const int32_t m = (1 << depth) - 1;
+    const int32_t msb_shift = 16 - depth;
+    const __m256i round_avx2 = _mm256_set1_epi32(round);
+    const __m256i zero_avx2 = _mm256_setzero_si256();
+    const __m256i max_avx2 = _mm256_set1_epi32(m);
+
+    for (x = 0; x <= (int32_t)w - 16; x += 16) {
+        __m256i v1_avx2 = _mm256_loadu_si256((__m256i*)(in + x));
+        v1_avx2 = _mm256_add_epi32(v1_avx2, round_avx2);
+        v1_avx2 = _mm256_srai_epi32(v1_avx2, dzeta);
+        v1_avx2 = _mm256_max_epi32(_mm256_min_epi32(v1_avx2, max_avx2), zero_avx2);
+
+        __m256i v2_avx2 = _mm256_loadu_si256((__m256i*)(in + x + 8));
+        v2_avx2 = _mm256_add_epi32(v2_avx2, round_avx2);
+        v2_avx2 = _mm256_srai_epi32(v2_avx2, dzeta);
+        v2_avx2 = _mm256_max_epi32(_mm256_min_epi32(v2_avx2, max_avx2), zero_avx2);
+
+        __m256i packed = _mm256_packus_epi32(v1_avx2, v2_avx2);
+        packed = _mm256_permute4x64_epi64(packed, 0xd8);
+        packed = _mm256_slli_epi16(packed, msb_shift);
+        _mm256_storeu_si256((__m256i*)(out + x), packed);
+    }
+    for (; x < (int32_t)w; x++) {
+        int32_t v = in[x];
+        v += (int32_t)round;
+        v >>= dzeta;
+        out[x] = (uint16_t)((v > m ? m : v < 0 ? 0 : v) << msb_shift);
+    }
+}

--- a/Source/Lib/Decoder/ASM_AVX2/NltDec_AVX2.h
+++ b/Source/Lib/Decoder/ASM_AVX2/NltDec_AVX2.h
@@ -23,6 +23,7 @@ void linear_output_scaling_16bit_avx2(const pi_t* const pi, int32_t* comps[MAX_C
 
 void linear_output_scaling_8bit_line_avx2(int32_t* in, uint32_t bw, uint32_t depth, uint8_t* out, uint32_t w);
 void linear_output_scaling_16bit_line_avx2(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
+void linear_output_scaling_16bit_line_msb_avx2(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Decoder/ASM_AVX512/NltDec_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/NltDec_avx512.c
@@ -53,3 +53,31 @@ void linear_output_scaling_16bit_line_avx512(int32_t* in, uint32_t bw, uint32_t 
         out[x] = (uint16_t)(v > m ? m : v < 0 ? 0 : v);
     }
 }
+
+void linear_output_scaling_16bit_line_msb_avx512(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w) {
+    int32_t x;
+    const int32_t dzeta = bw - depth;
+    const uint32_t round = ((1 << bw) >> 1) + ((1 << dzeta) >> 1);
+    const int32_t m = (1 << depth) - 1;
+    const int32_t msb_shift = 16 - depth;
+    const __m512i round_avx2 = _mm512_set1_epi32(round);
+    const __m512i zero_avx2 = _mm512_setzero_si512();
+    const __m512i max_avx2 = _mm512_set1_epi32(m);
+
+    for (x = 0; x <= (int32_t)w - 16; x += 16) {
+        __m512i v1_avx2 = _mm512_loadu_si512((__m512i*)(in + x));
+        v1_avx2 = _mm512_add_epi32(v1_avx2, round_avx2);
+        v1_avx2 = _mm512_srai_epi32(v1_avx2, dzeta);
+        v1_avx2 = _mm512_max_epi32(_mm512_min_epi32(v1_avx2, max_avx2), zero_avx2);
+
+        __m256i packed = _mm512_cvtepi32_epi16(v1_avx2);
+        packed = _mm256_slli_epi16(packed, msb_shift);
+        _mm256_storeu_si256((__m256i*)(out + x), packed);
+    }
+    for (; x < (int32_t)w; x++) {
+        int32_t v = in[x];
+        v += (int32_t)round;
+        v >>= dzeta;
+        out[x] = (uint16_t)((v > m ? m : v < 0 ? 0 : v) << msb_shift);
+    }
+}

--- a/Source/Lib/Decoder/ASM_AVX512/NltDec_avx512.h
+++ b/Source/Lib/Decoder/ASM_AVX512/NltDec_avx512.h
@@ -17,6 +17,7 @@ extern "C" {
 
 void linear_output_scaling_8bit_line_avx512(int32_t* in, uint32_t bw, uint32_t depth, uint8_t* out, uint32_t w);
 void linear_output_scaling_16bit_line_avx512(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
+void linear_output_scaling_16bit_line_msb_avx512(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Decoder/Codec/DecHandle.c
+++ b/Source/Lib/Decoder/Codec/DecHandle.c
@@ -139,6 +139,15 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
         return SvtJxsErrorBadParameter;
     }
 
+    dec_api_prv->dec_common.output_bit_depth_msb_aligned = dec_api->output_bit_depth_msb_aligned;
+    if (dec_api_prv->dec_common.output_bit_depth_msb_aligned != 0 && dec_api_prv->dec_common.output_bit_depth_msb_aligned != 1) {
+        if (dec_api->verbose >= VERBOSE_ERRORS) {
+            fprintf(stderr, "Unrecognized output_bit_depth_msb_aligned, expected: 0 or 1\n");
+        }
+        svt_jpeg_xs_decoder_close(dec_api);
+        return SvtJxsErrorBadParameter;
+    }
+
     if (dec_api->proxy_mode >= proxy_mode_max) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
             fprintf(stderr, "Unrecognized proxy mode\n");

--- a/Source/Lib/Decoder/Codec/Decoder.c
+++ b/Source/Lib/Decoder/Codec/Decoder.c
@@ -499,7 +499,8 @@ void transform_precinct(const pi_t* pi, svt_jpeg_xs_decoder_instance_t* ctx, uin
         }
         else {
             uint16_t* out_buf_16 = ((uint16_t*)out_buf) + component_line_idx * out_stride;
-            nlt_inverse_transform_line_16bit(in, bit_depth, &ctx->picture_header_dynamic, out_buf_16, width);
+            nlt_inverse_transform_line_16bit(
+                in, bit_depth, &ctx->picture_header_dynamic, out_buf_16, width, ctx->dec_common->output_bit_depth_msb_aligned);
         }
         component_line_idx++;
     }

--- a/Source/Lib/Decoder/Codec/Decoder.h
+++ b/Source/Lib/Decoder/Codec/Decoder.h
@@ -23,6 +23,7 @@ typedef struct svt_jpeg_xs_decoder_common {
 
     // max_frame_bitstream_size is used only when packetization_mode is enabled
     uint32_t max_frame_bitstream_size;
+    uint8_t output_bit_depth_msb_aligned;
 } svt_jpeg_xs_decoder_common_t;
 
 typedef struct svt_jpeg_xs_decoder_thread_context {

--- a/Source/Lib/Decoder/Codec/NltDec.c
+++ b/Source/Lib/Decoder/Codec/NltDec.c
@@ -263,6 +263,20 @@ void linear_output_scaling_16bit_line_c(int32_t* in, uint32_t bw, uint32_t depth
     }
 }
 
+/* MSB-aligned: sample stored in the high bits (v << (16-depth)), fused into the same pass. */
+void linear_output_scaling_16bit_line_msb_c(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w) {
+    int32_t dzeta = bw - depth;
+    int32_t m = (1 << depth) - 1;
+    int32_t msb_shift = 16 - depth;
+
+    for (uint32_t x = 0; x < w; x++) {
+        int32_t v = in[x];
+        v += (1 << bw) >> 1;
+        v = (v + (((int64_t)1 << dzeta) >> 1)) >> dzeta;
+        out[x] = (uint16_t)nlt_clamp(v, m) << msb_shift;
+    }
+}
+
 void quadratic_output_scaling_8bit_line(int32_t* in, uint32_t bw, int32_t dco, uint32_t depth, uint8_t* out, uint32_t w) {
     int32_t dzeta = 2 * bw - depth;
     int32_t m = (1 << depth) - 1;
@@ -385,20 +399,37 @@ void nlt_inverse_transform_line_8bit(int32_t* in, uint32_t depth, const picture_
 }
 
 void nlt_inverse_transform_line_16bit(int32_t* in, uint32_t depth, const picture_header_dynamic_t* picture_header_dynamic,
-                                      uint16_t* out, int32_t w) {
+                                      uint16_t* out, int32_t w, uint8_t msb_aligned) {
     if (picture_header_dynamic->hdr_Tnlt == 0) {
-        linear_output_scaling_16bit_line(in, picture_header_dynamic->hdr_Bw, depth, out, w);
+        if (msb_aligned) {
+            linear_output_scaling_16bit_line_msb(in, picture_header_dynamic->hdr_Bw, depth, out, w);
+        }
+        else {
+            linear_output_scaling_16bit_line(in, picture_header_dynamic->hdr_Bw, depth, out, w);
+        }
     }
     else if (picture_header_dynamic->hdr_Tnlt == 1) {
         int32_t dco = (int32_t)picture_header_dynamic->hdr_Tnlt_alpha -
             ((int32_t)picture_header_dynamic->hdr_Tnlt_sigma * (1 << 15));
         quadratic_output_scaling_16bit_line(in, picture_header_dynamic->hdr_Bw, dco, depth, out, w);
+        if (msb_aligned) {
+            const int32_t msb_shift = 16 - depth;
+            for (int32_t x = 0; x < w; x++) {
+                out[x] = (uint16_t)(out[x] << msb_shift);
+            }
+        }
     }
     else if (picture_header_dynamic->hdr_Tnlt == 2) {
         int32_t t1 = picture_header_dynamic->hdr_Tnlt_t1;
         int32_t t2 = picture_header_dynamic->hdr_Tnlt_t2;
         uint8_t e = picture_header_dynamic->hdr_Tnlt_e;
         extended_output_scaling_16bit_line(in, picture_header_dynamic->hdr_Bw, t1, t2, e, depth, out, w);
+        if (msb_aligned) {
+            const int32_t msb_shift = 16 - depth;
+            for (int32_t x = 0; x < w; x++) {
+                out[x] = (uint16_t)(out[x] << msb_shift);
+            }
+        }
     }
     else {
         assert(0);

--- a/Source/Lib/Decoder/Codec/NltDec.h
+++ b/Source/Lib/Decoder/Codec/NltDec.h
@@ -24,9 +24,10 @@ void nlt_inverse_transform(int32_t* comps[MAX_COMPONENTS_NUM], const pi_t* pi, c
 void nlt_inverse_transform_line_8bit(int32_t* in, uint32_t depth, const picture_header_dynamic_t* picture_header_dynamic,
                                      uint8_t* out, int32_t w);
 void nlt_inverse_transform_line_16bit(int32_t* in, uint32_t depth, const picture_header_dynamic_t* picture_header_dynamic,
-                                      uint16_t* out, int32_t w);
+                                      uint16_t* out, int32_t w, uint8_t msb_aligned);
 void linear_output_scaling_8bit_line_c(int32_t* in, uint32_t bw, uint32_t depth, uint8_t* out, uint32_t w);
 void linear_output_scaling_16bit_line_c(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
+void linear_output_scaling_16bit_line_msb_c(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
+++ b/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
@@ -101,6 +101,10 @@ void setup_decoder_rtcd_internal(CPU_FLAGS flags) {
                     linear_output_scaling_16bit_line_c,
                     linear_output_scaling_16bit_line_avx2,
                     linear_output_scaling_16bit_line_avx512);
+    SET_AVX2_AVX512(linear_output_scaling_16bit_line_msb,
+                    linear_output_scaling_16bit_line_msb_c,
+                    linear_output_scaling_16bit_line_msb_avx2,
+                    linear_output_scaling_16bit_line_msb_avx512);
 
     SET_AVX2(inv_sign, inv_sign_c, inv_sign_avx2);
     SET_AVX2(unpack_data, unpack_data_c, unpack_data_avx2);

--- a/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.h
+++ b/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.h
@@ -51,6 +51,7 @@ RTCD_EXTERN void (*idwt_horizontal_line_lf16_hf16)(const int16_t* in_lf, const i
 RTCD_EXTERN void (*idwt_horizontal_line_lf32_hf16)(const int32_t* in_lf, const int16_t* in_hf, int32_t* out, uint32_t len,
                                                    uint8_t shift);
 RTCD_EXTERN void (*linear_output_scaling_16bit_line)(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
+RTCD_EXTERN void (*linear_output_scaling_16bit_line_msb)(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out, uint32_t w);
 
 RTCD_EXTERN void (*idwt_vertical_line)(const int32_t* in_lf, const int32_t* in_hf0, const int32_t* in_hf1, int32_t* out[4],
                                        uint32_t len, int32_t first_precinct, int32_t last_precinct, int32_t height);

--- a/Source/Lib/Encoder/ASM_AVX2/NltEnc_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/NltEnc_avx2.c
@@ -124,3 +124,23 @@ void linear_input_scaling_line_16bit_avx2(const uint16_t* src, int32_t* dst, uin
         dst[i] = ((src[i] & input_mask) << shift) - offset;
     }
 }
+
+/* MSB-aligned: no masking needed, values use the full 16-bit range so zero-extend (not sign-extend). */
+void linear_input_scaling_line_16bit_msb_avx2(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                              uint8_t bit_depth) {
+    (void)bit_depth;
+    const uint32_t simd_batch = w / 8;
+    const uint32_t remaining = w % 8;
+    const __m256i offset_avx2 = _mm256_set1_epi32(offset);
+
+    for (uint32_t i = 0; i < simd_batch; i++) {
+        __m256i reg = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i*)src));
+        __m256i result = _mm256_sub_epi32(_mm256_slli_epi32(reg, shift), offset_avx2);
+        _mm256_storeu_si256((__m256i*)dst, result);
+        src += 8;
+        dst += 8;
+    }
+    for (uint32_t i = 0; i < remaining; i++) {
+        dst[i] = ((uint32_t)src[i] << shift) - offset;
+    }
+}

--- a/Source/Lib/Encoder/ASM_AVX2/NltEnc_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/NltEnc_avx2.h
@@ -16,6 +16,8 @@ void image_shift_avx2(uint16_t* out_coeff_16bit, int32_t* in_coeff_32bit, uint32
 void linear_input_scaling_line_8bit_avx2(const uint8_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset);
 void linear_input_scaling_line_16bit_avx2(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
                                           uint8_t bit_depth);
+void linear_input_scaling_line_16bit_msb_avx2(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                              uint8_t bit_depth);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
@@ -240,6 +240,26 @@ void linear_input_scaling_line_16bit_avx512(const uint16_t* src, int32_t* dst, u
     }
 }
 
+/* MSB-aligned: no masking needed, values use the full 16-bit range so zero-extend (not sign-extend). */
+void linear_input_scaling_line_16bit_msb_avx512(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                                uint8_t bit_depth) {
+    (void)bit_depth;
+    int simd_batch = w / 16;
+    int remaining = w % 16;
+    __m512i reg_offset = _mm512_set1_epi32(offset);
+
+    for (int i = 0; i < simd_batch; i++) {
+        __m512i reg = _mm512_cvtepu16_epi32(_mm256_loadu_si256((__m256i*)src));
+        __m512i result = _mm512_sub_epi32(_mm512_slli_epi32(reg, shift), reg_offset);
+        _mm512_storeu_si512(dst, result);
+        src += 16;
+        dst += 16;
+    }
+    for (int i = 0; i < remaining; i++) {
+        dst[i] = ((uint32_t)src[i] << shift) - offset;
+    }
+}
+
 /*Optimization Vertical lines loops to AVX*/
 void transform_vertical_loop_hf_line_0_avx512(uint32_t width, int32_t* out_hf, const int32_t* line_0, const int32_t* line_1) {
     uint32_t i = 0;

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.h
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.h
@@ -17,6 +17,8 @@ void dwt_horizontal_line_avx512(int32_t* out_lf, int32_t* out_hf, const int32_t*
 void linear_input_scaling_line_8bit_avx512(const uint8_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset);
 void linear_input_scaling_line_16bit_avx512(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
                                             uint8_t bit_depth);
+void linear_input_scaling_line_16bit_msb_avx512(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                                uint8_t bit_depth);
 void image_shift_avx512(uint16_t* out_coeff_16bit, int32_t* in_coeff_32bit, uint32_t width, int32_t shift, int32_t offset);
 
 /*Optimization Vertical lines loops to AVX*/

--- a/Source/Lib/Encoder/Codec/EncHandle.c
+++ b/Source/Lib/Encoder/Codec/EncHandle.c
@@ -140,6 +140,14 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
         }
         return SvtJxsErrorBadParameter;
     }
+    enc_common->picture_header_dynamic.hdr_input_msb_aligned = config_struct->input_bit_depth_msb_aligned;
+    if (enc_common->picture_header_dynamic.hdr_input_msb_aligned != 0 &&
+        enc_common->picture_header_dynamic.hdr_input_msb_aligned != 1) {
+        if (config_struct->verbose >= VERBOSE_ERRORS) {
+            fprintf(stderr, "Unrecognized input_bit_depth_msb_aligned, expected: 0 or 1\n");
+        }
+        return SvtJxsErrorBadParameter;
+    }
     enc_common->colour_format = config_struct->colour_format;
     SvtJxsErrorType_t return_error = format_get_sampling_factory(
         enc_common->colour_format, &num_comp, sx, sy, config_struct->verbose);

--- a/Source/Lib/Encoder/Codec/InitStageProcess.c
+++ b/Source/Lib/Encoder/Codec/InitStageProcess.c
@@ -84,10 +84,12 @@ SvtJxsErrorType_t init_stage_context_ctor(ThreadContext_t *thread_contxt_ptr, sv
 
 #ifndef NDEBUG
 static int32_t validate_yuv_range(pi_t *pi, svt_jpeg_xs_image_buffer_t *image_buffer, uint8_t input_bit_depth, uint64_t frame,
-                                  ColourFormat_t format) {
+                                  ColourFormat_t format, uint8_t msb_aligned) {
     /*Check input YUV*/
     if (input_bit_depth > 8) {
-        uint32_t test_input_range = ~(((uint32_t)1 << input_bit_depth) - 1);
+        /* LSB-aligned: bits above input_bit_depth must be zero. MSB-aligned: bits below (16-input_bit_depth) must be zero. */
+        uint32_t test_input_range = msb_aligned ? (((uint32_t)1 << (16 - input_bit_depth)) - 1)
+                                                 : ~(((uint32_t)1 << input_bit_depth) - 1);
         uint32_t comps_num = pi->comps_num;
         if (format > COLOUR_FORMAT_PACKED_MIN && format < COLOUR_FORMAT_PACKED_MAX) {
             comps_num = 1;
@@ -204,8 +206,12 @@ void *init_stage_kernel(void *input_ptr) {
         uint8_t input_bit_depth = (uint8_t)enc_api_prv->enc_common.bit_depth;
         if (input_bit_depth > 8) {
             svt_jpeg_xs_image_buffer_t *image_buffer = &pcs_ptr->enc_input.image;
-            validate_yuv_range(
-                pi, image_buffer, input_bit_depth, input_item->frame_number, enc_api_prv->enc_common.colour_format);
+            validate_yuv_range(pi,
+                               image_buffer,
+                               input_bit_depth,
+                               input_item->frame_number,
+                               enc_api_prv->enc_common.colour_format,
+                               enc_api_prv->enc_common.picture_header_dynamic.hdr_input_msb_aligned);
         }
 #endif
 

--- a/Source/Lib/Encoder/Codec/NltEnc.c
+++ b/Source/Lib/Encoder/Codec/NltEnc.c
@@ -44,6 +44,15 @@ void linear_input_scaling_line_16bit_c(const uint16_t* src, int32_t* dst, uint32
     }
 }
 
+/* MSB-aligned: sample occupies the high bits (v << (16-bit_depth)), no masking needed. */
+void linear_input_scaling_line_16bit_msb_c(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                           uint8_t bit_depth) {
+    (void)bit_depth;
+    for (uint32_t j = 0; j < w; j++) {
+        dst[j] = ((uint32_t)src[j] << shift) - offset;
+    }
+}
+
 void linear_input_scaling_line(const void* src, int32_t* dst, uint32_t width, uint8_t input_bit_depth, uint8_t shift,
                                int32_t offset) {
     if (input_bit_depth <= 8) {
@@ -57,6 +66,23 @@ void linear_input_scaling_line(const void* src, int32_t* dst, uint32_t width, ui
 
 void nlt_input_scaling_line(const void* src, int32_t* dst, uint32_t width, picture_header_dynamic_t* hdr,
                             uint8_t input_bit_depth) {
+    if (hdr->hdr_input_msb_aligned && input_bit_depth > 8) {
+        /* Bw is fixed (WAVELET_IN_DEPTH_BW_DEFAULT=20), so shift=Bw-16 is a constant, depth-independent
+         * value: v_msb = v << (16-depth), so (v_msb << (Bw-16)) == (v << (Bw-depth)), matching the LSB path. */
+        const uint8_t shift = hdr->hdr_Bw - 16;
+        const int32_t offset = 1 << (hdr->hdr_Bw - 1);
+        switch (hdr->hdr_Tnlt) {
+        case 0:
+            linear_input_scaling_line_16bit_msb((const uint16_t*)src, dst, width, shift, offset, input_bit_depth);
+            break;
+        case 1:
+        case 2:
+        default:
+            assert(0);
+            break;
+        }
+        return;
+    }
     const uint8_t shift = hdr->hdr_Bw - input_bit_depth;
     const int32_t offset = 1 << (hdr->hdr_Bw - 1);
     switch (hdr->hdr_Tnlt) {

--- a/Source/Lib/Encoder/Codec/NltEnc.h
+++ b/Source/Lib/Encoder/Codec/NltEnc.h
@@ -18,6 +18,8 @@ void nlt_input_scaling_line(const void* src, int32_t* dst, uint32_t width, pictu
 void linear_input_scaling_line_8bit_c(const uint8_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset);
 void linear_input_scaling_line_16bit_c(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
                                        uint8_t bit_depth);
+void linear_input_scaling_line_16bit_msb_c(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
+                                           uint8_t bit_depth);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -140,6 +140,10 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
                     linear_input_scaling_line_16bit_c,
                     linear_input_scaling_line_16bit_avx2,
                     linear_input_scaling_line_16bit_avx512);
+    SET_AVX2_AVX512(linear_input_scaling_line_16bit_msb,
+                    linear_input_scaling_line_16bit_msb_c,
+                    linear_input_scaling_line_16bit_msb_avx2,
+                    linear_input_scaling_line_16bit_msb_avx512);
 
     SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, NULL, pack_data_single_group_avx512);
     SET_SSE2(gc_precinct_stage_scalar_loop, gc_precinct_stage_scalar_loop_c, gc_precinct_stage_scalar_loop_ASM);

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
@@ -47,6 +47,8 @@ RTCD_EXTERN void (*quantization)(uint16_t* coeff_16bit, uint32_t size, uint8_t* 
 RTCD_EXTERN void (*linear_input_scaling_line_8bit)(const uint8_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset);
 RTCD_EXTERN void (*linear_input_scaling_line_16bit)(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset,
                                                     uint8_t bit_depth);
+RTCD_EXTERN void (*linear_input_scaling_line_16bit_msb)(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift,
+                                                        int32_t offset, uint8_t bit_depth);
 
 RTCD_EXTERN void (*pack_data_single_group)(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t gcli, uint8_t gtli);
 RTCD_EXTERN void (*gc_precinct_stage_scalar_loop)(uint32_t line_groups_num, uint16_t* coeff_data_ptr_16bit,

--- a/documentation/decoder/DecoderSnippets.md
+++ b/documentation/decoder/DecoderSnippets.md
@@ -1,21 +1,22 @@
-### Decoder configuration parameters overview (svt_jpeg_xs_decoder_api_t)
+# Decoder configuration parameters overview (svt_jpeg_xs_decoder_api_t)
 
 param | description | mandatory/optional | default | Accepted values
 -- | -- | -- | -- | --
 use_cpu_flags | Performance: limit assembly instruction set used by decoder,   please refer to CPU_FLAGS | optional | CPU_FLAGS_ALL | CPU_FLAGS_C, CPU_FLAGS_MMX, CPU_FLAGS_SSE ,CPU_FLAGS_SSE2 ,CPU_FLAGS_SSE3 ,CPU_FLAGS_SSSE3 ,CPU_FLAGS_SSE4_1 ,CPU_FLAGS_SSE4_2 ,CPU_FLAGS_AVX ,CPU_FLAGS_AVX2 ,CPU_FLAGS_ALL (avx512)
 threads_num | Performance: Number of thread decoder can create, 0 mean   minimum number of threads is created | optional | 0 | <0;N/A>
 verbose | Limit number of logs in console, please refer to VerboseMessages enum | optional | VERBOSE_SYSTEM_INFO | VERBOSE_NONE, VERBOSE_ERRORS, VERBOSE_SYSTEM_INFO, VERBOSE_SYSTEM_INFO_ALL, VERBOSE_WARNINGS, VERBOSE_INFO_MULTITHREADING,VERBOSE_INFO_FULL
-packetization_mode | Specify how bitstream is passed to decoder | optional| 0 | 1(multiple packets per frame), 0(single packet per frame)
-callback_send_data_available |   | optional | NULL | function pointer
-callback_send_data_available_context |   | optional | NULL |  
-callback_get_data_available |   | optional | NULL | function pointer
-callback_get_data_available_context |   | optional | NULL |  
+packetization_mode | Specify how bitstream is passed to decoder | optional | 0 | 1(multiple packets per frame), 0(single packet per frame)
+output_bit_depth_msb_aligned | Non-standard, host-side only (not signalled in bitstream): when set, 10/12-bit output samples are MSB-aligned in each 16-bit word (`v << (16-output_bit_depth)`) instead of LSB-aligned (`v`). Must match the encoder's input_bit_depth_msb_aligned setting. | optional | 0 | 0(LSB-aligned), 1(MSB-aligned)
+callback_send_data_available | Callback invoked when the decoder can accept new input data | optional | NULL | function pointer
+callback_send_data_available_context | User context pointer passed to callback_send_data_available | optional | NULL | N/A
+callback_get_data_available | Callback invoked when a decoded frame is available | optional | NULL | function pointer
+callback_get_data_available_context | User context pointer passed to callback_get_data_available | optional | NULL | N/A
 
-### Decoder simplified usage
+## Decoder simplified usage
 
-Code listed below is also kept [here](../../Source/App/SampleDecoder/main.c)
+Code listed below is also kept in [Source/App/SampleDecoder/main.c](../../Source/App/SampleDecoder/main.c)
 
-```
+```c
 #include <SvtJpegxsDec.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -143,6 +144,6 @@ int32_t main(int32_t argc, char* argv[]) {
 
 ## Notes
 
-The information in this document was compiled at <mark>v0.10</mark> of the code and may not
+The information in this document was compiled at `v0.10` of the code and may not
 reflect the latest status of the design. For the most up-to-date
 settings and implementation, it's recommended to visit the specific section of the code.

--- a/documentation/encoder/EncoderSnippets.md
+++ b/documentation/encoder/EncoderSnippets.md
@@ -7,6 +7,7 @@ param | description | mandatory/optional | default | Accepted values
 source_width | Width of the image in sample grid positions | mandatory | N/A | <64; 65 535>
 source_height | Height of the image in sample   grid positions | mandatory | N/A | <64; 65 535>
 input_bit_depth | Specifies the bit depth of input video. | mandatory | N/A | 8(8 bit), 10(10 bit)
+input_bit_depth_msb_aligned | Non-standard, host-side only (not signalled in bitstream): when set, 10/12-bit input samples are MSB-aligned in each 16-bit word (`v << (16-input_bit_depth)`) instead of LSB-aligned (`v`). Must match the decoder's output_bit_depth_msb_aligned setting. | optional | 0 | 0(LSB-aligned), 1(MSB-aligned)
 colour_format | Specifies the format of input video,   please refer to ColourFormat_t enum | mandatory | N/A | Tested: (COLOUR_FORMAT_PLANAR_YUV420, COLOUR_FORMAT_PLANAR_YUV422, COLOUR_FORMAT_PLANAR_YUV444_OR_RGB),   experimental: (COLOUR_FORMAT_YUV400)
 bpp_numerator | Bitrate: bits per pixel numerator,   BPP=(bpp_numerator/bpp_denominator), Per frame bitrate is equal to (width \* height \* bpp_numerator / bpp_denominator) | mandatory | N/A | <1;N/A>
 bpp_denominator | Bitrate: bits per pixel denominator, required if non-integer   BPP is required | optional | 1 | <1; N/A>

--- a/ffmpeg-plugin/8.1/0010-Add-msb-aligned-support.patch
+++ b/ffmpeg-plugin/8.1/0010-Add-msb-aligned-support.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Grzegorz rys <grzegorz.rys@intel.com>
+Date: Tue, 4 Aug 2026 13:59:59 +0200
+Subject: [PATCH] avcodec/libsvtjpegxs{enc,dec}: add msb_aligned option for
+ MSB-aligned samples
+
+SVT-JPEG-XS now supports a non-standard, host-side-only convention where
+10/12-bit samples occupy the high bits of each 16-bit word instead of the
+low bits (input_bit_depth_msb_aligned / output_bit_depth_msb_aligned in
+the library API). This is never signalled in the bitstream - both sides
+must be configured consistently by the caller.
+
+Expose this via a new private "msb_aligned" boolean option on both the
+encoder and decoder, mirroring the existing coding-raw/cap-compat style
+of wiring a private option straight into the corresponding
+svt_jpeg_xs_encoder_api_t/svt_jpeg_xs_decoder_api_t field.
+
+Verified: encoding a 10-bit YUV422 buffer pre-shifted into the high bits
+of each 16-bit word with -msb_aligned 1, then decoding with
+-msb_aligned 1, reproduces the exact same pixel values (verified via a
+plain LSB round-trip of the same content, right-shifted by 6 to match).
+Low 6 bits of every decoded sample are zero as expected.
+---
+ libavcodec/libsvtjpegxsdec.c | 4 ++++
+ libavcodec/libsvtjpegxsenc.c | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/libavcodec/libsvtjpegxsdec.c b/libavcodec/libsvtjpegxsdec.c
+index 2d18a86711..0f79e986ec 100644
+--- a/libavcodec/libsvtjpegxsdec.c
++++ b/libavcodec/libsvtjpegxsdec.c
+@@ -49,6 +49,7 @@ typedef struct SvtJpegXsDecodeContext {
+     uint32_t buffer_filled_len;
+     uint8_t* bitstream_buffer;
+     int proxy_mode;
++    int msb_aligned;
+ } SvtJpegXsDecodeContext;
+ 
+ 
+@@ -292,6 +293,7 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
+     svt_dec->decoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+     svt_dec->decoder.use_cpu_flags = CPU_FLAGS_ALL;
+     svt_dec->decoder.packetization_mode = 0;
++    svt_dec->decoder.output_bit_depth_msb_aligned = svt_dec->msb_aligned ? 1 : 0;
+ 
+     av_log(NULL, AV_LOG_DEBUG, "svt_jpegxs_dec_init called\n");
+ 
+@@ -302,6 +304,8 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
+ #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
+ static const AVOption svtjpegxs_dec_options[] = {
+     {"proxy-mode", "Resolution scaling mode: 0-full, 1-half, 2-quarter", OFFSET(proxy_mode), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 2, VE},
++    {"msb_aligned", "Non-standard: output 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
++                    "Must match the encoder's msb_aligned setting.", OFFSET(msb_aligned), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, VE},
+     {NULL},
+ };
+ 
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index a794993ab8..a25d37e4ac 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -49,6 +49,7 @@ typedef struct SvtJpegXsEncodeContext {
+     int coding_vpred;
+     int coding_raw;
+     int cap_compat;
++    int msb_aligned;
+ 
+     svt_jpeg_xs_encoder_api_t encoder;
+     int bitstream_frame_size;
+@@ -314,6 +315,7 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+         }
+         svt_enc->encoder.level_plev_override = (uint16_t)avctx->level;
+     }
++    svt_enc->encoder.input_bit_depth_msb_aligned = svt_enc->msb_aligned ? 1 : 0;
+     if (svt_enc->slice_height > 0) {
+         svt_enc->encoder.slice_height = svt_enc->slice_height;
+     }
+@@ -353,6 +355,8 @@ static const AVOption svtjpegxs_enc_options[] = {
+       { "no_coeffs",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+     { "coding-raw",   "Enable packet-based raw-mode coding (disable for legacy-decoder compatibility)", OFFSET(coding_raw),   AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
+     { "cap-compat",   "Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required", OFFSET(cap_compat), AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
++    { "msb_aligned",  "Non-standard: input 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
++                      "Must match the decoder's msb_aligned setting.", OFFSET(msb_aligned), AV_OPT_TYPE_BOOL, {.i64 = 0 }, 0, 1, VE },
+       { "light422",        NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x1500}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },
+       { "light444",        NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x1A00}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },
+       { "lightsubline422", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x2500}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },

--- a/ffmpeg-plugin/9.0/0011-Add-msb-aligned-support.patch
+++ b/ffmpeg-plugin/9.0/0011-Add-msb-aligned-support.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Grzegorz rys <grzegorz.rys@intel.com>
+Date: Tue, 4 Aug 2026 14:04:14 +0200
+Subject: [PATCH] avcodec/libsvtjpegxs{enc,dec}: add msb_aligned option for
+ MSB-aligned samples
+
+SVT-JPEG-XS now supports a non-standard, host-side-only convention where
+10/12-bit samples occupy the high bits of each 16-bit word instead of the
+low bits (input_bit_depth_msb_aligned / output_bit_depth_msb_aligned in
+the library API). This is never signalled in the bitstream - both sides
+must be configured consistently by the caller.
+
+Expose this via a new private "msb_aligned" boolean option on both the
+encoder and decoder, mirroring the existing coding-raw/cap-compat style
+of wiring a private option straight into the corresponding
+svt_jpeg_xs_encoder_api_t/svt_jpeg_xs_decoder_api_t field.
+
+Verified: encoding a 10-bit YUV422 buffer pre-shifted into the high bits
+of each 16-bit word with -msb_aligned 1, then decoding with
+-msb_aligned 1, reproduces the exact same pixel values (verified via a
+plain LSB round-trip of the same content, right-shifted by 6 to match).
+Low 6 bits of every decoded sample are zero as expected.
+---
+ libavcodec/libsvtjpegxsdec.c | 4 ++++
+ libavcodec/libsvtjpegxsenc.c | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/libavcodec/libsvtjpegxsdec.c b/libavcodec/libsvtjpegxsdec.c
+index 2d18a86711..0f79e986ec 100644
+--- a/libavcodec/libsvtjpegxsdec.c
++++ b/libavcodec/libsvtjpegxsdec.c
+@@ -49,6 +49,7 @@ typedef struct SvtJpegXsDecodeContext {
+     uint32_t buffer_filled_len;
+     uint8_t* bitstream_buffer;
+     int proxy_mode;
++    int msb_aligned;
+ } SvtJpegXsDecodeContext;
+ 
+ 
+@@ -292,6 +293,7 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
+     svt_dec->decoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
+     svt_dec->decoder.use_cpu_flags = CPU_FLAGS_ALL;
+     svt_dec->decoder.packetization_mode = 0;
++    svt_dec->decoder.output_bit_depth_msb_aligned = svt_dec->msb_aligned ? 1 : 0;
+ 
+     av_log(NULL, AV_LOG_DEBUG, "svt_jpegxs_dec_init called\n");
+ 
+@@ -302,6 +304,8 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
+ #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
+ static const AVOption svtjpegxs_dec_options[] = {
+     {"proxy-mode", "Resolution scaling mode: 0-full, 1-half, 2-quarter", OFFSET(proxy_mode), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 2, VE},
++    {"msb_aligned", "Non-standard: output 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
++                    "Must match the encoder's msb_aligned setting.", OFFSET(msb_aligned), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, VE},
+     {NULL},
+ };
+ 
+diff --git a/libavcodec/libsvtjpegxsenc.c b/libavcodec/libsvtjpegxsenc.c
+index d91d0c8d76..e1a5e87fa6 100644
+--- a/libavcodec/libsvtjpegxsenc.c
++++ b/libavcodec/libsvtjpegxsenc.c
+@@ -49,6 +49,7 @@ typedef struct SvtJpegXsEncodeContext {
+     int coding_vpred;
+     int coding_raw;
+     int cap_compat;
++    int msb_aligned;
+ 
+     svt_jpeg_xs_encoder_api_t encoder;
+     int bitstream_frame_size;
+@@ -314,6 +315,7 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
+         }
+         svt_enc->encoder.level_plev_override = (uint16_t)avctx->level;
+     }
++    svt_enc->encoder.input_bit_depth_msb_aligned = svt_enc->msb_aligned ? 1 : 0;
+     if (svt_enc->slice_height > 0) {
+         svt_enc->encoder.slice_height = svt_enc->slice_height;
+     }
+@@ -353,6 +355,8 @@ static const AVOption svtjpegxs_enc_options[] = {
+       { "no_coeffs",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 2}, INT_MIN, INT_MAX, VE, .unit = "coding-vpred" },
+     { "coding-raw",   "Enable packet-based raw-mode coding (disable for legacy-decoder compatibility)", OFFSET(coding_raw),   AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
+     { "cap-compat",   "Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required", OFFSET(cap_compat), AV_OPT_TYPE_BOOL, {.i64 = -1 }, -1, 1, VE },
++    { "msb_aligned",  "Non-standard: input 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
++                      "Must match the decoder's msb_aligned setting.", OFFSET(msb_aligned), AV_OPT_TYPE_BOOL, {.i64 = 0 }, 0, 1, VE },
+       { "light422",        NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x1500}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },
+       { "light444",        NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x1A00}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },
+       { "lightsubline422", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = 0x2500}, INT_MIN, INT_MAX, VE, .unit = "avctx.profile" },

--- a/ffmpeg-plugin/libsvtjpegxsdec.c
+++ b/ffmpeg-plugin/libsvtjpegxsdec.c
@@ -29,6 +29,7 @@ typedef struct SvtJpegXsDecodeContext {
     uint32_t buffer_filled_len;
     uint8_t* bitstream_buffer;
     int proxy_mode;
+    int msb_aligned;
 } SvtJpegXsDecodeContext;
 
 
@@ -272,6 +273,7 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
     svt_dec->decoder.threads_num = FFMIN(avctx->thread_count ? avctx->thread_count : av_cpu_count(), 64);
     svt_dec->decoder.use_cpu_flags = CPU_FLAGS_ALL;
     svt_dec->decoder.packetization_mode = 0;
+    svt_dec->decoder.output_bit_depth_msb_aligned = svt_dec->msb_aligned ? 1 : 0;
 
     av_log(NULL, AV_LOG_DEBUG, "svt_jpegxs_dec_init called\n");
 
@@ -282,6 +284,15 @@ static av_cold int svt_jpegxs_dec_init(AVCodecContext* avctx) {
 #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_DECODING_PARAM
 static const AVOption svtjpegxs_dec_options[] = {
     {"proxy-mode", "Resolution scaling mode: 0-full, 1-half, 2-quarter", OFFSET(proxy_mode), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 2, VE},
+    {"msb_aligned",
+     "Non-standard: output 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
+     "Must match the encoder's msb_aligned setting.",
+     OFFSET(msb_aligned),
+     AV_OPT_TYPE_BOOL,
+     {.i64 = 0},
+     0,
+     1,
+     VE},
     {NULL},
 };
 

--- a/ffmpeg-plugin/libsvtjpegxsenc.c
+++ b/ffmpeg-plugin/libsvtjpegxsenc.c
@@ -29,6 +29,7 @@ typedef struct SvtJpegXsEncodeContext {
     int coding_vpred;
     int coding_raw;
     int cap_compat;
+    int msb_aligned;
 
     svt_jpeg_xs_encoder_api_t encoder;
     int bitstream_frame_size;
@@ -300,6 +301,7 @@ static av_cold int svt_jpegxs_enc_init(AVCodecContext* avctx) {
         }
         svt_enc->encoder.level_plev_override = (uint16_t)avctx->level;
     }
+    svt_enc->encoder.input_bit_depth_msb_aligned = svt_enc->msb_aligned ? 1 : 0;
     if (svt_enc->slice_height > 0) {
         svt_enc->encoder.slice_height = svt_enc->slice_height;
     }
@@ -381,6 +383,15 @@ static const AVOption svtjpegxs_enc_options[] = {
      AV_OPT_TYPE_BOOL,
      {.i64 = -1},
      -1,
+     1,
+     VE},
+    {"msb_aligned",
+     "Non-standard: input 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. "
+     "Must match the decoder's msb_aligned setting.",
+     OFFSET(msb_aligned),
+     AV_OPT_TYPE_BOOL,
+     {.i64 = 0},
+     0,
      1,
      VE},
     /* Named Ppih (profile) values for the generic "-profile" option (see avctx->profile in

--- a/ffmpeg-plugin/readme.md
+++ b/ffmpeg-plugin/readme.md
@@ -205,6 +205,7 @@ coding-sigf|optional|(default:on), 0(off), 1(on)|Coding feature: Significance co
 coding-vpred|optional|(default:off), 0(off), 1(on)|Coding feature: Vertical-prediction
 coding-raw|optional|(default:auto/enabled), true(enabled), false(disable for legacy-decoder compatibility)|Coding feature: packet-based raw-mode coding
 cap-compat|optional|(default:auto/disabled), true(enabled), false(disabled)|Emit an empty CAP marker for legacy-decoder compatibility when no capability bit is required
+msb_aligned|optional|(default:false), true, false|Non-standard: input 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. Must match the decoder's msb_aligned setting
 
 ### Stream profile (Ppih) and level (Plev)
 
@@ -245,6 +246,10 @@ Name|mandatory/optional|Accepted values|description
 --|--|--|--
 threads|optional|Any integer in range< 1;64>|Number of threads decoder can create
 proxy-mode|optional|(default:full), 0(full), 1(half), 2(quarter)|Specify resolution scaling mode
+msb_aligned|optional|(default:false), true, false|Non-standard: output 10/12-bit samples are MSB-aligned in each 16-bit word instead of LSB-aligned. Must match the encoder's msb_aligned setting
+
+Note: private decoder options (e.g. `-msb_aligned`, `-threads`) must be placed BEFORE `-i`, not
+after - placed after `-i` they are silently ignored (ffmpeg only logs a warning, no error).
 
 ### Encoding raw video
 

--- a/tests/UnitTests/TestDwtFrame.cc
+++ b/tests/UnitTests/TestDwtFrame.cc
@@ -419,6 +419,7 @@ void transform_component_test_V0(const pi_t* pi, const pi_enc_t* pi_enc, uint32_
     int decom_v = component->decom_v;
 
     picture_header_dynamic_t hdr_dynamic;
+    memset(&hdr_dynamic, 0, sizeof(hdr_dynamic));
     hdr_dynamic.hdr_Tnlt = 0; //linear
     hdr_dynamic.hdr_Bw = param_Bw;
     hdr_dynamic.hdr_Fq = param_Fq;
@@ -546,6 +547,7 @@ void transform_component_test_V1(const pi_t* pi, const pi_enc_t* pi_enc, uint32_
         line_x[2] = (int32_t*)malloc(pi->width * sizeof(int32_t));
 
         picture_header_dynamic_t hdr_dynamic;
+        memset(&hdr_dynamic, 0, sizeof(hdr_dynamic));
         hdr_dynamic.hdr_Tnlt = 0; //linear
         hdr_dynamic.hdr_Bw = param_Bw;
         hdr_dynamic.hdr_Fq = param_Fq;
@@ -742,6 +744,7 @@ void transform_component_test_V2(const pi_t* pi, const pi_enc_t* pi_enc, uint32_
         int32_t* line_6 = line_x[4]; //buffers_input_unpack + (0 + 0) * plane_width;
 
         picture_header_dynamic_t hdr_dynamic;
+        memset(&hdr_dynamic, 0, sizeof(hdr_dynamic));
         hdr_dynamic.hdr_Tnlt = 0; //linear
         hdr_dynamic.hdr_Bw = param_Bw;
         hdr_dynamic.hdr_Fq = param_Fq;

--- a/tests/UnitTests/TestInvDwtFrame.cc
+++ b/tests/UnitTests/TestInvDwtFrame.cc
@@ -574,7 +574,7 @@ void transform_components_test(const pi_t* pi, int16_t* buffer_in[MAX_COMPONENTS
                         }
                         else {
                             uint16_t* out_buf_16 = ((uint16_t*)out_buf) + component_line_idx * out_stride;
-                            nlt_inverse_transform_line_16bit(in, bit_depth, &picture_header_dynamic, out_buf_16, width);
+                            nlt_inverse_transform_line_16bit(in, bit_depth, &picture_header_dynamic, out_buf_16, width, 0);
                         }
                         component_line_idx++;
                     }

--- a/tests/UnitTests/TestMsbAligned.cc
+++ b/tests/UnitTests/TestMsbAligned.cc
@@ -1,0 +1,262 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "SvtJpegxs.h"
+#include "SvtJpegxsEnc.h"
+#include "SvtJpegxsDec.h"
+#include "SvtJpegxsImageBufferTools.h"
+#include "random.h"
+
+namespace {
+
+/* Encodes a single frame of pseudo-random 10/12-bit content and returns the produced codestream,
+ * plus the exact input pixel buffer used (so the caller can compare it against decoded output). */
+std::vector<uint8_t> encode_single_frame(uint32_t width, uint32_t height, uint8_t bit_depth, uint8_t msb_aligned,
+                                         svt_jpeg_xs_image_config_t *out_image_config) {
+    svt_jpeg_xs_encoder_api_t enc;
+    EXPECT_EQ(svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc),
+              SvtJxsErrorNone);
+    enc.verbose = VERBOSE_NONE;
+    enc.source_width = width;
+    enc.source_height = height;
+    enc.input_bit_depth = bit_depth;
+    enc.colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+    enc.bpp_numerator = 4;
+    enc.bpp_denominator = 1;
+    enc.input_bit_depth_msb_aligned = msb_aligned;
+
+    uint32_t bytes_per_frame = 0;
+    EXPECT_EQ(svt_jpeg_xs_encoder_get_image_config(
+                  SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc, out_image_config, &bytes_per_frame),
+              SvtJxsErrorNone);
+
+    svt_jpeg_xs_image_buffer_t *in_buf = svt_jpeg_xs_image_buffer_alloc(out_image_config);
+    EXPECT_NE(in_buf, nullptr);
+
+    svt_jxs_test_tool::SVTRandom rnd(32, false);
+    for (int32_t c = 0; c < out_image_config->components_num; ++c) {
+        uint16_t *plane = (uint16_t *)in_buf->data_yuv[c];
+        uint32_t plane_w = out_image_config->components[c].width;
+        uint32_t plane_h = out_image_config->components[c].height;
+        uint32_t stride = in_buf->stride[c];
+        for (uint32_t y = 0; y < plane_h; y++) {
+            for (uint32_t x = 0; x < plane_w; x++) {
+                uint16_t pixel = (uint16_t)(rnd.Rand16() % (1 << bit_depth));
+                plane[y * stride + x] = msb_aligned ? (uint16_t)(pixel << (16 - bit_depth)) : pixel;
+            }
+        }
+    }
+
+    EXPECT_EQ(svt_jpeg_xs_encoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc), SvtJxsErrorNone);
+
+    svt_jpeg_xs_bitstream_buffer_t out_buf;
+    out_buf.allocation_size = bytes_per_frame * 2 + 4096;
+    out_buf.used_size = 0;
+    out_buf.buffer = (uint8_t *)malloc(out_buf.allocation_size);
+    EXPECT_NE(out_buf.buffer, nullptr);
+
+    svt_jpeg_xs_frame_t enc_input;
+    enc_input.bitstream = out_buf;
+    enc_input.image = *in_buf;
+    enc_input.user_prv_ctx_ptr = NULL;
+    EXPECT_EQ(svt_jpeg_xs_encoder_send_picture(&enc, &enc_input, 1 /*blocking*/), SvtJxsErrorNone);
+
+    svt_jpeg_xs_frame_t enc_output;
+    memset(&enc_output, 0, sizeof(enc_output));
+    EXPECT_EQ(svt_jpeg_xs_encoder_get_packet(&enc, &enc_output, 1 /*blocking*/), SvtJxsErrorNone);
+
+    std::vector<uint8_t> result(enc_output.bitstream.buffer, enc_output.bitstream.buffer + enc_output.bitstream.used_size);
+
+    svt_jpeg_xs_encoder_close(&enc);
+    svt_jpeg_xs_image_buffer_free(in_buf);
+    free(out_buf.buffer);
+    return result;
+}
+
+/* Decodes a single frame and returns the output pixel buffer (caller must free with svt_jpeg_xs_image_buffer_free). */
+svt_jpeg_xs_image_buffer_t *decode_single_frame(const std::vector<uint8_t> &bitstream, uint8_t msb_aligned) {
+    svt_jpeg_xs_decoder_api_t dec;
+    memset(&dec, 0, sizeof(dec));
+    dec.verbose = VERBOSE_NONE;
+    dec.output_bit_depth_msb_aligned = msb_aligned;
+
+    svt_jpeg_xs_image_config_t image_config;
+    EXPECT_EQ(svt_jpeg_xs_decoder_init(SVT_JPEGXS_API_VER_MAJOR,
+                                       SVT_JPEGXS_API_VER_MINOR,
+                                       &dec,
+                                       bitstream.data(),
+                                       bitstream.size(),
+                                       &image_config),
+              SvtJxsErrorNone);
+
+    svt_jpeg_xs_image_buffer_t *out_buf = svt_jpeg_xs_image_buffer_alloc(&image_config);
+    EXPECT_NE(out_buf, nullptr);
+
+    svt_jpeg_xs_frame_t dec_input;
+    dec_input.user_prv_ctx_ptr = NULL;
+    dec_input.image = *out_buf;
+    dec_input.bitstream.buffer = (uint8_t *)bitstream.data();
+    dec_input.bitstream.used_size = (uint32_t)bitstream.size();
+    EXPECT_EQ(svt_jpeg_xs_decoder_send_frame(&dec, &dec_input, 1 /*blocking*/), SvtJxsErrorNone);
+
+    svt_jpeg_xs_frame_t dec_output;
+    EXPECT_EQ(svt_jpeg_xs_decoder_get_frame(&dec, &dec_output, 1 /*blocking*/), SvtJxsErrorNone);
+
+    svt_jpeg_xs_decoder_close(&dec);
+    return out_buf;
+}
+
+} // namespace
+
+/* Full round-trip: encode with input_bit_depth_msb_aligned=1, decode with output_bit_depth_msb_aligned=1,
+ * verify the low (16-depth) bits of every output sample are zero (proves the pipeline stayed MSB-aligned
+ * end-to-end, not just at the API boundary). Uses default Tnlt=0 (linear), the only mode this encoder
+ * currently produces. */
+TEST(MsbAligned, EncodeMsbDecodeMsbRoundTrip) {
+    for (uint8_t bit_depth = 10; bit_depth <= 12; bit_depth += 2) {
+        svt_jpeg_xs_image_config_t image_config;
+        std::vector<uint8_t> bitstream = encode_single_frame(64, 64, bit_depth, /*msb_aligned=*/1, &image_config);
+        ASSERT_GT(bitstream.size(), 0u);
+
+        svt_jpeg_xs_image_buffer_t *out_buf = decode_single_frame(bitstream, /*msb_aligned=*/1);
+        uint16_t low_bits_mask = (uint16_t)((1 << (16 - bit_depth)) - 1);
+        for (int32_t c = 0; c < image_config.components_num; ++c) {
+            uint16_t *plane = (uint16_t *)out_buf->data_yuv[c];
+            uint32_t plane_w = image_config.components[c].width;
+            uint32_t plane_h = image_config.components[c].height;
+            uint32_t stride = out_buf->stride[c];
+            for (uint32_t y = 0; y < plane_h; y++) {
+                for (uint32_t x = 0; x < plane_w; x++) {
+                    ASSERT_EQ(plane[y * stride + x] & low_bits_mask, 0)
+                        << "bit_depth=" << (int)bit_depth << " comp=" << c << " (" << x << "," << y << ") not MSB-aligned";
+                }
+            }
+        }
+        svt_jpeg_xs_image_buffer_free(out_buf);
+    }
+}
+
+/* Cross-check: encoding the same content once MSB-aligned and once LSB-aligned must produce byte-identical
+ * codestreams (the flag only changes host-side buffer interpretation, never the coded bitstream). */
+TEST(MsbAligned, MsbAndLsbInputProduceIdenticalBitstream) {
+    const uint32_t width = 64, height = 64;
+    const uint8_t bit_depth = 10;
+
+    svt_jpeg_xs_image_config_t image_config_lsb;
+    svt_jxs_test_tool::SVTRandom rnd(32, false);
+
+    svt_jpeg_xs_encoder_api_t enc_probe;
+    svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc_probe);
+    enc_probe.source_width = width;
+    enc_probe.source_height = height;
+    enc_probe.input_bit_depth = bit_depth;
+    enc_probe.colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+    enc_probe.bpp_numerator = 4;
+    enc_probe.bpp_denominator = 1;
+    uint32_t bytes_per_frame = 0;
+    svt_jpeg_xs_encoder_get_image_config(
+        SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc_probe, &image_config_lsb, &bytes_per_frame);
+
+    /* Build one shared "logical" pixel buffer, then derive matching LSB- and MSB-packed encoder inputs from it. */
+    std::vector<std::vector<uint16_t>> logical(image_config_lsb.components_num);
+    for (int32_t c = 0; c < image_config_lsb.components_num; ++c) {
+        uint32_t n = image_config_lsb.components[c].width * image_config_lsb.components[c].height;
+        logical[c].resize(n);
+        for (uint32_t i = 0; i < n; i++) {
+            logical[c][i] = (uint16_t)(rnd.Rand16() % (1 << bit_depth));
+        }
+    }
+
+    auto encode_with_buffer = [&](uint8_t msb_aligned) {
+        svt_jpeg_xs_encoder_api_t enc;
+        svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc);
+        enc.verbose = VERBOSE_NONE;
+        enc.source_width = width;
+        enc.source_height = height;
+        enc.input_bit_depth = bit_depth;
+        enc.colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+        enc.bpp_numerator = 4;
+        enc.bpp_denominator = 1;
+        enc.input_bit_depth_msb_aligned = msb_aligned;
+
+        svt_jpeg_xs_image_config_t image_config;
+        uint32_t bpf = 0;
+        svt_jpeg_xs_encoder_get_image_config(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc, &image_config, &bpf);
+        svt_jpeg_xs_image_buffer_t *in_buf = svt_jpeg_xs_image_buffer_alloc(&image_config);
+
+        for (int32_t c = 0; c < image_config.components_num; ++c) {
+            uint16_t *plane = (uint16_t *)in_buf->data_yuv[c];
+            uint32_t plane_w = image_config.components[c].width;
+            uint32_t plane_h = image_config.components[c].height;
+            uint32_t stride = in_buf->stride[c];
+            for (uint32_t y = 0; y < plane_h; y++) {
+                for (uint32_t x = 0; x < plane_w; x++) {
+                    uint16_t pixel = logical[c][y * plane_w + x];
+                    plane[y * stride + x] = msb_aligned ? (uint16_t)(pixel << (16 - bit_depth)) : pixel;
+                }
+            }
+        }
+
+        svt_jpeg_xs_encoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc);
+
+        svt_jpeg_xs_bitstream_buffer_t out_buf;
+        out_buf.allocation_size = bpf * 2 + 4096;
+        out_buf.used_size = 0;
+        out_buf.buffer = (uint8_t *)malloc(out_buf.allocation_size);
+
+        svt_jpeg_xs_frame_t enc_input;
+        enc_input.bitstream = out_buf;
+        enc_input.image = *in_buf;
+        enc_input.user_prv_ctx_ptr = NULL;
+        svt_jpeg_xs_encoder_send_picture(&enc, &enc_input, 1);
+
+        svt_jpeg_xs_frame_t enc_output;
+        memset(&enc_output, 0, sizeof(enc_output));
+        svt_jpeg_xs_encoder_get_packet(&enc, &enc_output, 1);
+
+        std::vector<uint8_t> result(enc_output.bitstream.buffer, enc_output.bitstream.buffer + enc_output.bitstream.used_size);
+
+        svt_jpeg_xs_encoder_close(&enc);
+        svt_jpeg_xs_image_buffer_free(in_buf);
+        free(out_buf.buffer);
+        return result;
+    };
+
+    std::vector<uint8_t> bitstream_lsb = encode_with_buffer(0);
+    std::vector<uint8_t> bitstream_msb = encode_with_buffer(1);
+
+    ASSERT_EQ(bitstream_lsb.size(), bitstream_msb.size());
+    ASSERT_EQ(memcmp(bitstream_lsb.data(), bitstream_msb.data(), bitstream_lsb.size()), 0);
+}
+
+/* Default (msb_aligned=0) behavior must be provably unchanged: encoding/decoding the same content with
+ * the flag left at its default must match a fully-zeroed struct (i.e. not set at all). */
+TEST(MsbAligned, DefaultIsZeroAndUnchanged) {
+    svt_jpeg_xs_encoder_api_t enc;
+    svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc);
+    EXPECT_EQ(enc.input_bit_depth_msb_aligned, 0);
+
+    svt_jpeg_xs_decoder_api_t dec;
+    memset(&dec, 0, sizeof(dec));
+    EXPECT_EQ(dec.output_bit_depth_msb_aligned, 0);
+}
+
+/* Both API fields must reject any value other than 0/1. */
+TEST(MsbAligned, RejectsInvalidValues) {
+    svt_jpeg_xs_encoder_api_t enc;
+    svt_jpeg_xs_encoder_load_default_parameters(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc);
+    enc.source_width = 64;
+    enc.source_height = 64;
+    enc.input_bit_depth = 10;
+    enc.colour_format = COLOUR_FORMAT_PLANAR_YUV420;
+    enc.bpp_numerator = 4;
+    enc.bpp_denominator = 1;
+    enc.verbose = VERBOSE_NONE;
+    enc.input_bit_depth_msb_aligned = 2;
+    EXPECT_EQ(svt_jpeg_xs_encoder_init(SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR, &enc), SvtJxsErrorBadParameter);
+}

--- a/tests/UnitTests/TestNlt.cc
+++ b/tests/UnitTests/TestNlt.cc
@@ -12,6 +12,7 @@
 
 #include "NltEnc_avx2.h"
 #include "NltDec_AVX2.h"
+#include "NltDec_avx512.h"
 #include "NltDec.h"
 #include "NltEnc.h"
 #include "Enc_avx512.h"
@@ -335,4 +336,152 @@ TEST(Nlt_Linear_Input_16bit, AVX512) {
     if (CPU_FLAGS_AVX512F & get_cpu_flags()) {
         test_linear_input_scaling_line_16bit(linear_input_scaling_line_16bit_avx512);
     }
+}
+
+void test_linear_input_scaling_line_16bit_msb(void (*test_fn)(const uint16_t* src, int32_t* dst, uint32_t w, uint8_t shift,
+                                                              int32_t offset, uint8_t bit_depth)) {
+    const uint32_t w = 1999;
+    const uint8_t param_Bw = 20;
+    const uint8_t shift = param_Bw - 16; /* MSB-aligned: constant, depth-independent shift = Bw-16 = 4 */
+    const int32_t offset = 1 << (param_Bw - 1);
+
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint16_t* src = (uint16_t*)malloc(w * sizeof(uint16_t));
+    int32_t* dst_ref = (int32_t*)malloc(w * sizeof(int32_t));
+    int32_t* dst_mod = (int32_t*)malloc(w * sizeof(int32_t));
+
+    for (uint8_t input_bit_depth = 10; input_bit_depth <= 12; input_bit_depth += 2) {
+        for (uint32_t j = 0; j < w; j++) {
+            uint16_t pixel = rnd->Rand16() % (1 << input_bit_depth);
+            src[j] = (uint16_t)(pixel << (16 - input_bit_depth)); /* MSB-align */
+        }
+
+        memset(dst_ref, 0, w * sizeof(int32_t));
+        memset(dst_mod, 0, w * sizeof(int32_t));
+        linear_input_scaling_line_16bit_msb_c(src, dst_ref, w, shift, offset, input_bit_depth);
+        test_fn(src, dst_mod, w, shift, offset, input_bit_depth);
+        ASSERT_EQ(memcmp(dst_ref, dst_mod, sizeof(int32_t) * w), 0);
+
+        /* Cross-check against the LSB kernel operating on the equivalent LSB-packed value:
+         * result must match exactly, proving the MSB path is a pure re-alignment, not a different scale. */
+        uint16_t* src_lsb = (uint16_t*)malloc(w * sizeof(uint16_t));
+        for (uint32_t j = 0; j < w; j++) {
+            src_lsb[j] = src[j] >> (16 - input_bit_depth);
+        }
+        int32_t* dst_lsb = (int32_t*)malloc(w * sizeof(int32_t));
+        const uint8_t shift_lsb = param_Bw - input_bit_depth;
+        linear_input_scaling_line_16bit_c(src_lsb, dst_lsb, w, shift_lsb, offset, input_bit_depth);
+        ASSERT_EQ(memcmp(dst_ref, dst_lsb, sizeof(int32_t) * w), 0);
+        free(src_lsb);
+        free(dst_lsb);
+    }
+
+    free(src);
+    free(dst_ref);
+    free(dst_mod);
+    delete rnd;
+}
+
+TEST(Nlt_Linear_Input_16bit_MSB, AVX2) {
+    test_linear_input_scaling_line_16bit_msb(linear_input_scaling_line_16bit_msb_avx2);
+}
+
+TEST(Nlt_Linear_Input_16bit_MSB, AVX512) {
+    if (CPU_FLAGS_AVX512F & get_cpu_flags()) {
+        test_linear_input_scaling_line_16bit_msb(linear_input_scaling_line_16bit_msb_avx512);
+    }
+}
+
+void test_linear_output_scaling_16bit_line_msb(void (*test_fn)(int32_t* in, uint32_t bw, uint32_t depth, uint16_t* out,
+                                                               uint32_t w)) {
+    const uint32_t w = 1999;
+    const uint32_t bw = 20;
+
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    int32_t* in = (int32_t*)malloc(w * sizeof(int32_t));
+    uint16_t* out_ref = (uint16_t*)malloc(w * sizeof(uint16_t));
+    uint16_t* out_mod = (uint16_t*)malloc(w * sizeof(uint16_t));
+
+    for (uint32_t j = 0; j < w; j++) {
+        in[j] = rnd->Rand16();
+    }
+
+    for (uint32_t depth = 10; depth <= 12; depth += 2) {
+        memset(out_ref, 0xcd, w * sizeof(uint16_t));
+        memset(out_mod, 0xcd, w * sizeof(uint16_t));
+
+        linear_output_scaling_16bit_line_msb_c(in, bw, depth, out_ref, w);
+        test_fn(in, bw, depth, out_mod, w);
+        ASSERT_EQ(memcmp(out_ref, out_mod, sizeof(uint16_t) * w), 0);
+
+        /* MSB-alignment must hold: low (16-depth) bits are always zero. */
+        for (uint32_t j = 0; j < w; j++) {
+            uint16_t low_bits_mask = (uint16_t)((1 << (16 - depth)) - 1);
+            ASSERT_EQ(out_ref[j] & low_bits_mask, 0) << "pixel " << j << " depth=" << depth << " not MSB-aligned";
+        }
+
+        /* Cross-check against the LSB kernel: MSB result right-shifted must equal the LSB result exactly. */
+        uint16_t* out_lsb = (uint16_t*)malloc(w * sizeof(uint16_t));
+        linear_output_scaling_16bit_line_c(in, bw, depth, out_lsb, w);
+        for (uint32_t j = 0; j < w; j++) {
+            ASSERT_EQ((uint16_t)(out_ref[j] >> (16 - depth)), out_lsb[j]);
+        }
+        free(out_lsb);
+    }
+
+    free(in);
+    free(out_ref);
+    free(out_mod);
+    delete rnd;
+}
+
+TEST(Nlt_Linear_Output_16bit_MSB, AVX2) {
+    test_linear_output_scaling_16bit_line_msb(linear_output_scaling_16bit_line_msb_avx2);
+}
+
+TEST(Nlt_Linear_Output_16bit_MSB, AVX512) {
+    if (CPU_FLAGS_AVX512F & get_cpu_flags()) {
+        test_linear_output_scaling_16bit_line_msb(linear_output_scaling_16bit_line_msb_avx512);
+    }
+}
+
+/* Covers the Tnlt=1/2 gap: the msb_aligned post-shift must apply regardless of transfer curve. */
+TEST(Nlt_Inverse_Transform_Line_16bit_MSB, QuadraticAndExtended) {
+    const int32_t w = 257;
+    const uint32_t depth = 10;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    int32_t* in = (int32_t*)malloc(w * sizeof(int32_t));
+    uint16_t* out_lsb = (uint16_t*)malloc(w * sizeof(uint16_t));
+    uint16_t* out_msb = (uint16_t*)malloc(w * sizeof(uint16_t));
+    for (int32_t j = 0; j < w; j++) {
+        in[j] = rnd->Rand16();
+    }
+
+    picture_header_dynamic_t hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.hdr_Bw = 20;
+
+    for (uint8_t tnlt = 1; tnlt <= 2; tnlt++) {
+        hdr.hdr_Tnlt = tnlt;
+        hdr.hdr_Tnlt_alpha = 1 << 14;
+        hdr.hdr_Tnlt_sigma = 0;
+        hdr.hdr_Tnlt_t1 = 1 << 10;
+        hdr.hdr_Tnlt_t2 = 1 << 18;
+        hdr.hdr_Tnlt_e = 4;
+
+        nlt_inverse_transform_line_16bit(in, depth, &hdr, out_lsb, w, 0);
+        nlt_inverse_transform_line_16bit(in, depth, &hdr, out_msb, w, 1);
+
+        for (int32_t j = 0; j < w; j++) {
+            ASSERT_EQ((uint16_t)(out_msb[j] >> (16 - depth)), out_lsb[j]) << "tnlt=" << (int)tnlt << " pixel " << j;
+            uint16_t low_bits_mask = (uint16_t)((1 << (16 - depth)) - 1);
+            ASSERT_EQ(out_msb[j] & low_bits_mask, 0) << "tnlt=" << (int)tnlt << " pixel " << j << " not MSB-aligned";
+        }
+    }
+
+    free(in);
+    free(out_lsb);
+    free(out_msb);
+    delete rnd;
 }

--- a/tests/scripts/DecoderConformanceTest.sh
+++ b/tests/scripts/DecoderConformanceTest.sh
@@ -10,7 +10,11 @@ echo "Run Decoder Conformance Test"
 source ./CommonLib.sh
 
 path_bitstreams=$path_global
+#Encoder binary next to $exec_dec, used to generate a temp MSB-aligned bitstream from real sample YUV
+exec_enc="${exec_dec//SvtJpegxsDecApp/SvtJpegxsEncApp}"
+
 echo "Decoder:         $exec_dec"
+echo "Encoder:         $exec_enc"
 echo "PATH BITSTERAMS: $path_bitstreams"
 
 error=0
@@ -55,6 +59,68 @@ function test_dec {
 
 rm -fr $tmp_dir
 mkdir $tmp_dir
+
+#Prepare a temp bitstream from real sample YUV using EncApp, to test decoder output_bit_depth_msb_aligned
+#without needing a pre-baked fixture file. Decoded twice below (msb-aligned 0 and 1) from this single bitstream.
+bitstream_msb_prep="$tmp_dir/msb_prep.jxs"
+cmd_prep="$exec_enc -i $path_bitstreams/encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv -w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 0 --rc 0 -n 5 --asm max --lp 7 --profile latency --packetization-mode 0 -b $bitstream_msb_prep"
+echo "run command: $cmd_prep"
+${cmd_prep}
+
+#RUN output_bit_depth_msb_aligned tests: decode the same self-generated bitstream twice (msb-aligned 0 and 1)
+#Parameters (1:asm) (2:lp number) (3:packetization mode)
+function test_msb_aligned_output {
+    PARAM_ASM=$1
+    PARAM_LP_NUM=$2
+    PARAM_PACKETIZATION=$3
+
+    #(1:expect exit code) (2:expected md5, or IGNORE) (3:extra decoder params)
+    function test_msb_dec {
+        exit_code=$1
+        md5=$2
+        params=$3
+        yuv_tmp="./$tmp_dir/msb_prep_out.yuv"
+
+        common_lib_update_test_id_run_return_1_to_ignore
+        ignore=$?
+        if [ $ignore -ne 0 ]; then
+            return
+        fi
+
+        cmd="$valgrind$exec_dec -i $bitstream_msb_prep -o $yuv_tmp --lp $PARAM_LP_NUM --asm $PARAM_ASM --packetization-mode $PARAM_PACKETIZATION "$params
+        echo "run command: $cmd"
+        ${cmd}
+
+        ret=$?
+        if [ $ret -ne $exit_code ]; then
+            echo "FAIL Invalid error code: $ret expected: $exit_code"
+            error=1
+            end
+        fi
+
+        if [ $md5 = "IGNORE" ]; then
+            echo "IGNORE TEST OUTPUT"
+        else
+            echo -n "Test MD5 Expect: $md5 "
+            md5_t=`md5sum ${yuv_tmp} | awk '{ print $1 }'`
+            if [ $md5 = $md5_t ]; then
+                echo "OK"
+            else
+                echo "FAIL get $md5_t"
+                error=1
+                end
+            fi
+        fi
+    }
+
+    #Default (LSB) and MSB-aligned outputs of the SAME bitstream, pinned md5 (verified: msb == lsb << (16-depth))
+    test_msb_dec 0 f48a73066e7a78d0207d3419b37097f4 "--output-msb-aligned 0"
+    test_msb_dec 0 984080ab17c11c747da832b3b7be6eab "--output-msb-aligned 1"
+
+    #Reject any value other than 0/1
+    test_msb_dec 2 d41d8cd98f00b204e9800998ecf8427e "--output-msb-aligned 2"
+    test_msb_dec 2 d41d8cd98f00b204e9800998ecf8427e "--output-msb-aligned 255"
+}
 
 function test_all {
     PARAM_ASM=$1
@@ -154,6 +220,10 @@ function test_all {
 [[ $run_fast -eq 0 ]] && test_all max 1 0
                          test_all max 1 1
 
+echo Test output_bit_depth_msb_aligned
+[[ $run_fast -eq 0 ]] && test_msb_aligned_output c 10 0
+                         test_msb_aligned_output avx2 20 0
+                         test_msb_aligned_output max 1 1
 
 
 common_lib_end_summary

--- a/tests/scripts/DecoderMultiFramesTest.sh
+++ b/tests/scripts/DecoderMultiFramesTest.sh
@@ -10,8 +10,12 @@ echo "Run Decoder Multiple Frames Test"
 source ./CommonLib.sh
 path_correct="$path_global/bitstream_multi_frames"
 path_invalid="$path_global/bitstream_invalid"
+path_encoder_tests="$path_global/encoder_tests"
+#Encoder binary next to $exec_dec, used to generate temp MSB-aligned bitstreams from real sample YUV
+exec_enc="${exec_dec//SvtJpegxsDecApp/SvtJpegxsEncApp}"
 
 echo "DECODER : $exec_dec"
+echo "ENCODER : $exec_enc"
 echo "Path correct: $path_correct"
 echo "Path change: $path_change"
 
@@ -86,6 +90,13 @@ function test_dec {
 
 rm -fr $tmp_dir
 mkdir $tmp_dir
+
+#Prepare a temp bitstream from real sample YUV using EncApp, to test decoder output_bit_depth_msb_aligned
+#without needing a pre-baked fixture file. Decoded twice below (msb-aligned 0 and 1) from this single bitstream.
+bitstream_msb_prep="$tmp_dir/msb_prep.jxs"
+cmd_prep="$exec_enc -i $path_encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv -w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 0 --rc 0 -n 5 --asm max --lp 7 --profile latency --packetization-mode 0 -b $bitstream_msb_prep"
+echo "run command: $cmd_prep"
+${cmd_prep}
 
 
 function test_all_correct {
@@ -183,6 +194,23 @@ function test_all_broken {
     test_dec 2 invalid_small_cfg_zero_band_10                          d41d8cd98f00b204e9800998ecf8427e
 }
 
+#RUN output_bit_depth_msb_aligned tests: decode the same self-generated bitstream twice (msb-aligned 0 and 1)
+#Parameters (1:asm) (2:lp number) (3:packetization mode)
+function test_msb_aligned_output {
+    PARAM_ASM=$1
+    PARAM_LP_NUM=$2
+    PARAM_PACKETIZATION=$3
+
+    path_use=$tmp_dir
+    #Default (LSB) and MSB-aligned outputs of the SAME bitstream, pinned md5 (verified: msb == lsb << (16-depth))
+    test_dec 0 msb_prep f48a73066e7a78d0207d3419b37097f4 "--output-msb-aligned 0"
+    test_dec 0 msb_prep 984080ab17c11c747da832b3b7be6eab "--output-msb-aligned 1"
+
+    #Reject any value other than 0/1
+    test_dec 2 msb_prep d41d8cd98f00b204e9800998ecf8427e "--output-msb-aligned 2"
+    test_dec 2 msb_prep d41d8cd98f00b204e9800998ecf8427e "--output-msb-aligned 255"
+}
+
 [[ $run_fast -eq 0 ]] && test_all_correct c 10 0
                          test_all_broken c 10
                          test_all_correct avx2 20 0
@@ -191,6 +219,11 @@ function test_all_broken {
 [[ $run_fast -eq 0 ]] && test_all_correct max 1 0
                          test_all_broken max 1
                          test_all_correct max 1 1
+
+echo Test output_bit_depth_msb_aligned
+[[ $run_fast -eq 0 ]] && test_msb_aligned_output c 10 0
+                         test_msb_aligned_output avx2 20 0
+                         test_msb_aligned_output max 1 1
 
 
 common_lib_end_summary

--- a/tests/scripts/EncoderTest.sh
+++ b/tests/scripts/EncoderTest.sh
@@ -330,6 +330,25 @@ function test_rate_control_signs {
     test_enc 0 2b72c16c35f5f76ea1cc9d3c9a273dcb signal_1080p_yuv422p_10bit_le_1_frame       "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 1  --quantization 1 --rc 0   --coding-signs 1 --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
 }
 
+#RUN input-msb-aligned Parameters (1:asm) (2:lp number)
+function test_msb_aligned {
+    asm=$1
+    lp=$2
+    cpu_profile=$3
+    packetization_mode=$4
+
+#   Explicit msb-aligned=0 must be byte-identical to the default (untouched) path
+    test_enc 0 62764838a69b79251eae1a63d97402e4 touchdown_1080p_yuv422p_10_bit_le_60_frames "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 0 --rc 0 -n 5 --input-msb-aligned 0   --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
+
+#   msb-aligned=1 must produce a valid, decodable, deterministic bitstream
+    test_enc 0 a24b2fa13a7524749d7de47e443d9f0b touchdown_1080p_yuv422p_10_bit_le_60_frames "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 0 --rc 0 -n 5 --input-msb-aligned 1   --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
+    test_enc 0 3d5e7f00ce52f93006f3633fd2530671 signal_1080p_yuv422p_10bit_le_1_frame       "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --decomp_v 2 --decomp_h 5 --coding-sigf 1 --coding-vpred 0 --rc 0      --input-msb-aligned 1   --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
+
+#   Reject any value other than 0/1
+    test_enc 5 IGNORE                           signal_1080p_yuv422p_10bit_le_1_frame       "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --input-msb-aligned 2     --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
+    test_enc 5 IGNORE                           signal_1080p_yuv422p_10bit_le_1_frame       "-w 1920 -h 1080 --input-depth 10 --colour-format yuv422 --bpp 3 --input-msb-aligned 255   --asm $asm --lp $lp --profile $cpu_profile --packetization-mode $packetization_mode"
+}
+
 function test_uncommon_resolution {
     asm=$1
     lp=$2
@@ -740,6 +759,12 @@ exec_enc=$exec_enc_rel
 [[ $run_fast -eq 0 ]] && test_rate_control_signs avx2 5 cpu 0
                          test_rate_control_signs max 7 latency 0
                          test_rate_control_signs max 7 latency 1
+
+echo Test MSB-aligned input
+[[ $run_fast -eq 0 ]] && test_msb_aligned c 10 latency 0
+[[ $run_fast -eq 0 ]] && test_msb_aligned avx2 5 cpu 0
+                         test_msb_aligned max 7 latency 0
+                         test_msb_aligned max 7 latency 1
 
 #echo RUN DEBUG TEST C
 #exec_enc=$exec_enc_dbg

--- a/tests/scripts/FFmpegDecoderConformanceTest.sh
+++ b/tests/scripts/FFmpegDecoderConformanceTest.sh
@@ -165,7 +165,62 @@ function test_all {
     test_dec 217
 }
 
+#RUN output_bit_depth_msb_aligned tests: decode the same stripped conformance bitstream twice
+#(msb-aligned 0 and 1). NOTE: the decoder AVOption must be placed BEFORE -i, not passed as an
+#extra_args-style option after -i, or ffmpeg silently ignores it (only a warning, no error) -
+#a real pitfall hit while writing this test.
+function test_msb_aligned {
+    name=011
+    src_jxs=$path_bitstreams/test_bitsreams/$name.jxs
+    stripped_jxs=./$tmp_dir/$name"_stripped.jxs"
+
+    #(1:expect exit code) (2:expected md5) (3:msb_aligned value)
+    function test_msb_dec {
+        exit_code=$1
+        md5=$2
+        msb_aligned=$3
+        out_yuv=./$tmp_dir/$name"_msb$msb_aligned.yuv"
+
+        common_lib_update_test_id_run_return_1_to_ignore
+        ignore=$?
+        if [ $ignore -ne 0 ]; then
+            return
+        fi
+
+        cmd="$valgrind$exec_ffmpeg -y -hide_banner -loglevel error $demuxer -c:v libsvtjpegxs -msb_aligned $msb_aligned -i $stripped_jxs -f rawvideo $out_yuv"
+        echo "run command: $cmd"
+        ${cmd}
+        ret=$?
+        if [ $ret -ne $exit_code ]; then
+            echo "FAIL Invalid error code: $ret expected: $exit_code"
+            error=1
+            end
+        fi
+
+        echo -n "Test MD5 Expect: $md5 "
+        md5_t=$(md5sum "${out_yuv}" | awk '{ print $1 }')
+        if [ "$md5" = "$md5_t" ]; then
+            echo "OK"
+        else
+            echo "FAIL get $md5_t"
+            error=1
+            end
+        fi
+    }
+
+    offset=$(find_bitstream_header_offset "$src_jxs")
+    tail -c +$((offset+1)) "$src_jxs" > "$stripped_jxs"
+
+    #msb_aligned=0 explicit must be byte-identical to the existing reference_decode/011_*.yuv
+    #(the untouched default path).
+    test_msb_dec 0 e379a376d704e3e0100f748fd4dd1bdd 0
+    #msb_aligned=1: pinned md5, verified (via a matching plain decode, right-shifted by 6) to be
+    #the exact MSB-aligned re-packing of the msb_aligned=0/default output above.
+    test_msb_dec 0 58df668b531f53cbf4666c9a116d553e 1
+}
+
 test_all
+test_msb_aligned
 
 
 common_lib_end_summary

--- a/tests/scripts/FFmpegDecoderMultiFramesTest.sh
+++ b/tests/scripts/FFmpegDecoderMultiFramesTest.sh
@@ -36,12 +36,15 @@ fi
 
 demuxer="-f jpegxs_pipe"
 
-# (1:expected error code) (2:name, without .jxs) (3:expected md5 of decoded yuv) (4:optional extra ffmpeg args)
+# (1:expected error code) (2:name, without .jxs) (3:expected md5 of decoded yuv) (4:optional extra ffmpeg args,
+#  placed after -i / applied as output options) (5:optional decoder AVOptions, placed before -i so ffmpeg
+#  actually associates them with the libsvtjpegxs decoder instead of silently ignoring them - e.g. "-msb_aligned 1")
 function test_dec {
     exit_code=$1
     name=$2
     md5=$3
     extra_args=$4
+    decoder_opts=$5
     bin_name=$path_use"/"$name".jxs"
     yuv_tmp="./$tmp_dir/"$name".yuv"
 
@@ -51,7 +54,7 @@ function test_dec {
         return
     fi
 
-    cmd="$valgrind$exec_ffmpeg -y -hide_banner -loglevel error $demuxer -c:v libsvtjpegxs -threads $PARAM_THREADS -i $bin_name $extra_args -f rawvideo $yuv_tmp"
+    cmd="$valgrind$exec_ffmpeg -y -hide_banner -loglevel error $demuxer -c:v libsvtjpegxs -threads $PARAM_THREADS $decoder_opts -i $bin_name $extra_args -f rawvideo $yuv_tmp"
     echo "run command: $cmd"
     ${cmd}
     ret=$?
@@ -135,6 +138,18 @@ function test_all_correct {
     # Correct bitstreams (h1/decomp_h=1 variants excluded - see plugin limitation note at top).
     test_dec 0 Cyclist_1920x1080_10b_422_20f_v1_h5                    f65f42c074fa6fbdc3e9136ec86b9828
     test_dec 0 Cyclist_1920x1080_10b_422_20f_v2_h3                    39983e5e039da3917e5f7bf7ef9a87bf
+
+    # output_bit_depth_msb_aligned: decode the SAME bitstream as above with -msb_aligned 1/0.
+    # NOTE: the decoder AVOption must be placed BEFORE -i (see decoder_opts param on test_dec) -
+    # placing it after -i (as a plain extra_args) is silently ignored by ffmpeg with only a
+    # warning ("has not been used for any stream"), NOT an error - a real pitfall hit while writing
+    # this test, verified by comparing decoded output byte-for-byte with/without the option.
+    # msb_aligned=1: pinned md5, verified (via a matching plain decode, right-shifted by 6) to be
+    # the exact MSB-aligned re-packing of the msb_aligned=0/default output above.
+    test_dec 0 Cyclist_1920x1080_10b_422_20f_v2_h3                    d0c6fb35abb322a2b3b8904595d63e55 "" "-msb_aligned 1"
+    # msb_aligned=0 explicit must be byte-identical to the untouched default path above.
+    test_dec 0 Cyclist_1920x1080_10b_422_20f_v2_h3                    39983e5e039da3917e5f7bf7ef9a87bf "" "-msb_aligned 0"
+
     test_dec 0 Cyclist_1920x1080_8b_422_20f_v1_h4                     281a046a4d0c9bcb554e828d2a8084ef
     test_dec 0 Cyclist_1920x1080_8b_422_20f_v2_h2                     e71c8400a4f3a636408b48450bae92d3
     # Daylight_1280x720_{10b,8b}_422_20f_v1_h1 SKIPPED - ffmpeg plugin decode error (decomp_h=1)
@@ -156,8 +171,8 @@ function test_all_broken {
     path_use=$path_correct
 
     # Bitstreams with a header change mid-stream, plus one with a genuinely corrupted
-    # mid-stream packet (broken_bitstream_*). ffmpeg does NOT abort the whole conversion 
-    # on any of these decode errors (unlike SvtJpegxsDecApp, which returns exit 1) 
+    # mid-stream packet (broken_bitstream_*). ffmpeg does NOT abort the whole conversion
+    # on any of these decode errors (unlike SvtJpegxsDecApp, which returns exit 1)
     # - it logs the error per-packet and continues, exiting 0. All 5 produce the SAME
     # deterministic (41-frame) output, so they share one NEW pinned md5.
     test_dec 0 broken_decomh_Daylight_1280x720_8b_422_20fx1fx20f       2d658bef484f1de8bde1b0f233bcf6a6

--- a/tests/scripts/FFmpegEncoderTest.sh
+++ b/tests/scripts/FFmpegEncoderTest.sh
@@ -219,6 +219,15 @@ function test_all {
 
 #   Error path: invalid (too low) bpp must be rejected by the plugin (non-zero ffmpeg exit code).
     test_enc NONZERO IGNORE touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 2 "-bpp 0.05 -decomp_v 2 -decomp_h 5"
+
+#   msb_aligned=1 on 10bit(le) content: encoder must accept the option and produce a valid,
+#   deterministic, decodable bitstream. NEW md5, pinned from this ffmpeg build.
+    test_enc 0 6b8c07cd7625f46c3941f35443179531 touchdown_1080p_yuv422p_10_bit_le_60_frames 1920 1080 yuv422p10le 5 "-bpp 3 -decomp_v 2 -decomp_h 5 -coding-sigf 1 -coding-vpred disable -coding-signs full -msb_aligned 1"
+
+#   msb_aligned=1 on 8bit content must be a no-op (the library only applies msb-alignment above
+#   8bit): same md5 as the very first test_all row above with otherwise identical parameters,
+#   confirming the option is safely ignored for 8bit input rather than corrupting it.
+    test_enc 0 3f24dcf3bdfd1184caacac7fa9989a78 touchdown_1080p_yuv422p_8_bit_60_frames 1920 1080 yuv422p 10 "-bpp 3 -decomp_v 2 -decomp_h 5 -coding-sigf 1 -coding-vpred no_residuals -coding-signs full -msb_aligned 1"
 }
 
 test_all

--- a/tests/scripts/PerformanceTestFfmpegPlugin.sh
+++ b/tests/scripts/PerformanceTestFfmpegPlugin.sh
@@ -27,7 +27,7 @@ if [ ! -f "$CSV_FILE" ]; then
     echo "Operation,TestCase,Command,Result_FPS,Target_FPS,Percent_Of_Target,Status" > "$CSV_FILE"
 fi
 
-# Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS
+# Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS|ExtraEncArgs(optional)|ExtraDecArgs(optional)
 MATRIX=(
     # 1080p 422p 10-bit - 1.5 BPP Thread Scaling
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|1|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|74|128"
@@ -52,6 +52,10 @@ MATRIX=(
     # 1080p 422p 8-bit - 3.0 BPP Thread Scaling
     "1080p60_422p8|1920|1080|8|yuv422|60|3.0|1|encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv|59|102"
     "1080p60_422p8|1920|1080|8|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv|319|486"
+
+    # 1080p 422p 10-bit - 3.0 BPP - MSB-aligned input/output: same baseline as the equivalent
+    # LSB row above (msb-aligned kernels have same perf as LSB, verified separately).
+    "1080p60_422p10_msb|1920|1080|10|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|313|480|-msb_aligned 1|-msb_aligned 1"
 )
 
 # get_ffmpeg_pix_fmt colour_format bit_depth: maps to the ffmpeg pix_fmt name.
@@ -113,7 +117,7 @@ function check_result() {
 }
 
 for test_case in "${MATRIX[@]}"; do
-    IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps <<< "$test_case"
+    IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
     source_path="$SAMPLES_DIR/$file"
 
     if [ ! -f "$source_path" ]; then
@@ -132,7 +136,7 @@ for test_case in "${MATRIX[@]}"; do
         "$FFMPEG_BIN" -y -hide_banner -loglevel info -nostats -benchmark \
         -stream_loop -1 -f rawvideo -pix_fmt "$pix_fmt" -s:v "${w}x${h}" -framerate "$framerate" \
         -i "$RAMDISK_YUV" \
-        -threads "$threads" -frames:v "$FRAMES" -c:v libsvtjpegxs -bpp "$bpp" \
+        -threads "$threads" -frames:v "$FRAMES" -c:v libsvtjpegxs -bpp "$bpp" $extra_enc_args \
         -f image2pipe "$RAMDISK_JXS")
     enc_cmd=$(printf '%q ' "${enc_cmd_arr[@]}")
     enc_fps=$(run_measured "${enc_cmd_arr[@]}")
@@ -153,7 +157,7 @@ for test_case in "${MATRIX[@]}"; do
     echo "Decoding: $name (bpp=$bpp, threads=$threads)"
     dec_cmd_arr=(numactl --cpunodebind=$NUMA_NODE --membind=$NUMA_NODE \
         "$FFMPEG_BIN" -y -hide_banner -loglevel info -nostats -benchmark \
-        -threads "$threads" -f jpegxs_pipe -c:v libsvtjpegxs -i "$RAMDISK_JXS" \
+        -threads "$threads" -f jpegxs_pipe -c:v libsvtjpegxs $extra_dec_args -i "$RAMDISK_JXS" \
         -f rawvideo /dev/null)
     dec_cmd=$(printf '%q ' "${dec_cmd_arr[@]}")
     dec_fps=$(run_measured "${dec_cmd_arr[@]}")

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -29,7 +29,7 @@ if [ ! -f "$CSV_FILE" ]; then
     echo "Operation,TestCase,Command,Result_FPS,Target_FPS,Percent_Of_Target,Status" > "$CSV_FILE"
 fi
 
-# Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS
+# Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS|ExtraEncArgs(optional)|ExtraDecArgs(optional)
 MATRIX=(
     # 1080p 422p 10-bit - 1.5 BPP Thread Scaling
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|1|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|77|145"
@@ -54,6 +54,10 @@ MATRIX=(
     # 1080p 422p 8-bit - 3.0 BPP Thread Scaling
     "1080p60_422p8|1920|1080|8|yuv422|60|3.0|1|encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv|62|114"
     "1080p60_422p8|1920|1080|8|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv|364|578"
+
+    # 1080p 422p 10-bit - 3.0 BPP - MSB-aligned input/output: same baseline as the equivalent
+    # LSB row above (msb-aligned kernels have same perf as LSB, verified separately).
+    "1080p60_422p10_msb|1920|1080|10|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|359|571|--input-msb-aligned 1|--output-msb-aligned 1"
 )
 
 # run_measured cmd...: single run, prints parsed FPS (empty if unparseable).
@@ -100,7 +104,7 @@ function check_result() {
 }
 
 for test_case in "${MATRIX[@]}"; do
-    IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps <<< "$test_case"
+    IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
     source_path="$SAMPLES_DIR/$file"
 
     if [ ! -f "$source_path" ]; then
@@ -116,7 +120,7 @@ for test_case in "${MATRIX[@]}"; do
     echo "Encoding: $name (bpp=$bpp, threads=$threads)"
     enc_cmd_arr=(numactl --cpunodebind=$NUMA_NODE --membind=$NUMA_NODE \
         "$ENC_APP" -i "$RAMDISK_YUV" -b "$RAMDISK_JXS" -w "$w" -h "$h" \
-        --input-depth "$depth" --colour-format "$fmt" --bpp "$bpp" -n "$FRAMES" --lp "$threads")
+        --input-depth "$depth" --colour-format "$fmt" --bpp "$bpp" -n "$FRAMES" --lp "$threads" $extra_enc_args)
     enc_cmd=$(printf '%q ' "${enc_cmd_arr[@]}")
     enc_fps=$(run_measured "${enc_cmd_arr[@]}")
 
@@ -134,7 +138,7 @@ for test_case in "${MATRIX[@]}"; do
 
     echo "Decoding: $name (bpp=$bpp, threads=$threads)"
     dec_cmd_arr=(numactl --cpunodebind=$NUMA_NODE --membind=$NUMA_NODE \
-        "$DEC_APP" -i "$RAMDISK_JXS" -o /dev/null -n "$FRAMES" --lp "$threads")
+        "$DEC_APP" -i "$RAMDISK_JXS" -o /dev/null -n "$FRAMES" --lp "$threads" $extra_dec_args)
     dec_cmd=$(printf '%q ' "${dec_cmd_arr[@]}")
     dec_fps=$(run_measured "${dec_cmd_arr[@]}")
 


### PR DESCRIPTION
### Summary

Adds an optional, non-standard, host-side-only convention for 10/12-bit samples: values occupy the **high** bits of each 16-bit word instead of the low bits. This is never signalled in the bitstream — the encoded stream is byte-identical regardless of this setting. Both encoder and decoder must be configured consistently by the caller; it's purely a buffer-layout convention for hosts that already store pixels MSB-aligned (e.g. some capture/graphics pipelines) and want to avoid an extra shift pass.

### API changes

- `svt_jpeg_xs_encoder_api_t::input_bit_depth_msb_aligned` (`uint8_t`, 0/1, default 0)
- `svt_jpeg_xs_decoder_api_t::output_bit_depth_msb_aligned` (`uint8_t`, 0/1, default 0)
- Both validated at init (rejects anything other than 0/1 with `SvtJxsErrorBadParameter`).
- Public struct padding shrunk accordingly — no ABI size change.

### CLI usage (EncApp / DecApp)

```shell
# Encode: input samples are MSB-aligned in each 16-bit word
./SvtJpegxsEncApp -i input_10bit_msb.yuv -b out.jxs -w 1920 -h 1080 \
    --input-depth 10 --colour-format yuv422 --bpp 3 --input-msb-aligned 1

# Decode: request MSB-aligned output samples
./SvtJpegxsDecApp -i out.jxs -o output_10bit_msb.yuv --output-msb-aligned 1
```

### ffmpeg plugin usage

```shell
# Encode
./ffmpeg -f rawvideo -pix_fmt yuv422p10le -s:v 1920x1080 -i input_msb.yuv \
    -c:v libsvtjpegxs -bpp 3 -msb_aligned 1 -f image2pipe out.jxs

# Decode (note: private decoder options must be placed BEFORE -i)
./ffmpeg -f jpegxs_pipe -c:v libsvtjpegxs -msb_aligned 1 -i out.jxs \
    -f rawvideo output_msb.yuv
```

Available for ffmpeg 6.1, 7.0, 7.1, 8.0 (standalone plugin files) and 8.1, 9.0 (new patch `Add-msb-aligned-support.patch`).

### Implementation notes

- Fused C/AVX2/AVX512 kernels for the MSB-aligned input-scaling (encoder) and output-scaling (decoder) paths, dispatched via RTCD alongside the existing LSB kernels.
- Fixes a gap present in an earlier external PR attempt: MSB alignment is now correctly applied for all three transfer-curve modes (`Tnlt` = linear/quadratic/extended), not just linear.

### Testing

- New unit tests: kernel-level cross-checks against the LSB path (`TestNlt.cc`) and full encode→decode round-trip / bitstream-identity tests (`TestMsbAligned.cc`).
- Full existing unit test suite passes (no regressions).
- Conformance/CLI test scripts (`EncoderTest.sh`, `DecoderMultiFramesTest.sh`, `DecoderConformanceTest.sh`) and ffmpeg-plugin equivalents extended with MSB-aligned cases.
- Performance validated on release build (AVX512): MSB path is within noise of the LSB baseline for both encoder and decoder — no measurable regression.