### PR TITLE
Add configurable log callback API to SVT-JPEG-XS

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,21 @@ Please see [Encoder snippet](documentation/encoder/EncoderSnippets.md) for encod
 
 Please see [Decoder snippet](documentation/decoder/DecoderSnippets.md) for decoder structure overview and simplified decoder usage.
 
+## Logging
+
+By default, library log messages (errors, warnings, info) are printed to `stderr`. This can be
+controlled with two environment variables:
+
+- `SVT_LOG` - minimum log level to print: `-1`(all), `0`(fatal), `1`(error), `2`(warn), `3`(info,
+  default), `4`(debug). Out-of-range values are ignored and the default is kept.
+- `SVT_LOG_FILE` - path to a file to write log messages to instead of `stderr`.
+
+Host applications can also register a callback to intercept all log messages (e.g. to route them
+into an application-specific logger) via `svt_jpeg_xs_set_log_callback()`, declared in
+[Source/API/SvtJpegxs.h](Source/API/SvtJpegxs.h). This is a global, process-wide setting shared by
+all encoder/decoder instances, and must be called before the first log call happens (i.e. before any
+encoder/decoder init) to take effect.
+
 ## Notes
 
 The information in this document was compiled at `v0.10` of the code and may not

--- a/Source/API/SvtJpegxs.h
+++ b/Source/API/SvtJpegxs.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif // __cplusplus
 
 #include <stdint.h>
+#include <stdarg.h>
 
 /* API Version */
 #define SVT_JPEGXS_API_VER_MAJOR (0)
@@ -188,6 +189,46 @@ typedef uint64_t CPU_FLAGS;
 #define CPU_FLAGS_AVX512VL (1 << 15)
 #define CPU_FLAGS_ALL      ((CPU_FLAGS_AVX512VL << 1) - 1)
 #define CPU_FLAGS_INVALID  (1ULL << (sizeof(CPU_FLAGS) * 8ULL - 1ULL))
+
+/**
+ * @brief Log severity levels
+ */
+typedef enum {
+    SVT_LOG_ALL = -1,
+    SVT_LOG_FATAL = 0,
+    SVT_LOG_ERROR = 1,
+    SVT_LOG_WARN = 2,
+    SVT_LOG_INFO = 3,
+    SVT_LOG_DEBUG = 4,
+} SvtLogLevel;
+
+/**
+ * @brief Log callback function signature.
+ *
+ * Applications can register a callback to intercept log messages from the library.
+ * The callback receives every log call unfiltered (no level gating is applied before dispatch),
+ * so it is the callback's own responsibility to filter by `level` if desired.
+ *
+ * @param[in] context Opaque user-provided context pointer (may be NULL)
+ * @param[in] level   Severity level of the log message
+ * @param[in] tag     Optional log tag (may be NULL)
+ * @param[in] fmt     printf-style format string
+ * @param[in] args    Variable argument list corresponding to the format string
+ */
+typedef void (*SvtJxsLogCallback)(void *context, SvtLogLevel level, const char *tag, const char *fmt, va_list args);
+
+/**
+ * Register a callback for intercepting log messages.
+ *
+ * When a callback is registered, all log messages are dispatched to it instead of the default
+ * stderr/file output, for all encoder/decoder instances (this is a global setting). Must be called
+ * before the first log call happens (i.e. before any encoder/decoder init) to take effect - calling
+ * it later is a no-op. Passing a NULL callback is also a no-op.
+ *
+ * @param[in] callback Callback function pointer. Has no effect if NULL.
+ * @param[in] context  Opaque context pointer passed back to the callback. Ignored if callback is NULL.
+ */
+PREFIX_API void svt_jpeg_xs_set_log_callback(SvtJxsLogCallback callback, void *context);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/ImageBuffer.c
+++ b/Source/Lib/Common/Codec/ImageBuffer.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include "SvtJpegxsImageBufferTools.h"
 #include "Threads/SystemResourceManager.h"
+#include "SvtLog.h"
 
 struct svt_jpeg_xs_frame_pool {
     uint8_t use_image_buffer;
@@ -21,14 +22,13 @@ struct svt_jpeg_xs_frame_pool {
 
 PREFIX_API svt_jpeg_xs_image_buffer_t* svt_jpeg_xs_image_buffer_alloc(svt_jpeg_xs_image_config_t* image_config) {
     if (!image_config) {
-        fprintf(stderr, "Invalid image config: NULL pointer\n");
+        SVT_ERROR("Invalid image config: NULL pointer\n");
         return NULL;
     }
     if (image_config->components_num > MAX_COMPONENTS_NUM) {
-        fprintf(stderr,
-                "Invalid image config: components_num (%u) exceeds maximum (%u)\n",
-                image_config->components_num,
-                MAX_COMPONENTS_NUM);
+        SVT_ERROR("Invalid image config: components_num (%u) exceeds maximum (%u)\n",
+                  image_config->components_num,
+                  MAX_COMPONENTS_NUM);
         return NULL;
     }
 
@@ -46,13 +46,13 @@ PREFIX_API svt_jpeg_xs_image_buffer_t* svt_jpeg_xs_image_buffer_alloc(svt_jpeg_x
     if (image_config->format == COLOUR_FORMAT_PACKED_YUV444_OR_RGB) {
         const uint64_t stride64 = (uint64_t)image_config->components[0].width * 3;
         if (stride64 > UINT32_MAX) {
-            fprintf(stderr, "Image buffer alloc overflow: stride %" PRIu64 " exceeds uint32 max\n", stride64);
+            SVT_ERROR("Image buffer alloc overflow: stride %" PRIu64 " exceeds uint32 max\n", stride64);
             svt_jpeg_xs_image_buffer_free(image_buffer);
             return NULL;
         }
         const uint64_t alloc64 = stride64 * image_config->components[0].height * pixel_size;
         if (alloc64 > UINT32_MAX) {
-            fprintf(stderr, "Image buffer alloc overflow: alloc_size %" PRIu64 " exceeds uint32 max\n", alloc64);
+            SVT_ERROR("Image buffer alloc overflow: alloc_size %" PRIu64 " exceeds uint32 max\n", alloc64);
             svt_jpeg_xs_image_buffer_free(image_buffer);
             return NULL;
         }
@@ -70,8 +70,7 @@ PREFIX_API svt_jpeg_xs_image_buffer_t* svt_jpeg_xs_image_buffer_alloc(svt_jpeg_x
             const uint64_t alloc64 = (uint64_t)image_config->components[c].width * image_config->components[c].height *
                 pixel_size;
             if (alloc64 > UINT32_MAX) {
-                fprintf(
-                    stderr, "Image buffer alloc overflow: component %u alloc_size %" PRIu64 " exceeds uint32 max\n", c, alloc64);
+                SVT_ERROR("Image buffer alloc overflow: component %u alloc_size %" PRIu64 " exceeds uint32 max\n", c, alloc64);
                 svt_jpeg_xs_image_buffer_free(image_buffer);
                 return NULL;
             }
@@ -185,10 +184,9 @@ PREFIX_API svt_jpeg_xs_frame_pool_t* svt_jpeg_xs_frame_pool_alloc(const svt_jpeg
             frame_pool->use_image_buffer = 0;
         }
         else if (image_config->components_num > MAX_COMPONENTS_NUM) {
-            fprintf(stderr,
-                    "Invalid image config: components_num (%u) exceeds maximum (%u)\n",
-                    image_config->components_num,
-                    MAX_COMPONENTS_NUM);
+            SVT_ERROR("Invalid image config: components_num (%u) exceeds maximum (%u)\n",
+                      image_config->components_num,
+                      MAX_COMPONENTS_NUM);
             svt_jpeg_xs_frame_pool_free(frame_pool);
             return NULL;
         }

--- a/Source/Lib/Common/Codec/Pi.c
+++ b/Source/Lib/Common/Codec/Pi.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include "SvtJpegxs.h"
 #include "SvtUtility.h"
+#include "SvtLog.h"
 
 void set_precinct(pi_t* pi, precinct_band_info_t* b_info, uint32_t width, uint32_t height) {
     b_info->width = width;
@@ -591,11 +592,10 @@ SvtJxsErrorType_t pi_update_proxy_mode(pi_t* pi, proxy_mode_t proxy_mode, uint32
 
     if (proxy_subsampling > pi->decom_v || proxy_subsampling > pi->decom_h) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
-                    "Cannot use proxy-mode=%d for stream with decomp_v=%d decomp_h=%d\n",
-                    proxy_mode,
-                    pi->decom_v,
-                    pi->decom_h);
+            SVT_ERROR("Cannot use proxy-mode=%d for stream with decomp_v=%d decomp_h=%d\n",
+                      proxy_mode,
+                      pi->decom_v,
+                      pi->decom_h);
         }
         return SvtJxsErrorBadParameter;
     }

--- a/Source/Lib/Common/Codec/SvtLog.c
+++ b/Source/Lib/Common/Codec/SvtLog.c
@@ -16,31 +16,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static SvtLogLevel g_log_level;
-static FILE *g_log_file;
-
-static void svt_log_set_level(SvtLogLevel level) {
-    g_log_level = level;
-}
-
-static void svt_log_set_log_file(const char *file) {
-    if (file)
-        g_log_file = fopen(file, "w+");
-}
-
-void svt_jxs_log_init() {
-    const char *log = getenv("SVT_LOG");
-    SvtLogLevel level = SVT_LOG_INFO;
-    if (log)
-        level = (SvtLogLevel)atoi(log);
-    svt_log_set_level(level);
-
-    if (!g_log_file) {
-        const char *file = getenv("SVT_LOG_FILE");
-        svt_log_set_log_file(file);
-    }
-}
-
 static const char *log_level_str(SvtLogLevel level) {
     switch (level) {
     case SVT_LOG_FATAL:
@@ -58,18 +33,132 @@ static const char *log_level_str(SvtLogLevel level) {
     }
 }
 
-void svt_jxs_log(SvtLogLevel level, const char *tag, const char *format, ...) {
-    if (level > g_log_level)
+typedef struct DefaultLogCtx {
+    SvtLogLevel level;
+    FILE *file;
+} DefaultLogCtx;
+
+/* Handles both the default logger and a registered custom logger.
+ * If fn == default_logger, ctx is a DefaultLogCtx*, otherwise ctx is the user-provided context. */
+typedef struct SvtLogger {
+    SvtJxsLogCallback fn;
+    void *ctx;
+} SvtLogger;
+
+static void default_logger(void *context, SvtLogLevel level, const char *tag, const char *fmt, va_list args) {
+    DefaultLogCtx *logger = (DefaultLogCtx *)context;
+    if (level > logger->level)
+        return;
+    if (tag)
+        fprintf(logger->file, "%s[%s]: ", tag, log_level_str(level));
+    vfprintf(logger->file, fmt, args);
+    fflush(logger->file);
+}
+
+static SvtLogger *g_logger;
+
+static void logger_cleanup(void) {
+    if (g_logger->fn == default_logger) {
+        DefaultLogCtx *ctx = (DefaultLogCtx *)g_logger->ctx;
+        if (ctx->file && ctx->file != stderr)
+            fclose(ctx->file);
+        free(ctx);
+    }
+    free(g_logger);
+    g_logger = NULL;
+}
+
+// Staged by svt_jpeg_xs_set_log_callback() before first use; read exactly once by logger_create().
+static SvtLogger g_custom_logger_input;
+
+static void logger_create(void) {
+    g_logger = (SvtLogger *)calloc(1, sizeof(*g_logger));
+    if (!g_logger)
         return;
 
-    if (!g_log_file)
-        g_log_file = stderr;
+    SvtLogger custom = g_custom_logger_input;
+    if (custom.fn) {
+        // A custom logger was registered before the logger was first used.
+        *g_logger = custom;
+        atexit(logger_cleanup);
+        return;
+    }
 
-    if (tag)
-        fprintf(g_log_file, "%s[%s]: ", tag, log_level_str(level));
+    DefaultLogCtx *ctx = (DefaultLogCtx *)calloc(1, sizeof(*ctx));
+    if (!ctx) {
+        free(g_logger);
+        g_logger = NULL;
+        return;
+    }
+
+    const char *log = getenv("SVT_LOG");
+    ctx->level = SVT_LOG_INFO;
+    if (log) {
+        const int new_level = atoi(log);
+        if (new_level >= SVT_LOG_ALL && new_level <= SVT_LOG_DEBUG)
+            ctx->level = (SvtLogLevel)new_level;
+    }
+
+    const char *file = getenv("SVT_LOG_FILE");
+    if (file)
+        ctx->file = fopen(file, "w+");
+    if (!ctx->file)
+        ctx->file = stderr;
+
+    g_logger->fn = default_logger;
+    g_logger->ctx = ctx;
+    atexit(logger_cleanup);
+}
+
+#ifdef _WIN32
+#include <windows.h>
+
+static INIT_ONCE g_logger_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK logger_create_wrapper(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext) {
+    (void)InitOnce;
+    (void)Parameter;
+    (void)lpContext;
+    logger_create();
+    return TRUE;
+}
+
+static SvtLogger *get_logger(void) {
+    InitOnceExecuteOnce(&g_logger_once, logger_create_wrapper, NULL, NULL);
+    return g_logger;
+}
+#else
+#include <pthread.h>
+
+static pthread_once_t g_logger_once = PTHREAD_ONCE_INIT;
+
+static SvtLogger *get_logger(void) {
+    pthread_once(&g_logger_once, logger_create);
+    return g_logger;
+}
+#endif // _WIN32
+
+void svt_jxs_log_init() {
+    get_logger();
+}
+
+PREFIX_API void svt_jpeg_xs_set_log_callback(SvtJxsLogCallback callback, void *context) {
+    // Only take the custom context if a custom callback is also provided, so the default
+    // logger's own DefaultLogCtx* is never mistaken for a user context (or vice versa).
+    // Has effect only if called before the logger is first used (see logger_create()).
+    if (callback) {
+        g_custom_logger_input.fn = callback;
+        g_custom_logger_input.ctx = context;
+    }
+}
+
+void svt_jxs_log(SvtLogLevel level, const char *tag, const char *format, ...) {
+    SvtLogger *logger = get_logger();
+    if (!logger)
+        return;
 
     va_list args;
     va_start(args, format);
-    vfprintf(g_log_file, format, args);
+    logger->fn(logger->ctx, level, tag, format, args);
     va_end(args);
 }

--- a/Source/Lib/Common/Codec/SvtLog.h
+++ b/Source/Lib/Common/Codec/SvtLog.h
@@ -12,18 +12,15 @@
 #ifndef _SVT_LOG_H_
 #define _SVT_LOG_H_
 
+#include "SvtJpegxs.h" // SvtLogLevel, SvtJxsLogCallback
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #ifndef LOG_TAG
 #define LOG_TAG "Svt"
 #endif
-
-typedef enum {
-    SVT_LOG_ALL = -1,
-    SVT_LOG_FATAL = 0,
-    SVT_LOG_ERROR = 1,
-    SVT_LOG_WARN = 2,
-    SVT_LOG_INFO = 3,
-    SVT_LOG_DEBUG = 4,
-} SvtLogLevel;
 
 // define this to turn off all library log
 //#define SVT_LOG_QUIET
@@ -63,5 +60,9 @@ typedef enum {
 
 void svt_jxs_log_init();
 void svt_jxs_log(SvtLogLevel level, const char *tag, const char *format, ...);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif /*_SVT_LOG_H_*/

--- a/Source/Lib/Decoder/Codec/DecHandle.c
+++ b/Source/Lib/Decoder/Codec/DecHandle.c
@@ -75,27 +75,27 @@ PREFIX_API void svt_jpeg_xs_decoder_close(svt_jpeg_xs_decoder_api_t* dec_api) {
  **********************************/
 SvtJxsErrorType_t decoder_allocate_handle(svt_jpeg_xs_decoder_api_t* dec_api) {
     if (dec_api->verbose >= VERBOSE_SYSTEM_INFO) {
-        fprintf(stderr, "-------------------------------------------\n");
-        fprintf(stderr, "SVT [version]:\tSVT-JPEGXS Decoder Lib v%i.%i\n", SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR);
+        SVT_LOG("-------------------------------------------\n");
+        SVT_LOG("SVT [version]:\tSVT-JPEGXS Decoder Lib v%i.%i\n", SVT_JPEGXS_API_VER_MAJOR, SVT_JPEGXS_API_VER_MINOR);
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1930)
-        fprintf(stderr, "SVT [build]  :\tVisual Studio 2022");
+        SVT_LOG("SVT [build]  :\tVisual Studio 2022");
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
-        fprintf(stderr, "SVT [build]  :\tVisual Studio 2019");
+        SVT_LOG("SVT [build]  :\tVisual Studio 2019");
 #elif defined(_MSC_VER) && (_MSC_VER >= 1910)
-        fprintf(stderr, "SVT [build]  :\tVisual Studio 2017");
+        SVT_LOG("SVT [build]  :\tVisual Studio 2017");
 #elif defined(_MSC_VER) && (_MSC_VER >= 1900)
-        fprintf(stderr, "SVT [build]  :\tVisual Studio 2015");
+        SVT_LOG("SVT [build]  :\tVisual Studio 2015");
 #elif defined(_MSC_VER)
-        fprintf(stderr, "SVT [build]  :\tVisual Studio (old)");
+        SVT_LOG("SVT [build]  :\tVisual Studio (old)");
 #elif defined(__GNUC__)
-        fprintf(stderr, "SVT [build]  :\tGCC %s\t", __VERSION__);
+        SVT_LOG("SVT [build]  :\tGCC %s\t", __VERSION__);
 #else
-        fprintf(stderr, "SVT [build]  :\tunknown compiler");
+        SVT_LOG("SVT [build]  :\tunknown compiler");
 #endif
-        fprintf(stderr, " %zu bit\n", sizeof(void*) * 8);
-        fprintf(stderr, "LIB Build date: %s %s\n", __DATE__, __TIME__);
-        fprintf(stderr, "-------------------------------------------\n");
+        SVT_LOG(" %zu bit\n", sizeof(void*) * 8);
+        SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
+        SVT_LOG("-------------------------------------------\n");
     }
 
     SVT_CALLOC(dec_api->private_ptr, 1, sizeof(svt_jpeg_xs_decoder_api_prv_t));
@@ -133,7 +133,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
     dec_api_prv->packetization_mode = dec_api->packetization_mode;
     if (dec_api_prv->packetization_mode != 0 && dec_api_prv->packetization_mode != 1) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized packetization mode\n");
+            SVT_ERROR("Unrecognized packetization mode\n");
         }
         svt_jpeg_xs_decoder_close(dec_api);
         return SvtJxsErrorBadParameter;
@@ -142,7 +142,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
     dec_api_prv->dec_common.output_bit_depth_msb_aligned = dec_api->output_bit_depth_msb_aligned;
     if (dec_api_prv->dec_common.output_bit_depth_msb_aligned != 0 && dec_api_prv->dec_common.output_bit_depth_msb_aligned != 1) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized output_bit_depth_msb_aligned, expected: 0 or 1\n");
+            SVT_ERROR("Unrecognized output_bit_depth_msb_aligned, expected: 0 or 1\n");
         }
         svt_jpeg_xs_decoder_close(dec_api);
         return SvtJxsErrorBadParameter;
@@ -150,7 +150,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
 
     if (dec_api->proxy_mode >= proxy_mode_max) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized proxy mode\n");
+            SVT_ERROR("Unrecognized proxy mode\n");
         }
         svt_jpeg_xs_decoder_close(dec_api);
         return SvtJxsErrorBadParameter;
@@ -160,8 +160,8 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
     const CPU_FLAGS cpu_flags = get_cpu_flags();
     dec_api->use_cpu_flags &= cpu_flags;
     if (dec_api_prv->verbose >= VERBOSE_SYSTEM_INFO) {
-        fprintf(stderr, "[asm level on system : up to %s]\n", get_asm_level_name_str(cpu_flags));
-        fprintf(stderr, "[asm level selected : up to %s]\n", get_asm_level_name_str(dec_api->use_cpu_flags));
+        SVT_LOG("[asm level on system : up to %s]\n", get_asm_level_name_str(cpu_flags));
+        SVT_LOG("[asm level selected : up to %s]\n", get_asm_level_name_str(dec_api->use_cpu_flags));
     }
 
     setup_common_rtcd_internal(dec_api->use_cpu_flags);
@@ -169,7 +169,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
 
     //Init queue
     if (dec_api_prv->verbose >= VERBOSE_SYSTEM_INFO) {
-        fprintf(stderr, "[Threads            : %i]\n", dec_api->threads_num);
+        SVT_LOG("[Threads            : %i]\n", dec_api->threads_num);
     }
 
     //Zeroed handle memory
@@ -205,7 +205,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
     }
     if (dec_api_prv->packetization_mode == 1 && header_dynamic.hdr_Lcod == 0) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Packetization mode(multiple packets per frame) not supported with variable bitrate coding\n");
+            SVT_ERROR("Packetization mode(multiple packets per frame) not supported with variable bitrate coding\n");
         }
         svt_jpeg_xs_decoder_close(dec_api);
         return SvtJxsErrorBadParameter;
@@ -227,19 +227,16 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
                                                                    dec_api_prv->dec_common.picture_header_const.hdr_Sx,
                                                                    dec_api_prv->dec_common.picture_header_const.hdr_Sy);
         const char* color_format_name = svt_jpeg_xs_get_format_name(format);
-        fprintf(stderr, "-------------------------------------------\n");
-        fprintf(stderr,
-                "SVT [config]: Stream Resolution [width x height]     \t: %d x %d\n",
+        SVT_LOG("-------------------------------------------\n");
+        SVT_LOG("SVT [config]: Stream Resolution [width x height]     \t: %d x %d\n",
                 dec_api_prv->dec_common.picture_header_const.hdr_width,
                 dec_api_prv->dec_common.picture_header_const.hdr_height);
         if (dec_api_prv->proxy_mode != proxy_mode_full) {
-            fprintf(stderr,
-                    "SVT [config]: Decoding Resolution [width x height]     \t: %d x %d\n",
+            SVT_LOG("SVT [config]: Decoding Resolution [width x height]     \t: %d x %d\n",
                     out_image_config->width,
                     out_image_config->height);
         }
-        fprintf(stderr,
-                "SVT [config]: DecoderBitDepth / DecoderColorFormat\t: %d / %s\n",
+        SVT_LOG("SVT [config]: DecoderBitDepth / DecoderColorFormat\t: %d / %s\n",
                 dec_api_prv->dec_common.picture_header_const.hdr_bit_depth[0],
                 color_format_name);
     }
@@ -260,12 +257,12 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
         20; //Should be more that pool_decoders_instances_count to not reduce performance
 
     if (dec_api_prv->verbose >= VERBOSE_SYSTEM_INFO_ALL) {
-        fprintf(stderr, "-------------------------------------------\n");
-        fprintf(stderr, "[%s] universal_threads_num: %i\n", __FUNCTION__, (int)dec_api_prv->universal_threads_num);
-        fprintf(stderr, "[%s] TaskInputBitstreamQueueCount: %i\n", __FUNCTION__, (int)input_bitstream_queue_count);
-        fprintf(stderr, "[%s] OutoutBitstreamQueueCount: %i\n", __FUNCTION__, (int)output_bitsteram_queue_count);
-        fprintf(stderr, "[%s] sync_output_ringbuffer_size: %i\n", __FUNCTION__, (int)dec_api_prv->sync_output_ringbuffer_size);
-        fprintf(stderr, "[%s] PoolDecContextsNum: %i\n", __FUNCTION__, (int)pool_decoders_instances_count);
+        SVT_DEBUG("-------------------------------------------\n");
+        SVT_DEBUG("[%s] universal_threads_num: %i\n", __FUNCTION__, (int)dec_api_prv->universal_threads_num);
+        SVT_DEBUG("[%s] TaskInputBitstreamQueueCount: %i\n", __FUNCTION__, (int)input_bitstream_queue_count);
+        SVT_DEBUG("[%s] OutoutBitstreamQueueCount: %i\n", __FUNCTION__, (int)output_bitsteram_queue_count);
+        SVT_DEBUG("[%s] sync_output_ringbuffer_size: %i\n", __FUNCTION__, (int)dec_api_prv->sync_output_ringbuffer_size);
+        SVT_DEBUG("[%s] PoolDecContextsNum: %i\n", __FUNCTION__, (int)pool_decoders_instances_count);
     }
 
     if (!dec_api_prv->packetization_mode) {
@@ -357,11 +354,11 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_init(uint64_t version_api_major
     SVT_CREATE_THREAD(dec_api_prv->final_stage_thread_handle, thread_final_stage_kernel, dec_api_prv);
 
     if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-        fprintf(stderr, "[%s] End\n", __FUNCTION__);
+        SVT_DEBUG("[%s] End\n", __FUNCTION__);
     }
 
     if (dec_api_prv->verbose >= VERBOSE_ERRORS) {
-        fprintf(stderr, "-------------------------------------------\n");
+        SVT_LOG("-------------------------------------------\n");
         svt_jxs_log_init();
         svt_jxs_print_memory_usage();
     }
@@ -379,8 +376,8 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_send_frame(svt_jpeg_xs_decoder_
 
     if (dec_api_prv->packetization_mode) {
         if (dec_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "\nDecoder initialized for packet-based input, but svt_jpeg_xs_decoder_send_frame() is called\n");
-            fprintf(stderr, "Please use svt_jpeg_xs_decoder_send_packet() instead\n");
+            SVT_ERROR("\nDecoder initialized for packet-based input, but svt_jpeg_xs_decoder_send_frame() is called\n");
+            SVT_ERROR("Please use svt_jpeg_xs_decoder_send_packet() instead\n");
         }
         return SvtJxsErrorUndefined;
     }
@@ -390,7 +387,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_send_frame(svt_jpeg_xs_decoder_
     uint32_t pixel_size = input_bit_depth <= 8 ? sizeof(uint8_t) : sizeof(uint16_t);
     for (uint8_t c = 0; c < pi->comps_num; ++c) {
         if (dec_input->image.data_yuv[c] == NULL) {
-            fprintf(stderr, "Invalid input: data_yuv[%u] is NULL\n", c);
+            SVT_ERROR("Invalid input: data_yuv[%u] is NULL\n", c);
             return SvtJxsErrorBadParameter;
         }
         uint32_t min_size;
@@ -419,7 +416,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_send_frame(svt_jpeg_xs_decoder_
     }
 
     if (dec_api->verbose >= VERBOSE_INFO_MULTITHREADING) {
-        fprintf(stderr, "\n[%s] Send frame to Lib, Item: %p\n", __FUNCTION__, input_wrapper_ptr);
+        SVT_DEBUG("\n[%s] Send frame to Lib, Item: %p\n", __FUNCTION__, input_wrapper_ptr);
     }
 
     if ((input_wrapper_ptr != NULL) && (ret == SvtJxsErrorNone)) {
@@ -526,7 +523,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_decoder_send_eoc(svt_jpeg_xs_decoder_ap
         }
 
         if (dec_api->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "\n[%s] Send EOC to Lib, Item: %p\n", __FUNCTION__, input_wrapper_ptr);
+            SVT_DEBUG("\n[%s] Send EOC to Lib, Item: %p\n", __FUNCTION__, input_wrapper_ptr);
         }
 
         if (input_wrapper_ptr != NULL) {

--- a/Source/Lib/Decoder/Codec/DecThreadFinal.c
+++ b/Source/Lib/Decoder/Codec/DecThreadFinal.c
@@ -7,6 +7,7 @@
 #include "DecThreadFinal.h"
 #include "Threads/SvtThreads.h"
 #include "DecHandle.h"
+#include "SvtLog.h"
 
 SvtJxsErrorType_t final_sync_creator(void_ptr* object_dbl_ptr, void_ptr object_init_data_ptr) {
     UNUSED(object_init_data_ptr);
@@ -43,7 +44,7 @@ void* thread_final_stage_kernel(void* input_ptr) {
         ObjectWrapper_t* input_wrapper_ptr;
         // Get the Next svt Input Buffer [BLOCKING]
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "[%s] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__);
+            SVT_DEBUG("[%s] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__);
         }
         SVT_GET_FULL_OBJECT(dec_api_prv->final_consumer_fifo_ptr, &input_wrapper_ptr);
         TaskFinalSync* input_buffer_ptr = (TaskFinalSync*)input_wrapper_ptr->object_ptr;
@@ -126,7 +127,7 @@ void* thread_final_stage_kernel(void* input_ptr) {
             svt_jxs_release_object(wrapper_ptr_decoder_ctx);
 
             if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-                fprintf(stderr, "[%s] Get frame  %i Final thread\n", __FUNCTION__, (int)item->frame_num);
+                SVT_DEBUG("[%s] Get frame  %i Final thread\n", __FUNCTION__, (int)item->frame_num);
             }
         }
 
@@ -153,7 +154,7 @@ void* thread_final_stage_kernel(void* input_ptr) {
             buffer_output->frame_error = item->frame_error;
 
             if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-                fprintf(stderr, "[%s] Send frame  %i Final thread\n", __FUNCTION__, (int)item->frame_num);
+                SVT_DEBUG("[%s] Send frame  %i Final thread\n", __FUNCTION__, (int)item->frame_num);
             }
 
             svt_jxs_post_full_object(final_wrapper_ptr);

--- a/Source/Lib/Decoder/Codec/DecThreadInit.c
+++ b/Source/Lib/Decoder/Codec/DecThreadInit.c
@@ -9,6 +9,7 @@
 #include "SvtUtility.h"
 #include "Codestream.h"
 #include "SvtJpegxsImageBufferTools.h"
+#include "SvtLog.h"
 
 SvtJxsErrorType_t input_bitstream_creator(void_ptr* object_dbl_ptr, void_ptr object_init_data_ptr) {
     UNUSED(object_init_data_ptr);
@@ -181,11 +182,11 @@ static void send_slices_tasks(svt_jpeg_xs_decoder_api_prv_t* dec_api_prv, TaskIn
                     if (dec_ctx->picture_header_dynamic.hdr_Lcod != 0 &&
                         dec_ctx->picture_header_dynamic.hdr_Lcod != frame_bitstream_size) {
                         if (dec_api_prv->verbose >= VERBOSE_ERRORS) {
-                            fprintf(stderr,
-                                    "Warning: Frame decoded but may be broken! Decoded different stream size than expected from "
-                                    "header get=%u, expected=%u\n",
-                                    frame_bitstream_size,
-                                    dec_ctx->picture_header_dynamic.hdr_Lcod);
+                            SVT_WARN(
+                                "Warning: Frame decoded but may be broken! Decoded different stream size than expected from "
+                                "header get=%u, expected=%u\n",
+                                frame_bitstream_size,
+                                dec_ctx->picture_header_dynamic.hdr_Lcod);
                         }
                     }
                 }
@@ -226,18 +227,17 @@ void* thread_init_stage_kernel(void* input_ptr) {
         ObjectWrapper_t* input_wrapper_ptr;
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "[%s] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__);
+            SVT_DEBUG("[%s] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__);
         }
 
         SVT_GET_FULL_OBJECT(dec_api_prv->input_consumer_fifo_ptr, &input_wrapper_ptr);
         TaskInputBitstream* input_buffer_ptr = (TaskInputBitstream*)input_wrapper_ptr->object_ptr;
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr,
-                    "\n[%s] Send frame to Lib, Item: %p frame %lu\n",
-                    __FUNCTION__,
-                    input_wrapper_ptr,
-                    (unsigned long)frame_num);
+            SVT_DEBUG("\n[%s] Send frame to Lib, Item: %p frame %lu\n",
+                      __FUNCTION__,
+                      input_wrapper_ptr,
+                      (unsigned long)frame_num);
         }
 
         if (dec_api_prv->verbose >= VERBOSE_WARNINGS && (input_buffer_ptr->flags != SvtJxsDecoderEndOfCodestream)) {
@@ -251,23 +251,22 @@ void* thread_init_stage_kernel(void* input_ptr) {
                 dec_api_prv->proxy_mode);
             if ((ret != SvtJxsErrorNone) && input_buffer_ptr->dec_input.bitstream.used_size != read_size) {
                 //TODO: Hard to test this case and in future this problem should be removed
-                fprintf(stderr,
-                        "[%s] %p, %i Invalid frame, HOW TO HANDLE ERROR????\n",
-                        __FUNCTION__,
-                        input_buffer_ptr->dec_input.bitstream.buffer,
-                        (int32_t)input_buffer_ptr->dec_input.bitstream.used_size);
+                SVT_WARN("[%s] %p, %i Invalid frame, HOW TO HANDLE ERROR????\n",
+                         __FUNCTION__,
+                         input_buffer_ptr->dec_input.bitstream.buffer,
+                         (int32_t)input_buffer_ptr->dec_input.bitstream.used_size);
             }
         }
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "[%s] Before svt_jxs_get_empty_object(dec_api_prv->universal_producer_fifo_ptr\n", __FUNCTION__);
+            SVT_DEBUG("[%s] Before svt_jxs_get_empty_object(dec_api_prv->universal_producer_fifo_ptr\n", __FUNCTION__);
         }
 
         ObjectWrapper_t* wrapper_ptr_decoder_ctx = NULL;
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(
-                stderr, "[%s] Before svt_jxs_get_empty_object(dec_api_prv->internal_pool_frame_context_fifo_ptr\n", __FUNCTION__);
+            SVT_DEBUG(
+                "[%s] Before svt_jxs_get_empty_object(dec_api_prv->internal_pool_frame_context_fifo_ptr\n", __FUNCTION__);
         }
         SvtJxsErrorType_t err = svt_jxs_get_empty_object(dec_api_prv->internal_pool_decoder_instance_fifo_ptr,
                                                          &wrapper_ptr_decoder_ctx);
@@ -276,7 +275,7 @@ void* thread_init_stage_kernel(void* input_ptr) {
         }
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "[%s] Send frame  %i from Init thread\n", __FUNCTION__, (int)frame_num);
+            SVT_DEBUG("[%s] Send frame  %i from Init thread\n", __FUNCTION__, (int)frame_num);
         }
 
         svt_jpeg_xs_decoder_instance_t* dec_ctx = wrapper_ptr_decoder_ctx->object_ptr;
@@ -308,11 +307,11 @@ void* thread_init_stage_kernel(void* input_ptr) {
             if (dec_api_prv->verbose >= VERBOSE_ERRORS) {
                 if (input_buffer_ptr->flags == SvtJxsDecoderEndOfCodestream) {
                     if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-                        fprintf(stderr, "[%s] Send EOC frame: %i\n", __FUNCTION__, (int)dec_ctx->frame_num);
+                        SVT_DEBUG("[%s] Send EOC frame: %i\n", __FUNCTION__, (int)dec_ctx->frame_num);
                     }
                 }
                 else {
-                    fprintf(stderr, "[%s] Invalid Header frame: %i\n", __FUNCTION__, (int)dec_ctx->frame_num);
+                    SVT_ERROR("[%s] Invalid Header frame: %i\n", __FUNCTION__, (int)dec_ctx->frame_num);
                 }
             }
             ObjectWrapper_t* universal_wrapper_ptr = NULL;

--- a/Source/Lib/Decoder/Codec/DecThreadSlice.c
+++ b/Source/Lib/Decoder/Codec/DecThreadSlice.c
@@ -6,6 +6,7 @@
 #include "DecThreads.h"
 #include "DecThreadSlice.h"
 #include "DecThreadFinal.h"
+#include "SvtLog.h"
 
 /*Create input buffer item.*/
 SvtJxsErrorType_t universal_frame_task_creator(void_ptr* object_dbl_ptr, void_ptr object_init_data_ptr) {
@@ -65,7 +66,7 @@ void* thread_universal_stage_kernel(void* input_ptr) {
     for (;;) {
         ObjectWrapper_t* input_wrapper_ptr;
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr, "[%s][ThreadId %i] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__, universal_ctx->process_idx);
+            SVT_DEBUG("[%s][ThreadId %i] Before SVT_GET_FULL_OBJECT\n", __FUNCTION__, universal_ctx->process_idx);
         }
         SVT_GET_FULL_OBJECT(/*dec_api_prv->universal_consumer_fifo_ptr*/ universal_ctx->universal_consumer_fifo_ptr,
                             &input_wrapper_ptr);
@@ -73,11 +74,10 @@ void* thread_universal_stage_kernel(void* input_ptr) {
         svt_jpeg_xs_decoder_instance_t* dec_ctx = input_buffer_ptr->wrapper_ptr_decoder_ctx->object_ptr;
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr,
-                    "[%s][ThreadId %i] Get frame  %i from work thread\n",
-                    __FUNCTION__,
-                    universal_ctx->process_idx,
-                    (int)dec_ctx->frame_num);
+            SVT_DEBUG("[%s][ThreadId %i] Get frame  %i from work thread\n",
+                      __FUNCTION__,
+                      universal_ctx->process_idx,
+                      (int)dec_ctx->frame_num);
         }
 
         SvtJxsErrorType_t ret_decode = SvtJxsErrorNone;
@@ -99,25 +99,23 @@ void* thread_universal_stage_kernel(void* input_ptr) {
 
         if (dec_api_prv->verbose >= VERBOSE_WARNINGS) {
             if (ret_decode >= 0 && ret_decode != (int)input_buffer_ptr->bitstream_buf_size) {
-                fprintf(stderr,
-                        "[%s:Process ID: %i] WARNING frame %i !!! Unexpected size of frame, expected: %i get: %i\n",
-                        __FUNCTION__,
-                        universal_ctx->process_idx,
-                        (int)dec_ctx->frame_num,
-                        (int)input_buffer_ptr->bitstream_buf_size,
-                        ret_decode);
+                SVT_WARN("[%s:Process ID: %i] WARNING frame %i !!! Unexpected size of frame, expected: %i get: %i\n",
+                         __FUNCTION__,
+                         universal_ctx->process_idx,
+                         (int)dec_ctx->frame_num,
+                         (int)input_buffer_ptr->bitstream_buf_size,
+                         ret_decode);
             }
         }
 
         if (ret_decode < 0) {
             if (dec_api_prv->verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr,
-                        "[%s:Process ID: %i] %i, %p, %i HANDLE ERROR!!!\n",
-                        __FUNCTION__,
-                        universal_ctx->process_idx,
-                        (int)dec_ctx->frame_num,
-                        input_buffer_ptr->bitstream_buf,
-                        (int)input_buffer_ptr->bitstream_buf_size);
+                SVT_ERROR("[%s:Process ID: %i] %i, %p, %i HANDLE ERROR!!!\n",
+                          __FUNCTION__,
+                          universal_ctx->process_idx,
+                          (int)dec_ctx->frame_num,
+                          input_buffer_ptr->bitstream_buf,
+                          (int)input_buffer_ptr->bitstream_buf_size);
             }
         }
 
@@ -133,11 +131,10 @@ void* thread_universal_stage_kernel(void* input_ptr) {
         buffer_output->frame_error = input_buffer_ptr->frame_error;
 
         if (dec_api_prv->verbose >= VERBOSE_INFO_MULTITHREADING) {
-            fprintf(stderr,
-                    "[%s][ThreadId %i] Send frame  %i from work thread\n",
-                    __FUNCTION__,
-                    universal_ctx->process_idx,
-                    (int)dec_ctx->frame_num);
+            SVT_DEBUG("[%s][ThreadId %i] Send frame  %i from work thread\n",
+                      __FUNCTION__,
+                      universal_ctx->process_idx,
+                      (int)dec_ctx->frame_num);
         }
 
         svt_jxs_post_full_object(universal_wrapper_ptr);

--- a/Source/Lib/Decoder/Codec/Decoder.c
+++ b/Source/Lib/Decoder/Codec/Decoder.c
@@ -10,6 +10,7 @@
 #include "Packing.h"
 #include "Precinct.h"
 #include "Mct.h"
+#include "SvtLog.h"
 
 #include "NltDec.h"
 
@@ -527,7 +528,7 @@ SvtJxsErrorType_t svt_jpeg_xs_decode_slice(svt_jpeg_xs_decoder_instance_t* ctx, 
     }
     if (slice_idx != slice) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: (slice index) corruption detected  index=%d , expected=%d\n", slice_idx, slice);
+            SVT_ERROR("Error: (slice index) corruption detected  index=%d , expected=%d\n", slice_idx, slice);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }

--- a/Source/Lib/Decoder/Codec/Mct.c
+++ b/Source/Lib/Decoder/Codec/Mct.c
@@ -6,6 +6,7 @@
 #include "Mct.h"
 #include "Definitions.h"
 #include "Pi.h"
+#include "SvtLog.h"
 
 #define MAX_COMPONENTS 4
 #define MAX_CFA_TYPE   2
@@ -195,7 +196,7 @@ void mct_inverse_transform(int32_t* out_comps[MAX_COMPONENTS_NUM], const pi_t* p
                             h);
     }
     else {
-        fprintf(stderr, "Unknown color transform!!\n");
+        SVT_ERROR("Unknown color transform!!\n");
         assert(0);
     }
 }
@@ -218,7 +219,7 @@ void mct_inverse_transform_precinct(int32_t* out_comps[MAX_COMPONENTS_NUM],
                             h);
     }
     else {
-        fprintf(stderr, "Unknown color transform!!\n");
+        SVT_ERROR("Unknown color transform!!\n");
         assert(0);
     }
 }

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -9,6 +9,7 @@
 #include "EncDec.h"
 #include "Codestream.h"
 #include "decoder_dsp_rtcd.h"
+#include "SvtLog.h"
 
 typedef struct vlc_reader {
     uint8_t const* mem;
@@ -536,7 +537,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
         coding_modes[band] = read_2_bit(bitstream);
         if (prec_top == NULL && (coding_modes[band] & CODING_MODE_FLAG_VERTICAL_PRED)) {
             if (verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr, "Error: First precinct in Slice could not have Vertical Prediction!\n");
+                SVT_ERROR("Error: First precinct in Slice could not have Vertical Prediction!\n");
             }
             return SvtJxsErrorDecoderInvalidBitstream;
         }
@@ -660,7 +661,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                                 &precinct_bits_left);
                             if (ret) {
                                 if (verbose >= VERBOSE_ERRORS) {
-                                    fprintf(stderr,
+                                    SVT_ERROR(
                                             "Error: Invalid Variable Length Coding, Vertical Prediction Significance!!!\n");
                                 }
                                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -672,7 +673,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                                 bitstream, &prec->bands[c][b], &prec->p_info->b_info[c][b], ypos, &precinct_bits_left);
                             if (ret) {
                                 if (verbose >= VERBOSE_ERRORS) {
-                                    fprintf(stderr, "Error: Invalid Variable Length Coding, Predict from zero Significance!!!\n");
+                                    SVT_ERROR("Error: Invalid Variable Length Coding, Predict from zero Significance!!!\n");
                                 }
                                 return SvtJxsErrorDecoderInvalidBitstream;
                             }
@@ -691,7 +692,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                                 &precinct_bits_left);
                             if (ret) {
                                 if (verbose >= VERBOSE_ERRORS) {
-                                    fprintf(stderr,
+                                    SVT_ERROR(
                                             "Error: Invalid Variable Length Coding, Vertical Prediction Non Significance!!!\n");
                                 }
                                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -703,7 +704,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                                 bitstream, &prec->bands[c][b], &prec->p_info->b_info[c][b], ypos, &precinct_bits_left);
                             if (ret) {
                                 if (verbose >= VERBOSE_ERRORS) {
-                                    fprintf(stderr,
+                                    SVT_ERROR(
                                             "Error: Invalid Variable Length Coding, Predict from zero Non Significance!!!\n");
                                 }
                                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -722,7 +723,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
             int32_t leftover = (int32_t)pkt_header.gcli_len - (int32_t)subpkt_len_bytes;
             if (leftover > 0 && bitstream_reader_is_enough_bytes(bitstream, leftover)) {
                 if (verbose >= VERBOSE_WARNINGS) {
-                    fprintf(stderr, "WARNING: (GCLI) skipped=%d\n", leftover);
+                    SVT_WARN("WARNING: (GCLI) skipped=%d\n", leftover);
                 }
                 bitstream_reader_add_padding(bitstream, leftover);
                 // Fix: Deduct padding from budget to prevent drift between
@@ -731,7 +732,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
             }
             else {
                 if (verbose >= VERBOSE_ERRORS) {
-                    fprintf(stderr,
+                    SVT_ERROR(
                             "Error: (GCLI) corruption detected - unpacked=%d , expected=%d\n",
                             subpkt_len_bytes,
                             pkt_header.gcli_len);
@@ -765,7 +766,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
 
                 if (ret) {
                     if (verbose >= VERBOSE_ERRORS) {
-                        fprintf(stderr, "Error: unpack_data, invalid bitstream!!!\n");
+                        SVT_ERROR("Error: unpack_data, invalid bitstream!!!\n");
                     }
                     return SvtJxsErrorDecoderInvalidBitstream;
                 }
@@ -780,7 +781,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
             int32_t leftover = (int32_t)pkt_header.data_len - (int32_t)subpkt_len_bytes;
             if (leftover > 0 && bitstream_reader_is_enough_bytes(bitstream, leftover)) {
                 if (verbose >= VERBOSE_WARNINGS) {
-                    fprintf(stderr, "WARNING: (DATA) skipped=%d\n", leftover);
+                    SVT_WARN("WARNING: (DATA) skipped=%d\n", leftover);
                 }
                 bitstream_reader_add_padding(bitstream, leftover);
                 // Fix: Deduct padding from budget to prevent drift between
@@ -789,7 +790,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
             }
             else {
                 if (verbose >= VERBOSE_ERRORS) {
-                    fprintf(stderr,
+                    SVT_ERROR(
                             "Error: (DATA) corruption detected - unpacked=%d , expected=%d\n",
                             subpkt_len_bytes,
                             pkt_header.data_len);
@@ -817,7 +818,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                                                         &precinct_bits_left);
                     if (ret) {
                         if (verbose >= VERBOSE_ERRORS) {
-                            fprintf(stderr, "Error: unpack_sign, invalid bitstream!!!\n");
+                            SVT_ERROR("Error: unpack_sign, invalid bitstream!!!\n");
                         }
                         return SvtJxsErrorDecoderInvalidBitstream;
                     }
@@ -831,7 +832,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                 int32_t leftover = (int32_t)pkt_header.sign_len - (int32_t)subpkt_len_bytes;
                 if (leftover > 0 && bitstream_reader_is_enough_bytes(bitstream, leftover)) {
                     if (verbose >= VERBOSE_WARNINGS) {
-                        fprintf(stderr, "WARNING: (SIGN) skipped=%d\n", leftover);
+                        SVT_WARN("WARNING: (SIGN) skipped=%d\n", leftover);
                     }
                     bitstream_reader_add_padding(bitstream, leftover);
                     // Fix: Deduct padding from budget to prevent drift between
@@ -840,7 +841,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
                 }
                 else {
                     if (verbose >= VERBOSE_ERRORS) {
-                        fprintf(stderr,
+                        SVT_ERROR(
                                 "Error: (SIGN) corruption detected - unpacked=%d , expected=%d\n",
                                 subpkt_len_bytes,
                                 pkt_header.sign_len);
@@ -855,7 +856,7 @@ SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* pre
         ((int32_t)bitstream_reader_get_used_bytes(bitstream) - (int32_t)byte_pos_precinct);
     if (padding_len_bytes < 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
+            SVT_ERROR(
                     "Error: (PRECINCT) corruption detected size, expected max =%d , get=%d\n",
                     precinct_len_bytes,
                     bitstream_reader_get_used_bytes(bitstream) + (int32_t)byte_pos_precinct);

--- a/Source/Lib/Decoder/Codec/ParseHeader.c
+++ b/Source/Lib/Decoder/Codec/ParseHeader.c
@@ -13,6 +13,7 @@
 #include "Pi.h"
 #include "Codestream.h"
 #include "SvtJpegxsDec.h"
+#include "SvtLog.h"
 
 /* Maximum number of components allowed by the JPEG XS spec (ISO/IEC 21122) */
 #define JPEGXS_SPEC_MAX_COMPONENTS_NUM (8)
@@ -78,7 +79,7 @@ SvtJxsErrorType_t get_capabilities(bitstream_reader_t* bitstream, picture_header
                                    uint32_t verbose) {
     if (picture_header_const->marker_exist_CAP) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Capabilities marker!\n");
+            SVT_ERROR("Unexpected Capabilities marker!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -90,7 +91,7 @@ SvtJxsErrorType_t get_capabilities(bitstream_reader_t* bitstream, picture_header
     uint16_t val = read_16_bits(bitstream);
     if (val != CODESTREAM_CAP) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Capabilities marker not found!\n");
+            SVT_ERROR("Capabilities marker not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -118,13 +119,13 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
                                      picture_header_dynamic_t* picture_header_dynamic, uint32_t verbose) {
     if (picture_header_const->marker_exist_CAP == 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Capabilities marker Not found!\n");
+            SVT_ERROR("Capabilities marker Not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
     if (picture_header_const->marker_exist_PIH) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Picture header!\n");
+            SVT_ERROR("Unexpected Picture header!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -137,14 +138,14 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
     uint16_t val = read_16_bits(bitstream);
     if (val != CODESTREAM_PIH) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header marker not found!\n");
+            SVT_ERROR("Picture header marker not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
     uint16_t size_bytes = read_16_bits(bitstream);
     if (size_bytes != PICTURE_HEADER_SIZE_BYTES) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header size invalid, expected=26, read=%d!\n", size_bytes);
+            SVT_ERROR("Picture header size invalid, expected=26, read=%d!\n", size_bytes);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -160,7 +161,7 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
     picture_header_const->hdr_Hsl = read_16_bits(bitstream);
     if (picture_header_const->hdr_Hsl < 1) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header invalid Height of a slice in precincts, read=%d!\n", picture_header_const->hdr_Hsl);
+            SVT_ERROR("Picture header invalid Height of a slice in precincts, read=%d!\n", picture_header_const->hdr_Hsl);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -168,7 +169,7 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
     picture_header_const->hdr_comps_num = read_8_bits(bitstream);
     if (picture_header_const->hdr_comps_num < 1 || picture_header_const->hdr_comps_num > JPEGXS_SPEC_MAX_COMPONENTS_NUM) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
+            SVT_ERROR(
                     "Picture header invalid number of components expected 1-%d, read=%d!\n",
                     JPEGXS_SPEC_MAX_COMPONENTS_NUM,
                     picture_header_const->hdr_comps_num);
@@ -188,7 +189,7 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
     picture_header_const->hdr_significance_group_size = read_8_bits(bitstream);
     if (picture_header_const->hdr_significance_group_size != 8) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
+            SVT_ERROR(
                     "Picture header invalid coeff group expected 8, read=%d!\n",
                     picture_header_const->hdr_significance_group_size);
         }
@@ -208,7 +209,7 @@ SvtJxsErrorType_t get_picture_header(bitstream_reader_t* bitstream, picture_head
 
     if (picture_header_dynamic->hdr_Br != 4) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header invalid Br expected 4, read=%d!\n", picture_header_dynamic->hdr_Br);
+            SVT_ERROR("Picture header invalid Br expected 4, read=%d!\n", picture_header_dynamic->hdr_Br);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -259,21 +260,21 @@ SvtJxsErrorType_t get_component_table(bitstream_reader_t* bitstream, picture_hea
 
     if (picture_header_const->marker_exist_CAP == 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Capabilities marker Not found!\n");
+            SVT_ERROR("Capabilities marker Not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
 
     if (picture_header_const->marker_exist_PIH == 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header Not found!\n");
+            SVT_ERROR("Picture header Not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
 
     if (picture_header_const->marker_exist_CDT) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Component table!\n");
+            SVT_ERROR("Unexpected Component table!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -294,7 +295,7 @@ SvtJxsErrorType_t get_component_table(bitstream_reader_t* bitstream, picture_hea
         picture_header_const->hdr_comps_num > sizeof(picture_header_const->hdr_Sx) / sizeof(picture_header_const->hdr_Sx[0]) ||
         picture_header_const->hdr_comps_num > sizeof(picture_header_const->hdr_Sy) / sizeof(picture_header_const->hdr_Sy[0])) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Not supported number of components! Max: %u\n", MAX_COMPONENTS_NUM);
+            SVT_ERROR("Not supported number of components! Max: %u\n", MAX_COMPONENTS_NUM);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -315,21 +316,21 @@ SvtJxsErrorType_t get_weights_table(bitstream_reader_t* bitstream, picture_heade
                                     uint32_t verbose) {
     if (picture_header_const->marker_exist_CAP == 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Capabilities marker Not found!\n");
+            SVT_ERROR("Capabilities marker Not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
 
     if (picture_header_const->marker_exist_PIH == 0) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Picture header Not found!\n");
+            SVT_ERROR("Picture header Not found!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
 
     if (picture_header_const->marker_exist_WGT) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Component table!\n");
+            SVT_ERROR("Unexpected Component table!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -344,7 +345,7 @@ SvtJxsErrorType_t get_weights_table(bitstream_reader_t* bitstream, picture_heade
 
     if (size_bytes & 1) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Invalid Odd bytes in weight table !\n");
+            SVT_ERROR("Invalid Odd bytes in weight table !\n");
         }
         return SvtJxsErrorDecoderBitstreamTooShort;
     }
@@ -354,7 +355,7 @@ SvtJxsErrorType_t get_weights_table(bitstream_reader_t* bitstream, picture_heade
         bands_exist > sizeof(picture_header_const->hdr_gain) / sizeof(picture_header_const->hdr_gain[0]) ||
         bands_exist > sizeof(picture_header_const->hdr_priority) / sizeof(picture_header_const->hdr_priority[0])) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Not supported elements in weight table! Max: %u\n", MAX_BANDS_NUM);
+            SVT_ERROR("Not supported elements in weight table! Max: %u\n", MAX_BANDS_NUM);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -396,7 +397,7 @@ SvtJxsErrorType_t get_nonlinearity(bitstream_reader_t* bitstream, picture_header
     }
     else {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized nonlinearity type=%d\n", picture_header_dynamic->hdr_Tnlt);
+            SVT_ERROR("Unrecognized nonlinearity type=%d\n", picture_header_dynamic->hdr_Tnlt);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -418,7 +419,7 @@ SvtJxsErrorType_t get_cwd(bitstream_reader_t* bitstream, picture_header_const_t*
 SvtJxsErrorType_t get_cts(bitstream_reader_t* bitstream, picture_header_dynamic_t* picture_header_dynamic, uint32_t verbose) {
     if (picture_header_dynamic->marker_exist_CTS) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Colour transformation specification marker!\n");
+            SVT_ERROR("Unexpected Colour transformation specification marker!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -447,7 +448,7 @@ SvtJxsErrorType_t get_crg(bitstream_reader_t* bitstream, picture_header_const_t*
                           picture_header_dynamic_t* picture_header_dynamic, uint32_t verbose) {
     if (picture_header_dynamic->marker_exist_CRG) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unexpected Component registration marker!\n");
+            SVT_ERROR("Unexpected Component registration marker!\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -467,7 +468,7 @@ SvtJxsErrorType_t get_crg(bitstream_reader_t* bitstream, picture_header_const_t*
         picture_header_const->hdr_comps_num >
             sizeof(picture_header_dynamic->hdr_Ycrg) / sizeof(picture_header_dynamic->hdr_Ycrg[0])) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Not supported number of components! Max: %u\n", MAX_COMPONENTS_NUM);
+            SVT_ERROR("Not supported number of components! Max: %u\n", MAX_COMPONENTS_NUM);
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -519,7 +520,7 @@ SvtJxsErrorType_t get_header(bitstream_reader_t* bitstream, picture_header_const
     val = read_16_bits(bitstream);
     if (val != CODESTREAM_SOC) {
         if (verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Start of codestream marker not found\n");
+            SVT_ERROR("Start of codestream marker not found\n");
         }
         return SvtJxsErrorDecoderInvalidBitstream;
     }
@@ -576,7 +577,7 @@ SvtJxsErrorType_t get_header(bitstream_reader_t* bitstream, picture_header_const
             if (picture_header_const->marker_exist_CAP == 0 || picture_header_const->marker_exist_PIH == 0 ||
                 picture_header_const->marker_exist_CDT == 0 || picture_header_const->marker_exist_WGT == 0) {
                 if (verbose >= VERBOSE_ERRORS) {
-                    fprintf(stderr, "Mandatory markers not found!\n");
+                    SVT_ERROR("Mandatory markers not found!\n");
                 }
                 return SvtJxsErrorDecoderInvalidBitstream;
             }
@@ -586,7 +587,7 @@ SvtJxsErrorType_t get_header(bitstream_reader_t* bitstream, picture_header_const
                     if (picture_header_const->hdr_Sx[c] != picture_header_const->hdr_Sx[0] ||
                         picture_header_const->hdr_Sy[c] != picture_header_const->hdr_Sy[0]) {
                         if (verbose >= VERBOSE_ERRORS) {
-                            fprintf(stderr, "Invalid YUV format for filter Color Transform!\n");
+                            SVT_ERROR("Invalid YUV format for filter Color Transform!\n");
                         }
                         return SvtJxsErrorDecoderInvalidBitstream;
                     }
@@ -596,7 +597,7 @@ SvtJxsErrorType_t get_header(bitstream_reader_t* bitstream, picture_header_const
             if (picture_header_const->hdr_Cpih == 3) {
                 if (picture_header_dynamic->marker_exist_CTS == 0 || picture_header_dynamic->marker_exist_CRG == 0) {
                     if (verbose >= VERBOSE_ERRORS) {
-                        fprintf(stderr, "Mandatory markers not found!\n");
+                        SVT_ERROR("Mandatory markers not found!\n");
                     }
                     return SvtJxsErrorDecoderInvalidBitstream;
                 }
@@ -605,7 +606,7 @@ SvtJxsErrorType_t get_header(bitstream_reader_t* bitstream, picture_header_const
             return SvtJxsErrorNone;
         default:
             if (verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr, "Unrecognized marker found!\n");
+                SVT_ERROR("Unrecognized marker found!\n");
             }
             return SvtJxsErrorDecoderInvalidBitstream;
         }
@@ -833,7 +834,7 @@ SvtJxsErrorType_t static_get_single_frame_size(const uint8_t* bitstream_buf, siz
                         const uint64_t byte_size64 = (uint64_t)out_image_config->components[c].width *
                             out_image_config->components[c].height * pixel_size;
                         if (byte_size64 > UINT32_MAX) {
-                            fprintf(stderr,
+                            SVT_ERROR(
                                     "Image component %d byte_size overflow: %" PRIu64 " exceeds uint32 max\n",
                                     c,
                                     byte_size64);

--- a/Source/Lib/Encoder/Codec/EncHandle.c
+++ b/Source/Lib/Encoder/Codec/EncHandle.c
@@ -136,7 +136,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     enc_common->bit_depth = config_struct->input_bit_depth;
     if (enc_common->bit_depth < 8 || enc_common->bit_depth > 14) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Incorrect bit_depth, expected: 8 to 14,  provided: %d\n", enc_common->bit_depth);
+            SVT_ERROR("Incorrect bit_depth, expected: 8 to 14,  provided: %d\n", enc_common->bit_depth);
         }
         return SvtJxsErrorBadParameter;
     }
@@ -144,7 +144,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     if (enc_common->picture_header_dynamic.hdr_input_msb_aligned != 0 &&
         enc_common->picture_header_dynamic.hdr_input_msb_aligned != 1) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized input_bit_depth_msb_aligned, expected: 0 or 1\n");
+            SVT_ERROR("Unrecognized input_bit_depth_msb_aligned, expected: 0 or 1\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -157,7 +157,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (config_struct->ndecomp_v == 0 && config_struct->colour_format == COLOUR_FORMAT_PLANAR_YUV420) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
+            SVT_ERROR(
                     "Error: The input format YUV420 requires vertical decomposition level 1 or 2, provided %d\n",
                     config_struct->ndecomp_v);
         }
@@ -166,40 +166,40 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (config_struct->slice_height == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: slice_height cannot be 0\n");
+            SVT_ERROR("Error: slice_height cannot be 0\n");
         }
         return SvtJxsErrorBadParameter;
     }
     if (config_struct->slice_height >= config_struct->source_height) {
         if (config_struct->verbose >= VERBOSE_SYSTEM_INFO) {
-            fprintf(stderr, "Warning: slice_height is limited to source_height %d\n", config_struct->source_height);
+            SVT_WARN("Warning: slice_height is limited to source_height %d\n", config_struct->source_height);
         }
         config_struct->slice_height = config_struct->source_height;
     }
     else if (config_struct->slice_height % ((uint32_t)1 << config_struct->ndecomp_v)) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: slice_height have to be multiple of 2^(decomp_v)\n");
+            SVT_ERROR("Error: slice_height have to be multiple of 2^(decomp_v)\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->quantization != QUANT_TYPE_DEADZONE && config_struct->quantization != QUANT_TYPE_UNIFORM) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized quantization method provided, expected 0 or 1\n");
+            SVT_ERROR("Unrecognized quantization method provided, expected 0 or 1\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->bpp_denominator == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "bpp_denominator cannot be 0!\n");
+            SVT_ERROR("bpp_denominator cannot be 0!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->bpp_numerator == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "bpp_numerator cannot be 0!\n");
+            SVT_ERROR("bpp_numerator cannot be 0!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -211,14 +211,14 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (bytes_per_frame >= (((uint64_t)1) << 32)) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Impossible compression. Please use smaller bpp param!\n");
+            SVT_ERROR("Impossible compression. Please use smaller bpp param!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (bytes_per_frame == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Impossible compression. Please use bigger bpp param!\n");
+            SVT_ERROR("Impossible compression. Please use bigger bpp param!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -241,14 +241,14 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     enc_common->cpu_profile = config_struct->cpu_profile;
     if (enc_common->cpu_profile != CPU_PROFILE_LOW_LATENCY && enc_common->cpu_profile != CPU_PROFILE_CPU) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized cpu_profile provided!\n");
+            SVT_ERROR("Unrecognized cpu_profile provided!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (enc_common->rate_control_mode >= RC_MODE_SIZE) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Unrecognized rc mode provided!\n");
+            SVT_ERROR("Unrecognized rc mode provided!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -261,7 +261,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     if (config_struct->coding_vertical_prediction_mode >= METHOD_PRED_SIZE) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
             //Invalid VPrediction mode
-            fprintf(stderr, "Error: Invalid Vertical Prediction Mode!\n");
+            SVT_ERROR("Error: Invalid Vertical Prediction Mode!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -279,13 +279,13 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (config_struct->coding_signs_handling > SIGN_HANDLING_STRATEGY_FULL) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Invalid coding_signs_handling mode!\n");
+            SVT_ERROR("Error: Invalid coding_signs_handling mode!\n");
         }
         return SvtJxsErrorBadParameter;
     }
     if (config_struct->coding_signs_handling == SIGN_HANDLING_STRATEGY_FAST) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr,
+            SVT_WARN(
                     "Warning: coding_signs_handling PACK mode in this RC mode do not have any quality benefits. Only slow down "
                     "performance!\n");
         }
@@ -305,7 +305,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (config_struct->source_width < 4) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Minimum Width is 4!\n");
+            SVT_ERROR("Error: Minimum Width is 4!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -313,7 +313,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     if ((COLOUR_FORMAT_PLANAR_YUV422 == enc_common->colour_format || COLOUR_FORMAT_PLANAR_YUV420 == enc_common->colour_format) &&
         (config_struct->source_width % 2 != 0)) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: The input format requires a width divisible by 2!\n");
+            SVT_ERROR("Error: The input format requires a width divisible by 2!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -321,13 +321,13 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     if (COLOUR_FORMAT_PLANAR_YUV420 == enc_common->colour_format) {
         if (config_struct->source_height % 2 != 0) {
             if (config_struct->verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr, "Error: The input format YUV420 requires a height divisible by 2!\n");
+                SVT_ERROR("Error: The input format YUV420 requires a height divisible by 2!\n");
             }
             return SvtJxsErrorBadParameter;
         }
         if (config_struct->ndecomp_v == 0) {
             if (config_struct->verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr, "Error: The input format YUV420 requires not zeroed Vertical Decomposition!\n");
+                SVT_ERROR("Error: The input format YUV420 requires not zeroed Vertical Decomposition!\n");
             }
             return SvtJxsErrorBadParameter;
         }
@@ -336,35 +336,35 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     if (enc_common->colour_format == COLOUR_FORMAT_PACKED_YUV444_OR_RGB && enc_common->cpu_profile == CPU_PROFILE_CPU) {
         //TODO: Implement packed RGB/YUV444 in threading model CPU_PROFILE_CPU
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: The input format packed YUV/RGB works only in Low latency threading model!\n");
+            SVT_ERROR("Error: The input format packed YUV/RGB works only in Low latency threading model!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->ndecomp_v > 2) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Vertical Decomposition is too big (range 0-2)!\n");
+            SVT_ERROR("Error: Vertical Decomposition is too big (range 0-2)!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->ndecomp_h > 5) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Horizontal Decomposition is too big (range 0-5)!\n");
+            SVT_ERROR("Error: Horizontal Decomposition is too big (range 0-5)!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->ndecomp_h < config_struct->ndecomp_v) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: The horizontal decomposition must be greater or equal to the vertical decomposition!\n");
+            SVT_ERROR("Error: The horizontal decomposition must be greater or equal to the vertical decomposition!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (config_struct->ndecomp_h == 0 && config_struct->ndecomp_v == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Zero decomposition not supported now yet!\n");
+            SVT_ERROR("Error: Zero decomposition not supported now yet!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -406,14 +406,14 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
 
     if (min_width_band == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "The width is too small for this format, use less Horizontal Decomposition!\n");
+            SVT_ERROR("The width is too small for this format, use less Horizontal Decomposition!\n");
         }
         return SvtJxsErrorBadParameter;
     }
 
     if (min_height_band == 0) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "The height is too small for this format, use less Vertical Decomposition!\n");
+            SVT_ERROR("The height is too small for this format, use less Vertical Decomposition!\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -449,7 +449,7 @@ static SvtJxsErrorType_t encoder_init_configuration(svt_jpeg_xs_encoder_common_t
     return_error = weight_table_calculate(pi, config_struct->verbose, enc_common->colour_format);
     if (return_error) {
         if (config_struct->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Error: Error calculate Weight Tables for this configuration\n");
+            SVT_ERROR("Error: Error calculate Weight Tables for this configuration\n");
         }
         return SvtJxsErrorBadParameter;
     }
@@ -515,7 +515,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_load_default_parameters(uint64_
     }
 
     if (!enc_api) {
-        fprintf(stderr, "Error: svt_jpeg_xs_encoder_api_t parameter cannot be NULL!\n");
+        SVT_ERROR("Error: svt_jpeg_xs_encoder_api_t parameter cannot be NULL!\n");
         return SvtJxsErrorBadParameter;
     }
 
@@ -578,7 +578,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_get_image_config(uint64_t versi
     out_image_config->format = enc_api->colour_format;
     if (out_image_config->bit_depth < 8 || out_image_config->bit_depth > 14) {
         if (enc_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Incorrect bit_depth, expected: 8 to 14,  provided: %d\n", out_image_config->bit_depth);
+            SVT_ERROR("Incorrect bit_depth, expected: 8 to 14,  provided: %d\n", out_image_config->bit_depth);
         }
         return SvtJxsErrorBadParameter;
     }
@@ -600,7 +600,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_get_image_config(uint64_t versi
         //Single plane of size w*h*3
         const uint64_t byte_size64 = (uint64_t)enc_api->source_width * enc_api->source_height * 3 * pixel_size;
         if (byte_size64 > UINT32_MAX) {
-            fprintf(stderr, "Image component 0 byte_size overflow: %" PRIu64 " exceeds uint32 max\n", byte_size64);
+            SVT_ERROR("Image component 0 byte_size overflow: %" PRIu64 " exceeds uint32 max\n", byte_size64);
             return SvtJxsErrorBadParameter;
         }
         out_image_config->components[0].byte_size = (uint32_t)byte_size64;
@@ -617,7 +617,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_get_image_config(uint64_t versi
             const uint64_t byte_size64 = (uint64_t)out_image_config->components[c].width *
                 out_image_config->components[c].height * pixel_size;
             if (byte_size64 > UINT32_MAX) {
-                fprintf(stderr, "Image component %d byte_size overflow: %" PRIu64 " exceeds uint32 max\n", c, byte_size64);
+                SVT_ERROR("Image component %d byte_size overflow: %" PRIu64 " exceeds uint32 max\n", c, byte_size64);
                 return SvtJxsErrorBadParameter;
             }
             out_image_config->components[c].byte_size = (uint32_t)byte_size64;
@@ -627,7 +627,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_get_image_config(uint64_t versi
     if (out_bytes_per_frame) {
         if (enc_api->bpp_denominator == 0) {
             if (enc_api->verbose >= VERBOSE_ERRORS) {
-                fprintf(stderr, "bpp_denominator cannot be 0!\n");
+                SVT_ERROR("bpp_denominator cannot be 0!\n");
             }
             return SvtJxsErrorBadParameter;
         }
@@ -776,7 +776,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_init(uint64_t version_api_major
         SLICE_HEADER_SIZE_BYTES * enc_common->pi.slice_num;
     if (headers_len_per_frame >= enc_common->picture_header_dynamic.hdr_Lcod) {
         if (enc_api->verbose >= VERBOSE_ERRORS) {
-            fprintf(stderr, "Impossible compression. Please use bigger bpp param!\n");
+            SVT_ERROR("Impossible compression. Please use bigger bpp param!\n");
         }
         svt_jpeg_xs_encoder_close(enc_api);
         return SvtJxsErrorBadParameter;
@@ -989,7 +989,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_send_picture(svt_jpeg_xs_encode
         return SvtJxsErrorBadParameter;
     }
     if (enc_input->bitstream.buffer == NULL) {
-        fprintf(stderr, "Invalid input: bitstream buffer is NULL\n");
+        SVT_ERROR("Invalid input: bitstream buffer is NULL\n");
         return SvtJxsErrorBadParameter;
     }
 
@@ -998,7 +998,7 @@ PREFIX_API SvtJxsErrorType_t svt_jpeg_xs_encoder_send_picture(svt_jpeg_xs_encode
     uint32_t pixel_size = input_bit_depth <= 8 ? sizeof(uint8_t) : sizeof(uint16_t);
     for (uint8_t c = 0; c < pi->comps_num; ++c) {
         if (enc_input->image.data_yuv[c] == NULL) {
-            fprintf(stderr, "Invalid input: data_yuv[%u] is NULL\n", c);
+            SVT_ERROR("Invalid input: data_yuv[%u] is NULL\n", c);
             return SvtJxsErrorBadParameter;
         }
         uint32_t min_size;

--- a/Source/Lib/Encoder/Codec/FinalStageProcess.c
+++ b/Source/Lib/Encoder/Codec/FinalStageProcess.c
@@ -110,7 +110,7 @@ void *final_stage_kernel(void *input_ptr) {
         pack_result = (PackOutput *)input_wrapper_ptr->object_ptr;
 
         if (pack_result->pcs_wrapper_ptr == NULL) {
-            fprintf(stderr, "FATAL ERROR [%s:%i] Final thread pcs_wrapper_ptr is NULL\n", __func__, __LINE__);
+            SVT_FATAL("FATAL ERROR [%s:%i] Final thread pcs_wrapper_ptr is NULL\n", __func__, __LINE__);
             svt_jxs_release_object(input_wrapper_ptr);
             continue;
         }
@@ -135,7 +135,7 @@ void *final_stage_kernel(void *input_ptr) {
             PictureControlSet *pcs_ringbuffer_ptr = (PictureControlSet *)pcs_ringbuffer_obj->object_ptr;
             if ((pcs_ringbuffer_obj != pack_result->pcs_wrapper_ptr) ||
                 (pcs_ringbuffer_ptr->frame_number != pcs_ptr->frame_number)) {
-                fprintf(stderr, "FATAL ERROR [%s:%i] Final thread ring is full\n", __func__, __LINE__);
+                SVT_FATAL("FATAL ERROR [%s:%i] Final thread ring is full\n", __func__, __LINE__);
                 // TODO: Return internal error
                 continue;
             }

--- a/Source/Lib/Encoder/Codec/InitStageProcess.c
+++ b/Source/Lib/Encoder/Codec/InitStageProcess.c
@@ -105,14 +105,14 @@ static int32_t validate_yuv_range(pi_t *pi, svt_jpeg_xs_image_buffer_t *image_bu
                 }
                 for (uint32_t x = 0; x < width; ++x) {
                     if (plane_buffer_in[x] & test_input_range) {
-                        fprintf(stderr,
-                                "Warning: Invalid YUV have values out of a range %u bits!! Frame: %lu, Component: %u, x: %u, y: "
-                                "%u!!\n",
-                                input_bit_depth,
-                                (unsigned long)frame,
-                                component_id,
-                                x,
-                                y);
+                        SVT_WARN(
+                            "Warning: Invalid YUV have values out of a range %u bits!! Frame: %lu, Component: %u, x: %u, y: "
+                            "%u!!\n",
+                            input_bit_depth,
+                            (unsigned long)frame,
+                            component_id,
+                            x,
+                            y);
                         return -1;
                     }
                 }

--- a/Source/Lib/Encoder/Codec/PackPrecinct.c
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include "encoder_dsp_rtcd.h"
+#include "SvtLog.h"
 
 void pack_significance(bitstream_writer_t* bitstream, uint8_t gtli, uint8_t* significance_data_max_ptr, uint32_t width) {
     for (uint32_t i = 0; i < width; i++) {
@@ -331,7 +332,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
             align_bitstream_writer_to_next_byte(bitstream);
             if (((int)bitstream_writer_get_used_bits(bitstream) - bits_pos_last) !=
                 (int)(precinct->packet_size_gcli_bytes[packet_idx] << 3)) {
-                fprintf(stderr,
+                SVT_ERROR(
                         "Error[%s:%i]: Pack Raw Coding length mismatch: rate control=%d packing=%d\n",
                         __FUNCTION__,
                         __LINE__,
@@ -371,7 +372,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
             align_bitstream_writer_to_next_byte(bitstream);
             if (((int)bitstream_writer_get_used_bits(bitstream) - bits_pos_last) !=
                 (int)(precinct->packet_size_significance_bytes[packet_idx] << 3)) {
-                fprintf(stderr,
+                SVT_ERROR(
                         "Error[%s:%i]: Pack Significance length mismatch: rate control=%d packing=%d\n",
                         __FUNCTION__,
                         __LINE__,
@@ -427,7 +428,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
             align_bitstream_writer_to_next_byte(bitstream);
             if (((int)bitstream_writer_get_used_bits(bitstream) - bits_pos_last) !=
                 (int)(precinct->packet_size_gcli_bytes[packet_idx] << 3)) {
-                fprintf(stderr,
+                SVT_ERROR(
                         "Error[%s:%i]: Pack bit-plane count length mismatch: rate control=%d packing=%d\n",
                         __FUNCTION__,
                         __LINE__,
@@ -461,7 +462,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
         align_bitstream_writer_to_next_byte(bitstream);
         if (((int)bitstream_writer_get_used_bits(bitstream) - bits_pos_last) !=
             (int)(precinct->packet_size_data_bytes[packet_idx] << 3)) {
-            fprintf(stderr,
+            SVT_ERROR(
                     "Error[%s:%i]: Pack %i data length mismatch: rate control=%d packing=%d\n",
                     __FUNCTION__,
                     __LINE__,
@@ -499,7 +500,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
             if (SIGN_HANDLING_STRATEGY_FULL == coding_signs_handling) {
                 if (((int)bitstream_writer_get_used_bits(bitstream) - bits_pos_last) !=
                     (int)(precinct->packet_size_signs_handling_bytes[packet_idx] << 3)) {
-                    fprintf(stderr,
+                    SVT_ERROR(
                             "Error[%s:%i]: Pack %i SIGN length mismatch: rate control=%d packing=%d\n",
                             __FUNCTION__,
                             __LINE__,
@@ -513,7 +514,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
                 //Lazy calculate PACK
                 assert(SIGN_HANDLING_STRATEGY_FAST == coding_signs_handling);
                 if (packet_signs_size_bytes > precinct->packet_size_signs_handling_bytes[packet_idx]) {
-                    fprintf(stderr,
+                    SVT_ERROR(
                             "Error[%s:%i]: Pack %i SIGN length too big: rate control=%d packing=%d\n",
                             __FUNCTION__,
                             __LINE__,
@@ -540,7 +541,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
     int bits_pos_end = bitstream_writer_get_used_bits(bitstream);
     if (bits_pos_end - bits_pos_begin !=
         (int)((precinct->pack_total_bytes - precinct->pack_padding_bytes - precinct_signs_retrieve_bytes) << 3)) {
-        fprintf(stderr,
+        SVT_ERROR(
                 "Error[%s:%i]: Precinct size invalid  Precinct=%d expected=%d\n",
                 __FUNCTION__,
                 __LINE__,
@@ -549,7 +550,7 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
         return SvtJxsErrorEncodeFrameError;
     }
     if (bits_pos_end % 8) {
-        fprintf(stderr, "Error[%s:%i]: Precinct invalid alignment to 8 bits\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("Error[%s:%i]: Precinct invalid alignment to 8 bits\n", __FUNCTION__, __LINE__);
         return SvtJxsErrorEncodeFrameError;
     }
 

--- a/Source/Lib/Encoder/Codec/PackStageProcess.c
+++ b/Source/Lib/Encoder/Codec/PackStageProcess.c
@@ -310,7 +310,7 @@ static SvtJxsErrorType_t process_precinct(PictureControlSet* pcs_ptr, svt_jpeg_x
 
     if (error) {
 #ifndef NDEBUG
-        fprintf(stderr, "Error calculate RC for precinct: %i\n", prec_idx);
+        SVT_ERROR("Error calculate RC for precinct: %i\n", prec_idx);
 #endif
         return error;
     }
@@ -373,7 +373,7 @@ static SvtJxsErrorType_t process_slice(PictureControlSet* pcs_ptr, svt_jpeg_xs_e
         pcs_ptr, precincts, prec_num, slice_budget_bytes, enc_common->coding_signs_handling);
     if (error) {
 #ifndef NDEBUG
-        fprintf(stderr, "Error calculate RC for slice: %i\n", pack_input->slice_idx);
+        SVT_ERROR("Error calculate RC for slice: %i\n", pack_input->slice_idx);
 #endif
         return error;
     }
@@ -521,7 +521,7 @@ static SvtJxsErrorType_t process_slice(PictureControlSet* pcs_ptr, svt_jpeg_xs_e
                                       enc_common->coding_signs_handling);
         if (error) {
 #ifndef NDEBUG
-            fprintf(stderr, "Error pack  precinct: %i\n", prec_first_idx + i);
+            SVT_ERROR("Error pack  precinct: %i\n", prec_first_idx + i);
 #endif
             return error;
         }
@@ -549,7 +549,7 @@ static SvtJxsErrorType_t process_slice(PictureControlSet* pcs_ptr, svt_jpeg_xs_e
         error = pack_precinct(bitstream, pi, &precincts[i], enc_common->coding_signs_handling);
         if (error) {
 #ifndef NDEBUG
-            fprintf(stderr, "Error pack  precinct: %i\n", prec_first_idx + i);
+            SVT_ERROR("Error pack  precinct: %i\n", prec_first_idx + i);
 #endif
             return error;
         }
@@ -677,7 +677,7 @@ void* pack_stage_kernel(void* input_ptr) {
                                          &budget_padding_left_bytes);
                 if (error) {
 #ifndef NDEBUG
-                    fprintf(stderr, "err happen when pack prec\n");
+                    SVT_ERROR("err happen when pack prec\n");
 #endif
                     break;
                 }
@@ -696,7 +696,7 @@ void* pack_stage_kernel(void* input_ptr) {
                                   &bitstream);
 #ifndef NDEBUG
             if (error) {
-                fprintf(stderr, "Error calculate RC or pack for slice: %i\n", pack_input->slice_idx);
+                SVT_ERROR("Error calculate RC or pack for slice: %i\n", pack_input->slice_idx);
             }
 #endif
         }
@@ -706,11 +706,10 @@ void* pack_stage_kernel(void* input_ptr) {
             uint32_t used_bytes = bitstream_writer_get_used_bytes(&bitstream);
             uint32_t used_bytes_expected = pack_input->out_bytes_end - pack_input->out_bytes_begin;
             if (used_bytes_expected != used_bytes) {
-                fprintf(stderr,
-                        "Error pack slice: %i, Expected write to bitstream: %u Get: %u\n",
-                        pack_input->slice_idx,
-                        used_bytes_expected,
-                        used_bytes);
+                SVT_ERROR("Error pack slice: %i, Expected write to bitstream: %u Get: %u\n",
+                          pack_input->slice_idx,
+                          used_bytes_expected,
+                          used_bytes);
                 assert(0);
             }
         }

--- a/Source/Lib/Encoder/Codec/PreRcStageProcess.c
+++ b/Source/Lib/Encoder/Codec/PreRcStageProcess.c
@@ -58,7 +58,7 @@ PackInput_t* pre_rc_send_frame_to_pack_slices(PictureControlSet* pcs_ptr, Fifo_t
             output_wrapper_ptr = output_wrapper_ptr_next;
             if (output_wrapper_ptr == NULL) {
                 /*This path should never happen!*/
-                fprintf(stderr, "Fatal Error: Pre RC Stage Process, Invalid next slice pointer!\n");
+                SVT_FATAL("Fatal Error: Pre RC Stage Process, Invalid next slice pointer!\n");
                 return NULL;
             }
             pack_input = (PackInput_t*)output_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/ProfileLevel.c
+++ b/Source/Lib/Encoder/Codec/ProfileLevel.c
@@ -6,6 +6,7 @@
 #include "ProfileLevel.h"
 
 #include <stdio.h>
+#include "SvtLog.h"
 
 uint16_t derive_stream_profile_ppih(ColourFormat_t colour_format, uint8_t bit_depth, uint32_t verbose) {
     uint16_t ppih;
@@ -35,12 +36,11 @@ uint16_t derive_stream_profile_ppih(ColourFormat_t colour_format, uint8_t bit_de
      * Keep declaring the closest Main profile (still a validly-defined codeword, unlike Ppih=0) but
      * make the limitation visible. */
     if (bit_depth > 12 && verbose >= VERBOSE_WARNINGS) {
-        fprintf(stderr,
-                "Warning: bit depth %u exceeds the maximum (12) defined by any ISO/IEC 21122-2 lossy profile; "
-                "declaring the closest Main profile (Ppih=0x%04X). Use profile_override_enable if a different "
-                "declaration is required.\n",
-                bit_depth,
-                ppih);
+        SVT_WARN("Warning: bit depth %u exceeds the maximum (12) defined by any ISO/IEC 21122-2 lossy profile; "
+                 "declaring the closest Main profile (Ppih=0x%04X). Use profile_override_enable if a different "
+                 "declaration is required.\n",
+                 bit_depth,
+                 ppih);
     }
 
     return ppih;

--- a/Source/Lib/Encoder/Codec/RateControl.c
+++ b/Source/Lib/Encoder/Codec/RateControl.c
@@ -12,6 +12,7 @@
 #include "PackPrecinct.h"
 #include "SvtUtility.h"
 #include "encoder_dsp_rtcd.h"
+#include "SvtLog.h"
 
 #define PRINT_RECALC_VPRED 0
 
@@ -866,7 +867,7 @@ static SvtJxsErrorType_t rate_control_find_best_quantization_refinement(svt_jpeg
     ret = rate_control_find_best_quantization(
         enc_common, budget_bytes, precinct, out_quantization, coding_vertical_prediction_mode, coding_signs_handling);
     if (ret) {
-        fprintf(stderr, "[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
         return ret;
     }
 #if PRINT_RECALC_VPRED
@@ -881,7 +882,7 @@ static SvtJxsErrorType_t rate_control_find_best_quantization_refinement(svt_jpeg
                                             coding_vertical_prediction_mode,
                                             coding_signs_handling);
     if (ret) {
-        fprintf(stderr, "[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
     }
     return ret;
 }
@@ -1218,7 +1219,7 @@ static SvtJxsErrorType_t rate_control_find_best_quantization_refinement_binary_s
         enc_common, budget_bytes, precinct, out_quantization, coding_vertical_prediction_mode, coding_signs_handling);
     if (ret) {
 #ifndef NDEBUG
-        fprintf(stderr, "[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
 #endif
         return ret;
     }
@@ -1235,7 +1236,7 @@ static SvtJxsErrorType_t rate_control_find_best_quantization_refinement_binary_s
                                                           coding_signs_handling);
 #ifndef NDEBUG
     if (ret) {
-        fprintf(stderr, "[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
     }
 #endif
     return ret;
@@ -1265,7 +1266,7 @@ SvtJxsErrorType_t rate_control_precinct(struct PictureControlSet *pcs_ptr, preci
 
     if (budget_bytes > PRECINCT_MAX_BYTES_SIZE) {
 #ifndef NDEBUG
-        fprintf(stderr, "[%s[%d]] RC precinct error Precinct size is Too BIG, use smaller bpp value!!\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error Precinct size is Too BIG, use smaller bpp value!!\n", __FUNCTION__, __LINE__);
 #endif
         return SvtJxsErrorEncodeFrameError;
     }
@@ -1273,7 +1274,7 @@ SvtJxsErrorType_t rate_control_precinct(struct PictureControlSet *pcs_ptr, preci
     uint32_t headers_bytes = rate_control_get_headers_bytes(enc_common, precinct);
     if (budget_bytes <= headers_bytes) {
 #ifndef NDEBUG
-        fprintf(stderr, "Impossible compression. Please use bigger bpp param!\n");
+        SVT_ERROR("Impossible compression. Please use bigger bpp param!\n");
 #endif
         return SvtJxsErrorUndefined;
     }
@@ -1346,7 +1347,7 @@ SvtJxsErrorType_t rate_control_slice_quantization_fast_no_vpred_no_sign_full(str
 
     if (DIV_ROUND_UP(budget_slice_bytes, prec_num) > PRECINCT_MAX_BYTES_SIZE) {
 #ifndef NDEBUG
-        fprintf(stderr, "[%s[%d]] RC precinct error Precinct size is Too BIG, use smaller bpp value!!\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error Precinct size is Too BIG, use smaller bpp value!!\n", __FUNCTION__, __LINE__);
 #endif
         return SvtJxsErrorEncodeFrameError;
     }
@@ -1358,7 +1359,7 @@ SvtJxsErrorType_t rate_control_slice_quantization_fast_no_vpred_no_sign_full(str
     }
     if (budget_slice_bytes <= headers_bytes) {
 #ifndef NDEBUG
-        fprintf(stderr, "Impossible compression. Please use bigger bpp param!\n");
+        SVT_ERROR("Impossible compression. Please use bigger bpp param!\n");
 #endif
         return SvtJxsErrorUndefined;
     }
@@ -1376,7 +1377,7 @@ SvtJxsErrorType_t rate_control_slice_quantization_fast_no_vpred_no_sign_full(str
         enc_common, budget_slice_to_data_bytes, precincts, prec_num, &quantization, coding_signs_handling);
     if (ret) {
 #ifndef NDEBUG
-        fprintf(stderr, "[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found quantization\n", __FUNCTION__, __LINE__);
 #endif
         return ret;
     }
@@ -1390,7 +1391,7 @@ SvtJxsErrorType_t rate_control_slice_quantization_fast_no_vpred_no_sign_full(str
                                                                                      coding_signs_handling);
     if (ret) {
 #ifndef NDEBUG
-        fprintf(stderr, "[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
+        SVT_ERROR("[%s[%d]] RC precinct error not found refinement\n", __FUNCTION__, __LINE__);
 #endif
         return ret;
     }
@@ -1405,7 +1406,7 @@ SvtJxsErrorType_t rate_control_slice_quantization_fast_no_vpred_no_sign_full(str
         int empty = precinct_encoder_compute_truncation(&enc_common->pi, &precincts[i], quantization, refinement);
         if (empty) {
 #ifndef NDEBUG
-            fprintf(stderr, "[%s[%d]] RC Invalid recalculate truncation!\n", __FUNCTION__, __LINE__);
+            SVT_ERROR("[%s[%d]] RC Invalid recalculate truncation!\n", __FUNCTION__, __LINE__);
 #endif
             return SvtJxsErrorEncodeFrameError;
         }

--- a/Source/Lib/Encoder/Codec/WeightTable.c
+++ b/Source/Lib/Encoder/Codec/WeightTable.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <string.h>
 #include "SvtJpegxs.h"
+#include "SvtLog.h"
 
 /*Band not exist, local define*/
 #define NE BAND_NOT_EXIST
@@ -348,7 +349,7 @@ int weight_table_calculate(pi_t* pi, uint8_t verbose, ColourFormat_t color_forma
     }
 
     if (color_format == COLOUR_FORMAT_INVALID) {
-        fprintf(stderr, "Error: Weight table not supported format!\n");
+        SVT_ERROR("Error: Weight table not supported format!\n");
         return -1;
     }
 
@@ -360,16 +361,15 @@ int weight_table_calculate(pi_t* pi, uint8_t verbose, ColourFormat_t color_forma
         int ret = weight_table_recalculate_table(pi, &table, color_format, verbose);
         if (ret) {
             if (verbose) {
-                fprintf(stderr,
-                        "Error: Weight table not defined. Can not recalculated table! H:%i V:%i sy:%i%i%i sx:%i%i%i \n",
-                        pi->decom_h,
-                        pi->decom_v,
-                        pi->components[0].Sy,
-                        pi->components[1].Sy,
-                        pi->components[2].Sy,
-                        pi->components[0].Sx,
-                        pi->components[1].Sx,
-                        pi->components[2].Sx);
+                SVT_ERROR("Error: Weight table not defined. Can not recalculated table! H:%i V:%i sy:%i%i%i sx:%i%i%i \n",
+                          pi->decom_h,
+                          pi->decom_v,
+                          pi->components[0].Sy,
+                          pi->components[1].Sy,
+                          pi->components[2].Sy,
+                          pi->components[0].Sx,
+                          pi->components[1].Sx,
+                          pi->components[2].Sx);
             }
             return -1;
         }
@@ -402,7 +402,7 @@ int weight_table_calculate(pi_t* pi, uint8_t verbose, ColourFormat_t color_forma
     }
     for (uint32_t p = 0; p < pi->bands_num_exists; ++p) {
         if (global_prioity[p] != 1) {
-            fprintf(stderr, "Error: Weight table priority not consistent!\n");
+            SVT_ERROR("Error: Weight table priority not consistent!\n");
             assert(0);
             return -1;
         }

--- a/tests/UnitTests/TestSvtLog.cc
+++ b/tests/UnitTests/TestSvtLog.cc
@@ -1,0 +1,100 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+
+#include "gtest/gtest.h"
+#include "SvtJpegxs.h"
+#include "SvtLog.h"
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+struct CallbackResult {
+    int called;
+    SvtLogLevel level;
+    char tag[32];
+    char message[256];
+};
+
+void test_log_callback(void* context, SvtLogLevel level, const char* tag, const char* fmt, va_list args) {
+    CallbackResult* result = static_cast<CallbackResult*>(context);
+    result->called = 1;
+    result->level = level;
+    if (tag) {
+        snprintf(result->tag, sizeof(result->tag), "%s", tag);
+    }
+    else {
+        result->tag[0] = '\0';
+    }
+    vsnprintf(result->message, sizeof(result->message), fmt, args);
+}
+
+} // namespace
+
+/*
+ * The logger is initialized exactly once per process (lazily, on first log call), so a custom
+ * callback registered via svt_jpeg_xs_set_log_callback() only takes effect if no log call has
+ * happened yet in this process. Since other tests in this same binary may already have triggered
+ * default logger initialization, fork a fresh child process to get an untouched logger state.
+ */
+TEST(LogCallback, CustomCallbackInterceptsMessages) {
+    int pipefd[2];
+    ASSERT_EQ(pipe(pipefd), 0);
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+
+    if (pid == 0) {
+        // Child: fresh process, logger not yet initialized.
+        close(pipefd[0]);
+        CallbackResult result;
+        memset(&result, 0, sizeof(result));
+        svt_jpeg_xs_set_log_callback(test_log_callback, &result);
+        svt_jxs_log(SVT_LOG_ERROR, "TestTag", "hello %d\n", 42);
+        ssize_t written = write(pipefd[1], &result, sizeof(result));
+        (void)written;
+        close(pipefd[1]);
+        _exit(0);
+    }
+
+    close(pipefd[1]);
+    CallbackResult result;
+    memset(&result, 0, sizeof(result));
+    ssize_t bytes_read = read(pipefd[0], &result, sizeof(result));
+    close(pipefd[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    ASSERT_EQ(bytes_read, static_cast<ssize_t>(sizeof(result)));
+    EXPECT_TRUE(result.called);
+    EXPECT_EQ(result.level, SVT_LOG_ERROR);
+    EXPECT_STREQ(result.tag, "TestTag");
+    EXPECT_STREQ(result.message, "hello 42\n");
+}
+
+/*
+ * Sanity check: without a callback registered, the default logger must remain usable (no crash) -
+ * exercised in a fresh subprocess for the same isolation reason as above.
+ */
+TEST(LogCallback, DefaultLoggerStillWorksWithoutCallback) {
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+        svt_jxs_log(SVT_LOG_ERROR, "TestTag", "default logger message\n");
+        _exit(0);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+#endif // _WIN32


### PR DESCRIPTION
## Summary

Adds a `svt_jpeg_xs_set_log_callback()` API that lets host applications
intercept all library log output, instead of it being written directly to
`stderr`. This mirrors the pattern already used in SVT-AV1.

As a follow-up to make the new API actually useful, all `fprintf(stderr, ...)`
call sites inside `Source/Lib` (174 sites across 19 files) were routed through
the existing `SVT_LOG`/`SVT_ERROR`/`SVT_WARN`/`SVT_FATAL`/`SVT_DEBUG` macros —
previously many of these bypassed the logger entirely, so a registered
callback would have silently missed most diagnostic output.

Jira: SDBQ-3774

## Changes

**1. Log callback API** (`feat(logging): add configurable log callback API`)
- New public API in `SvtJpegxs.h`: `SvtLogLevel` enum, `SvtJxsLogCallback`
  typedef, `svt_jpeg_xs_set_log_callback(callback, context)`. Purely additive
  — no API version bump needed.
- `SvtLog.c` reworked around a process-wide, lazily-initialized logger
  (`pthread_once` on POSIX / `InitOnceExecuteOnce` on Windows) that dispatches
  to either a caller-registered callback or the existing default
  stderr/`SVT_LOG_FILE`-based logger.
- `SvtLog.h` declarations wrapped in `extern "C"` so C++ callers link against
  the correct C symbol names (previously worked only by accident for C-only
  callers).
- New `tests/UnitTests/TestSvtLog.cc` with fork-based tests verifying a
  custom callback intercepts log calls, and that the default logger still
  works unaffected when no callback is registered.

**2. `fprintf(stderr)` → `SVT_LOG` cleanup** (`refactor(logging): route
Source/Lib fprintf(stderr) calls through SVT_LOG`)
- Mechanically replaced all 174 `fprintf(stderr, ...)` sites in `Source/Lib`
  with the appropriate severity macro:
  - `SVT_ERROR` — invalid-parameter / corruption paths (majority)
  - `SVT_WARN` — messages explicitly labeled "Warning"
  - `SVT_FATAL` — messages labeled "FATAL ERROR"
  - `SVT_LOG` — plain banners / config-summary prints
  - `SVT_DEBUG` — verbose multithreading trace dumps gated by
    `VERBOSE_INFO_MULTITHREADING` / `VERBOSE_SYSTEM_INFO_ALL`
- No functional/behavioral change.

## Testing

- Full unit test suite: 2959/2959 passing.
- `tests/scripts/EncoderTest.sh` (fast mode): 685/685 passing.
- `tests/scripts/DecoderConformanceTest.sh` (fast mode): 263/263 passing.
- `tests/scripts/DecoderMultiFramesTest.sh` (full mode): 183/183 passing.
- Bitstream output verified byte-identical (`md5sum`) before/after the
  `fprintf`→`SVT_LOG` refactor, for both encoder and decoder.
- New callback correctly captures real encoder/decoder CLI diagnostics
  end-to-end (e.g. `Svt[error]: Unrecognized output_bit_depth_msb_aligned,
  expected: 0 or 1`), not just in the unit tests.

## Performance

100-iteration interleaved A/B benchmark (baseline vs. this branch, same
binaries alternated per-run to control for build/thermal noise):

| | Baseline mean | Current mean | Diff | Significant? |
|---|---|---|---|---|
| Encoder FPS | 63.69 | 63.81 | +0.19% | No (within noise) |
| Decoder FPS | 59.64 | 58.68 | -1.6% | No (within noise) |

No measurable performance regression from either change.