### PR TITLE
fix(cmake): gate CTest module inclusion behind BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,9 +312,8 @@ if(BUILD_APPS)
     add_subdirectory(Source/App/SampleDecoder)
 endif()
 
-include(CTest)
-
 if(BUILD_TESTING)
+    include(CTest)
     set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)
     set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
@@ -322,7 +321,6 @@ if(BUILD_TESTING)
     add_subdirectory(third_party/googletest-1.14.0)
 
     add_subdirectory(tests/UnitTests)
-    #enable_testing()
 endif()
 
 add_subdirectory(third_party/cpuinfo)


### PR DESCRIPTION
include(CTest) unconditionally set BUILD_TESTING default to ON, so googletest and UnitTests were always configured/built even when only -DBUILD_TESTING was never requested (e.g. Coverity's plain --release build). Move include(CTest) inside the if(BUILD_TESTING) block so tests only build when explicitly requested via --test / -DBUILD_TESTING=ON.