### PR TITLE
fix(ci): expand paths-filter coverage for build-triggering workflows

### DIFF
--- a/.github/config/path_filters.yaml
+++ b/.github/config/path_filters.yaml
@@ -4,13 +4,20 @@ base_build: &base_build
   - 'tests/**'
   - 'third_party/**'
   - 'Build/**'
+  - 'CMakeLists.txt'
+  - .github/config/path_filters.yaml
   - .github/workflows/base_build.yaml
 
 ffmpeg_plugin_build: &ffmpeg_plugin_build
   - 'ffmpeg-plugin/**'
   - '.github/scripts/build_ffmpeg_plugin*'
   - 'Source/API/**'
+  - 'Source/Lib/**'
+  - 'third_party/**'
+  - 'Build/**'
+  - 'CMakeLists.txt'
   - 'tests/scripts/FFmpeg*.sh'
+  - .github/config/path_filters.yaml
   - .github/workflows/ffmpeg_plugin_build.yaml
 
 gstreamer_plugin_build: &gstreamer_plugin_build
@@ -18,4 +25,9 @@ gstreamer_plugin_build: &gstreamer_plugin_build
   - 'tests/scripts/Gstreamer*.sh'
   - 'tests/scripts/ParallelAllGstreamerTests.sh'
   - 'Source/API/**'
+  - 'Source/Lib/**'
+  - 'third_party/**'
+  - 'Build/**'
+  - 'CMakeLists.txt'
+  - .github/config/path_filters.yaml
   - .github/workflows/gstreamer_plugin_build.yaml


### PR DESCRIPTION
base_build, ffmpeg_plugin_build, and gstreamer_plugin_build all run cmake against the top-level CMakeLists.txt, but it was absent from every filter list, so editing it silently skipped all three jobs.

ffmpeg_plugin_build and gstreamer_plugin_build also rebuild the full SvtJpegxs library from source (build.sh install) before building the plugin, but their filters only covered Source/API/**. Add Source/Lib/**, third_party/**, and Build/** so codec/build script changes are no longer invisible to those workflows.