### PR TITLE
ci: eliminate redundant SVT-JPEG-XS library rebuilds across CI/CD workflows (SDBQ-3790)

### DIFF
--- a/.github/scripts/build_ffmpeg_plugin.sh
+++ b/.github/scripts/build_ffmpeg_plugin.sh
@@ -33,8 +33,13 @@ export INSTALL_DIR="$PWD/install-dir"
 mkdir -p "$INSTALL_DIR"
 
 echo "=== 1. Compile and install svt-jpegxs ==="
-cd "$JPEGXS_REPO/Build/linux"
-./build.sh install --prefix "$INSTALL_DIR"
+if find "$INSTALL_DIR" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+    echo "svt-jpegxs already installed under $INSTALL_DIR (reused build artifact), skipping rebuild."
+else
+    cd "$JPEGXS_REPO/Build/linux"
+    ./build.sh install --prefix "$INSTALL_DIR"
+    cd "$JPEGXS_REPO"
+fi
 
 echo "=== 2. Export installation location ==="
 export LD_LIBRARY_PATH="$INSTALL_DIR/lib:${LD_LIBRARY_PATH}"
@@ -42,19 +47,26 @@ export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
 echo "=== 3. Download/Compile FFmpeg ==="
 cd "$PWD"
-clone_attempt=1
-max_clone_attempts=5
-until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
-    if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
-        echo "git clone failed after $max_clone_attempts attempts, giving up."
-        exit 1
-    fi
-    clone_attempt=$((clone_attempt + 1))
-    echo "git clone failed (attempt $((clone_attempt - 1))/$max_clone_attempts), retrying in 10s..."
-    rm -rf "ffmpeg-${FFMPEG_VERSION}"
-    sleep 10
-done
-cd "ffmpeg-${FFMPEG_VERSION}"
+if [[ -n "$FFMPEG_SRC_DIR" && -d "$FFMPEG_SRC_DIR/.git" ]]; then
+    echo "Reusing pre-fetched FFmpeg source from $FFMPEG_SRC_DIR"
+    cp -r "$FFMPEG_SRC_DIR" "ffmpeg-${FFMPEG_VERSION}"
+    cd "ffmpeg-${FFMPEG_VERSION}"
+    git checkout "release/$FFMPEG_VERSION"
+else
+    clone_attempt=1
+    max_clone_attempts=5
+    until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
+        if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
+            echo "git clone failed after $max_clone_attempts attempts, giving up."
+            exit 1
+        fi
+        clone_attempt=$((clone_attempt + 1))
+        echo "git clone failed (attempt $((clone_attempt - 1))/$max_clone_attempts), retrying in 10s..."
+        rm -rf "ffmpeg-${FFMPEG_VERSION}"
+        sleep 10
+    done
+    cd "ffmpeg-${FFMPEG_VERSION}"
+fi
 
 echo "=== 4. Apply jpeg-xs plugin patches ==="
 git config --global user.email "runner@github.com"

--- a/.github/scripts/build_ffmpeg_plugin_msys.sh
+++ b/.github/scripts/build_ffmpeg_plugin_msys.sh
@@ -29,8 +29,11 @@ mkdir -p "$INSTALL_DIR"
 
 # 1. Compile and install svt-jpegxs
 cd "$JPEGXS_REPO"
-cmake -S . -B svtjpegxs-build -DBUILD_APPS=OFF -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
-cmake --build svtjpegxs-build -j10 --config Release --target install
+if find "$INSTALL_DIR" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+    echo "svt-jpegxs already installed under $INSTALL_DIR (reused build artifact), skipping rebuild."
+else
+    ./Build/linux/build.sh install --prefix "$INSTALL_DIR" --no-app --static
+fi
 
 # 2. Set PKG_CONFIG_PATH
 export LD_LIBRARY_PATH="$INSTALL_DIR/lib:${LD_LIBRARY_PATH}"
@@ -41,19 +44,26 @@ cd "$PWD"
 git config --global user.email "runner@github.com"
 git config --global user.name "action-runner"
 
-clone_attempt=1
-max_clone_attempts=5
-until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
-    if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
-        echo "git clone failed after $max_clone_attempts attempts, giving up."
-        exit 1
-    fi
-    clone_attempt=$((clone_attempt + 1))
-    echo "git clone failed (attempt $((clone_attempt - 1))/$max_clone_attempts), retrying in 10s..."
-    rm -rf "ffmpeg-${FFMPEG_VERSION}"
-    sleep 10
-done
-cd "ffmpeg-$FFMPEG_VERSION"
+if [[ -n "$FFMPEG_SRC_DIR" && -d "$FFMPEG_SRC_DIR/.git" ]]; then
+    echo "Reusing pre-fetched FFmpeg source from $FFMPEG_SRC_DIR"
+    cp -r "$FFMPEG_SRC_DIR" "ffmpeg-${FFMPEG_VERSION}"
+    cd "ffmpeg-$FFMPEG_VERSION"
+    git checkout "release/$FFMPEG_VERSION"
+else
+    clone_attempt=1
+    max_clone_attempts=5
+    until git clone --branch "release/$FFMPEG_VERSION" --depth 1 https://github.com/FFmpeg/FFmpeg.git "ffmpeg-${FFMPEG_VERSION}"; do
+        if [[ "$clone_attempt" -ge "$max_clone_attempts" ]]; then
+            echo "git clone failed after $max_clone_attempts attempts, giving up."
+            exit 1
+        fi
+        clone_attempt=$((clone_attempt + 1))
+        echo "git clone failed (attempt $((clone_attempt - 1))/$max_clone_attempts), retrying in 10s..."
+        rm -rf "ffmpeg-${FFMPEG_VERSION}"
+        sleep 10
+    done
+    cd "ffmpeg-$FFMPEG_VERSION"
+fi
 
 # 4. Apply jpeg-xs plugin patches
 if [[ "$COPY_FILES" == "y" ]]; then

--- a/.github/scripts/build_gstreamer_plugin.sh
+++ b/.github/scripts/build_gstreamer_plugin.sh
@@ -23,13 +23,16 @@ GST_COMMIT=${1:-8ca913845a142ebbea86eede74292d840f12a046}
 
 echo "=== 0. Create installation directory and export env variable ==="
 export INSTALL_DIR="$JPEGXS_REPO/install-dir"
-rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
 echo "=== 1. Compile and install svt-jpegxs ==="
-cd "$JPEGXS_REPO/Build/linux"
-./build.sh install --prefix "$INSTALL_DIR"
-cd "$JPEGXS_REPO"
+if find "$INSTALL_DIR" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+    echo "svt-jpegxs already installed under $INSTALL_DIR (reused build artifact), skipping rebuild."
+else
+    cd "$JPEGXS_REPO/Build/linux"
+    ./build.sh install --prefix "$INSTALL_DIR"
+    cd "$JPEGXS_REPO"
+fi
 
 echo "=== 2. Make the SvtJpegxs.pc pkg-config file discoverable ==="
 SVT_PC_FILE=$(find "$INSTALL_DIR" -name 'SvtJpegxs.pc' | head -1)

--- a/.github/scripts/fuzzy_tests.sh
+++ b/.github/scripts/fuzzy_tests.sh
@@ -44,20 +44,28 @@ else
   done
 fi
 
-export CPATH="/usr/local/include/svt-jpegxs"
-export LD_LIBRARY_PATH="/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export CPATH="${SVT_INSTALL_DIR:-/usr/local}/include/svt-jpegxs"
+export LD_LIBRARY_PATH="${SVT_INSTALL_DIR:-/usr/local}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # 1. Build and install SVT-JPEG-XS
 if [ $BUILD -eq 1 ]; then
-  echo "Building and installing SVT-JPEG-XS..."
-  cd "$BUILD_DIR"
-  ./build.sh install
+  if find "${SVT_INSTALL_DIR:-/usr/local}" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+    echo "svt-jpegxs already installed under ${SVT_INSTALL_DIR:-/usr/local} (reused build artifact), skipping rebuild."
+  else
+    echo "Building and installing SVT-JPEG-XS..."
+    cd "$BUILD_DIR"
+    if [ -n "$SVT_INSTALL_DIR" ]; then
+      ./build.sh install --prefix "$SVT_INSTALL_DIR"
+    else
+      ./build.sh install
+    fi
+  fi
   # 3. Build Fuzzy Tests
   cd "$FUZZY_DIR"
   echo "Building encoder fuzzer..."
-  clang -lSvtJpegxs -fsanitize=fuzzer encoder.c -o SvtJxsEncFuzzer
+  clang -L"${SVT_INSTALL_DIR:-/usr/local}/lib" -lSvtJpegxs -fsanitize=fuzzer encoder.c -o SvtJxsEncFuzzer
   echo "Building decoder fuzzer..."
-  clang -lSvtJpegxs -fsanitize=fuzzer decoder.c -o SvtJxsDecFuzzer
+  clang -L"${SVT_INSTALL_DIR:-/usr/local}/lib" -lSvtJpegxs -fsanitize=fuzzer decoder.c -o SvtJxsDecFuzzer
   chmod +x SvtJxsEncFuzzer
   chmod +x SvtJxsDecFuzzer
 fi

--- a/.github/workflows/base_build.yaml
+++ b/.github/workflows/base_build.yaml
@@ -57,10 +57,10 @@ jobs:
            sudo apt-get update
            sudo apt-get -y install cmake nasm valgrind make gcc g++
 
-    - name: 'Build:  Debug and Release versions'
+    - name: 'Build:  Debug and Release versions, install Release tree (reused by ffmpeg/gstreamer/fuzzy-test workflows)'
       working-directory: Build/linux
       run: |
-        ./build.sh --jobs=10 --all --test
+        ./build.sh --jobs=10 --all --test install --prefix "${{ github.workspace }}/install-dir"
 
     - name: "Archive: upload artifacts"
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -71,6 +71,14 @@ jobs:
           Bin/
           tests/scripts/parrallelUT.sh
           tests/scripts/
+
+    - name: "Archive: upload installed svt-jpegxs tree (fixed name, consumed cross-workflow via workflow_run)"
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: linux-svtjpegxs-install
+        retention-days: 1
+        path: |
+          install-dir/
 
   linux-unit-tests-release:
     needs: linux-build

--- a/.github/workflows/ffmpeg_plugin_build.yaml
+++ b/.github/workflows/ffmpeg_plugin_build.yaml
@@ -1,9 +1,9 @@
 name: ffmpeg Plugin Build
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
+  workflow_run:
+    workflows: ["Base Build"]
+    types: [completed]
   workflow_dispatch:
 
 defaults:
@@ -12,19 +12,23 @@ defaults:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 env:
   INPUT_FILES_PATH: /opt/samples
   JOBS_NUM: 100
+  FFMPEG_SRC_ARTIFACT: ffmpeg-source-${{ github.run_number }}
+  LINUX_LIB_ARTIFACTS: linux-svtjpegxs-lib-build-${{ github.run_number }}
   LINUX_ARTIFACTS_6_1: linux-ffmpeg-6-1-build-${{ github.run_number }}
   LINUX_ARTIFACTS_7_0: linux-ffmpeg-7-0-build-${{ github.run_number }}
   LINUX_ARTIFACTS_7_1: linux-ffmpeg-7-1-build-${{ github.run_number }}
   LINUX_ARTIFACTS_8_0: linux-ffmpeg-8-0-build-${{ github.run_number }}
   LINUX_ARTIFACTS_8_1: linux-ffmpeg-8-1-build-${{ github.run_number }}
   LINUX_ARTIFACTS_9_0: linux-ffmpeg-9-0-build-${{ github.run_number }}
+  WINDOWS_LIB_ARTIFACTS: windows-svtjpegxs-mingw-lib-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_6_1: windows-ffmpeg-6-1-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_7_0: windows-ffmpeg-7-0-build-${{ github.run_number }}
   WINDOWS_ARTIFACTS_7_1: windows-ffmpeg-7-1-build-${{ github.run_number }}
@@ -33,6 +37,7 @@ env:
   WINDOWS_ARTIFACTS_9_0: windows-ffmpeg-9-0-build-${{ github.run_number }}
 jobs:
   changes:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -40,14 +45,106 @@ jobs:
       changed: ${{ steps.filter.outputs.ffmpeg_plugin_build == 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           filters: .github/config/path_filters.yaml
 
-  ffmpeg-6-1-linux-build:
+
+  ffmpeg-source-fetch:
       needs: changes
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      runs-on: 'ubuntu-22.04'
+      timeout-minutes: 30
+      steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Fetch: all 6 FFmpeg release branches once, reused by every linux/windows ffmpeg-plugin build job'
+        run: |
+          mkdir ffmpeg-source
+          cd ffmpeg-source
+          git init -q
+          git remote add origin https://github.com/FFmpeg/FFmpeg.git
+          for v in 6.1 7.0 7.1 8.0 8.1 9.0; do
+            fetch_attempt=1
+            max_fetch_attempts=5
+            until git fetch --depth 1 origin "release/$v:release/$v"; do
+              if [[ "$fetch_attempt" -ge "$max_fetch_attempts" ]]; then
+                echo "git fetch release/$v failed after $max_fetch_attempts attempts, giving up."
+                exit 1
+              fi
+              fetch_attempt=$((fetch_attempt + 1))
+              echo "git fetch release/$v failed (attempt $((fetch_attempt - 1))/$max_fetch_attempts), retrying in 10s..."
+              sleep 10
+            done
+          done
+
+      - name: "Archive: upload artifacts"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          retention-days: 1
+          include-hidden-files: true
+          path: |
+            ffmpeg-source/
+
+
+  linux-lib-build:
+      needs: changes
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      runs-on: 'ubuntu-22.04'
+      timeout-minutes: 60
+      steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Setup:  Install dependencies'
+        run: |
+            sudo apt-get update
+            sudo apt-get -y install cmake nasm make gcc g++ pkg-config
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact from Base Build (falls back to local build if missing)'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        continue-on-error: true
+        with:
+          name: linux-svtjpegxs-install
+          path: install-dir
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Build: SVT-JPEG-XS (shared, Release) once, reused by all ffmpeg-plugin linux jobs (skipped if reused from Base Build)'
+        working-directory: Build/linux
+        run: |
+          if find "${{ github.workspace }}/install-dir" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+            echo "Reusing svt-jpegxs artifact from Base Build workflow run, skipping rebuild."
+          else
+            ./build.sh install --prefix "${{ github.workspace }}/install-dir"
+          fi
+
+      - name: "Archive: upload artifacts"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          retention-days: 1
+          path: |
+            install-dir/
+
+  ffmpeg-6-1-linux-build:
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -63,9 +160,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 6.1 y
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -76,7 +192,7 @@ jobs:
             install-dir/
 
   ffmpeg-7-0-linux-build:
-      needs: changes
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -93,9 +209,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 7.0 y
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -106,7 +241,7 @@ jobs:
             install-dir/
 
   ffmpeg-7-1-linux-build:
-      needs: changes
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -123,9 +258,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 7.1 y
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -136,7 +290,7 @@ jobs:
             install-dir/
 
   ffmpeg-8-0-linux-build:
-      needs: changes
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -153,9 +307,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 8.0 y
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -166,7 +339,7 @@ jobs:
             install-dir/
 
   ffmpeg-8-1-linux-build:
-      needs: changes
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -183,9 +356,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 8.1 y n
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -196,7 +388,7 @@ jobs:
             install-dir/
 
   ffmpeg-9-0-linux-build:
-      needs: changes
+      needs: [changes, linux-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'ubuntu-22.04'
       timeout-minutes: 120
@@ -215,9 +407,28 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.LINUX_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Make svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         run: .github/scripts/build_ffmpeg_plugin.sh 9.0 y n
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -250,6 +461,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -317,6 +530,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -384,13 +599,15 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: "${{ env.LINUX_ARTIFACTS_7_1 }}"
           path: install-dir
-          
+
       - name: 'Setup: Make ffmpeg executable'
         run: sudo chmod -R 755 install-dir/
 
@@ -451,6 +668,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -518,6 +737,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -585,6 +806,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -638,7 +861,7 @@ jobs:
               ' ffmpeg_functional_tests.log
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-   
+
   ffmpeg-9-0-performance-tests:
       needs: ffmpeg-9-0-linux-build
       runs-on: ['self-hosted', 'linux', 'x64', 'valgrind', 'jpeg-perf']
@@ -656,6 +879,8 @@ jobs:
 
         - name: 'Checkout repository'
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+          with:
+            ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
         - name: 'Setup: Download build artifacts'
           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -718,9 +943,52 @@ jobs:
             path: |
               tests/scripts/ffmpeg_results.csv
               tests/scripts/ffmpeg_plugin_performance.log
-        
-  ffmpeg-6-1-windows-build:
+
+  windows-mingw-lib-build:
       needs: changes
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      runs-on: 'windows-2022'
+      timeout-minutes: 60
+      steps:
+      - name: 'Harden Runner'
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
+        shell: pwsh
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
+      - name: 'install msys2 shell'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          cache: true
+          install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm
+
+      - name: 'Build: SVT-JPEG-XS (MinGW, static, Release) once, reused by all ffmpeg-plugin windows jobs'
+        working-directory: "${{ github.workspace }}"
+        shell: msys2 {0}
+        run: |
+          pacman -S --noconfirm make mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-yasm mingw-w64-x86_64-diffutils mingw-w64-x86_64-winpthreads
+          ./Build/linux/build.sh install --prefix "$(pwd)/install-dir" --no-app --static
+
+      - name: "Archive: upload artifacts"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          retention-days: 1
+          path: |
+            install-dir/
+
+  ffmpeg-6-1-windows-build:
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -732,25 +1000,40 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm
+
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
 
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-           export ASM_NASM="${{ env.ASM_NASM }}"
            ./.github/scripts/build_ffmpeg_plugin_msys.sh 6.1
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -761,7 +1044,7 @@ jobs:
             install-dir/bin/
 
   ffmpeg-7-0-windows-build:
-      needs: changes
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -773,24 +1056,39 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
+
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-          export ASM_NASM="${{ env.ASM_NASM }}"
           ./.github/scripts/build_ffmpeg_plugin_msys.sh 7.0
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -801,7 +1099,7 @@ jobs:
             install-dir/bin/
 
   ffmpeg-7-1-windows-build:
-      needs: changes
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -813,24 +1111,39 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
+
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-          export ASM_NASM="${{ env.ASM_NASM }}"
           ./.github/scripts/build_ffmpeg_plugin_msys.sh 7.1
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -841,7 +1154,7 @@ jobs:
             install-dir/bin/
 
   ffmpeg-8-0-windows-build:
-      needs: changes
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -853,24 +1166,39 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm nasm
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
+
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-          export ASM_NASM="${{ env.ASM_NASM }}"
           ./.github/scripts/build_ffmpeg_plugin_msys.sh 8.0
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -881,7 +1209,7 @@ jobs:
             install-dir/bin/
 
   ffmpeg-8-1-windows-build:
-      needs: changes
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -893,24 +1221,39 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm nasm
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
+
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-          export ASM_NASM="${{ env.ASM_NASM }}"
           ./.github/scripts/build_ffmpeg_plugin_msys.sh 8.1 n
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -921,7 +1264,7 @@ jobs:
             install-dir/bin/
 
   ffmpeg-9-0-windows-build:
-      needs: changes
+      needs: [changes, windows-mingw-lib-build, ffmpeg-source-fetch]
       if: ${{ needs.changes.outputs.changed == 'true' }}
       runs-on: 'windows-2022'
       timeout-minutes: 120
@@ -933,24 +1276,39 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: 'Install dependencies'
-        working-directory: "${{ github.workspace }}"
+      - name: 'Setup: Download pre-built svt-jpegxs artifact'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.WINDOWS_LIB_ARTIFACTS }}"
+          path: install-dir
+
+      - name: 'Setup: Disable Windows Defender real-time scanning (speeds up many-small-file MinGW builds)'
         shell: pwsh
-        run: ./.github/scripts/configure.ps1
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: 'install msys2 shell'
         uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           update: true
+          cache: true
           install: git mingw-w64-ucrt-x86_64-gcc cmake mingw-w64-ucrt-x86_64-yasm nasm
+      - name: 'Setup: Download pre-fetched FFmpeg source'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: "${{ env.FFMPEG_SRC_ARTIFACT }}"
+          path: ffmpeg-source
+
       - name: 'install ffmpeg plugin'
         working-directory: "${{ github.workspace }}"
         shell: msys2 {0}
         run: |
-          export ASM_NASM="${{ env.ASM_NASM }}"
           ./.github/scripts/build_ffmpeg_plugin_msys.sh 9.0 n
+        env:
+          FFMPEG_SRC_DIR: ${{ github.workspace }}/ffmpeg-source
 
       - name: "Archive: upload artifacts"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/fuzzy-tests.yaml
+++ b/.github/workflows/fuzzy-tests.yaml
@@ -1,6 +1,9 @@
 name: Fuzzy Tests
 
 on:
+  workflow_run:
+    workflows: ["Base Build"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       branch:
@@ -13,7 +16,6 @@ on:
         type: number
         required: false
         default: 60
-  pull_request:
 
 defaults:
   run:
@@ -21,12 +23,14 @@ defaults:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   JOBS_NUM: 100
   TIMEOUT_SECONDS: ${{ inputs.timeout || 60 }}
 jobs:
-  decoder:
+  build-lib:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ['self-hosted', 'linux', 'x64', 'valgrind']
     steps:
     - name: 'Harden Runner'
@@ -36,6 +40,8 @@ jobs:
 
     - name: 'Checkout repository'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.workflow_run.head_sha || github.sha }}
 
     - name: 'Setup:  Install dependencies'
       run: |
@@ -48,18 +54,81 @@ jobs:
         sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
         chmod -R u+rwX "$GITHUB_WORKSPACE" || true
 
-    - name: 'Build: binaries'
+    - name: 'Setup: Download pre-built svt-jpegxs artifact from Base Build (falls back to local build if missing)'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      continue-on-error: true
+      with:
+        name: linux-svtjpegxs-install
+        path: install-dir
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: 'Build: SVT-JPEG-XS once, reused by decoder+encoder fuzzer jobs (skipped if reused from Base Build)'
+      working-directory: Build/linux
+      run: |
+        if find "${{ github.workspace }}/install-dir" -name 'SvtJpegxs.pc' 2>/dev/null | grep -q .; then
+          echo "Reusing svt-jpegxs artifact from Base Build workflow run, skipping rebuild."
+        else
+          ./build.sh install --prefix "${{ github.workspace }}/install-dir"
+        fi
+
+    - name: "Archive: upload artifacts"
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: fuzzy-tests-svtjpegxs-lib-${{ github.run_number }}
+        retention-days: 1
+        path: |
+          install-dir/
+
+  decoder:
+    needs: build-lib
+    runs-on: ['self-hosted', 'linux', 'x64', 'valgrind']
+    steps:
+    - name: 'Harden Runner'
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+      with:
+        egress-policy: audit
+
+    - name: 'Checkout repository'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.workflow_run.head_sha || github.sha }}
+
+    - name: 'Setup:  Install dependencies'
+      run: |
+            sudo apt update
+            sudo apt -y install cmake nasm clang
+
+    - name: Fix workspace permissions
+      if: always()
+      run: |
+        sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
+        chmod -R u+rwX "$GITHUB_WORKSPACE" || true
+
+    - name: 'Setup: Download pre-built svt-jpegxs artifact'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        name: fuzzy-tests-svtjpegxs-lib-${{ github.run_number }}
+        path: install-dir
+
+    - name: 'Setup: Make svt-jpegxs artifact executable'
+      run: sudo chmod -R 755 install-dir/
+
+    - name: 'Build: fuzzer binaries'
       run: |
         .github/scripts/fuzzy_tests.sh -b
+      env:
+        SVT_INSTALL_DIR: ${{ github.workspace }}/install-dir
 
     - name: "Run: Decoder fuzzing tests"
       run: |
         .github/scripts/fuzzy_tests.sh -td
       env:
+        SVT_INSTALL_DIR: ${{ github.workspace }}/install-dir
         INPUT_FILES_PATH: /opt/samples/Samples/ConformanceTestDecoder/test_bitsreams
 
   encoder:
-    needs: decoder
+    needs: [build-lib, decoder]
     runs-on: ['self-hosted', 'linux', 'x64', 'valgrind']
     steps:
     - name: 'Harden Runner'
@@ -69,6 +138,8 @@ jobs:
 
     - name: 'Checkout repository'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.workflow_run.head_sha || github.sha }}
 
     - name: 'Setup:  Install dependencies'
       run: |
@@ -81,10 +152,23 @@ jobs:
         sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
         chmod -R u+rwX "$GITHUB_WORKSPACE" || true
 
-    - name: 'Build: binaries'
+    - name: 'Setup: Download pre-built svt-jpegxs artifact'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        name: fuzzy-tests-svtjpegxs-lib-${{ github.run_number }}
+        path: install-dir
+
+    - name: 'Setup: Make svt-jpegxs artifact executable'
+      run: sudo chmod -R 755 install-dir/
+
+    - name: 'Build: fuzzer binaries'
       run: |
         .github/scripts/fuzzy_tests.sh -b
+      env:
+        SVT_INSTALL_DIR: ${{ github.workspace }}/install-dir
 
     - name: "Run: Encoder fuzzing tests"
       run: |
         .github/scripts/fuzzy_tests.sh -te
+      env:
+        SVT_INSTALL_DIR: ${{ github.workspace }}/install-dir

--- a/.github/workflows/gstreamer_plugin_build.yaml
+++ b/.github/workflows/gstreamer_plugin_build.yaml
@@ -1,9 +1,9 @@
 name: GStreamer Plugin Build
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
+  workflow_run:
+    workflows: ["Base Build"]
+    types: [completed]
   workflow_dispatch:
 
 defaults:
@@ -12,9 +12,10 @@ defaults:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -24,6 +25,7 @@ env:
 
 jobs:
   changes:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -31,10 +33,13 @@ jobs:
       changed: ${{ steps.filter.outputs.gstreamer_plugin_build == 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           filters: .github/config/path_filters.yaml
 
   gstreamer-linux-build-test:
@@ -52,11 +57,25 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Install dependencies'
         run: |
             sudo apt-get update
             sudo apt-get -y install cmake make gcc g++ nasm ninja-build python3-venv pkg-config flex bison libglib2.0-dev
+
+      - name: 'Setup: Download pre-built svt-jpegxs artifact from Base Build (falls back to local build if missing)'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        continue-on-error: true
+        with:
+          name: linux-svtjpegxs-install
+          path: install-dir
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Setup: Make downloaded svt-jpegxs artifact executable'
+        run: sudo chmod -R 755 install-dir/ 2> /dev/null || true
 
       - name: 'Build: SVT-JPEG-XS and minimal GStreamer with the svtjpegxs plugin'
         run: .github/scripts/build_gstreamer_plugin.sh
@@ -148,6 +167,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: 'Setup: Download build artifacts'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -144,7 +144,7 @@ check_executable() (
 
 install_build() (
     build_type=Release
-    sudo=$(check_executable -p sudo)
+    sudo=$(check_executable -p sudo) || true
     while [ -n "$*" ]; do
         case $(printf %s "$1" | tr '[:upper:]' '[:lower:]') in
         release) build_type="Release" && shift ;;

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ Please see [Encoder snippet](documentation/encoder/EncoderSnippets.md) for encod
 
 Please see [Decoder snippet](documentation/decoder/DecoderSnippets.md) for decoder structure overview and simplified decoder usage.
 
+## CI/CD
+
+Please see [CI/CD](documentation/ci-cd/README.md) for an overview of the GitHub Actions workflows
+and how the core library build is shared across them.
+
 ## Logging
 
 By default, library log messages (errors, warnings, info) are printed to `stderr`. This can be

--- a/documentation/ci-cd/README.md
+++ b/documentation/ci-cd/README.md
@@ -1,0 +1,94 @@
+# CI/CD
+
+This document describes the GitHub Actions workflows in `.github/workflows/` and how they fit
+together, in particular how the core library build is shared across workflows to avoid redundant
+rebuilds.
+
+## Workflows
+
+| Workflow file | Name | Trigger | Purpose |
+| -- | -- | -- | -- |
+| `base_build.yaml` | Base Build | `push` (main), `pull_request` | Builds the core library (Linux gcc + Windows MSVC), runs unit/conformance/performance tests. |
+| `ffmpeg_plugin_build.yaml` | ffmpeg Plugin Build | `workflow_run` (after Base Build), `workflow_dispatch` | Builds and tests the ffmpeg plugin against 6 ffmpeg versions (6.1, 7.0, 7.1, 8.0, 8.1, 9.0), on Linux and Windows. |
+| `gstreamer_plugin_build.yaml` | GStreamer Plugin Build | `workflow_run` (after Base Build), `workflow_dispatch` | Builds and tests the GStreamer plugin. |
+| `fuzzy-tests.yaml` | Fuzzy Tests | `workflow_run` (after Base Build), `workflow_dispatch` | Runs libFuzzer-based encoder/decoder fuzzing. |
+| `coverity.yaml` | Coverity Build | scheduled, `workflow_dispatch` | Nightly Coverity static analysis scan. |
+| `linter.yaml` | - | `push`, `pull_request` | super-linter checks (bash, markdown, etc.). |
+
+## Why `workflow_run` instead of `push`/`pull_request`
+
+`ffmpeg_plugin_build.yaml`, `gstreamer_plugin_build.yaml` and `fuzzy-tests.yaml` trigger on
+`workflow_run` (fires once `Base Build` completes for a given commit) rather than directly on
+`push`/`pull_request`. This lets them download and reuse the core library artifact that
+`Base Build` already produced, instead of rebuilding it themselves.
+
+Two consequences of this design worth knowing:
+
+- These 3 workflows only start after `Base Build` finishes for the same commit - they no longer
+  run fully in parallel with it.
+- `workflow_run`-triggered workflows always execute using the workflow YAML committed on the
+  **default branch**, never the triggering PR's version. A PR that changes one of these 3 files
+  cannot exercise its own new `workflow_run` behavior through its own checks - that only becomes
+  testable after merging to `main`. Use `workflow_dispatch` to test job-level logic changes on a
+  branch before merging (it just won't exercise the actual `Base Build` artifact reuse, since
+  there is no `workflow_run` event context).
+
+## Shared build artifacts
+
+The core library used to be rebuilt from scratch independently by every workflow/job that needed
+it. It is now built at most 3 times per run and reused everywhere else:
+
+| Producer | Toolchain | Consumed by |
+| -- | -- | -- |
+| `base_build.yaml` `linux-build` | gcc | `ffmpeg_plugin_build.yaml` `linux-lib-build`, `gstreamer_plugin_build.yaml`, `fuzzy-tests.yaml` `build-lib` (all fall back to a local build if the artifact is unavailable) |
+| `base_build.yaml` `windows-build` | MSVC | native Windows apps/tests only - not consumed by ffmpeg (different toolchain, see below) |
+| `ffmpeg_plugin_build.yaml` `windows-mingw-lib-build` | MinGW (static) | all 6 `ffmpeg-*-windows-build` jobs |
+
+`linux-lib-build`, `gstreamer_plugin_build.yaml`'s build job, and `fuzzy-tests.yaml`'s `build-lib`
+job each try to download `base_build`'s installed tree first (`continue-on-error: true` on the
+download step) and only fall back to building locally if it is missing - for example if
+`Base Build`'s own path filter did not match for that commit.
+
+### Why Windows needs two toolchains
+
+`base_build.yaml`'s `windows-build` uses MSVC. The ffmpeg plugin on Windows is built through
+MSYS2/MinGW, because that is FFmpeg's own supported way of building on Windows (`./configure` is a
+POSIX shell script). A MinGW-built static library cannot be linked into an MSVC-built ffmpeg
+binary (different C runtime/ABI), so `windows-mingw-lib-build` builds the core library once with
+MinGW, reused by all 6 `ffmpeg-*-windows-build` jobs, instead of doing that 6 times.
+
+### FFmpeg upstream source is also fetched only once
+
+`ffmpeg_plugin_build.yaml`'s `ffmpeg-source-fetch` job fetches all 6 FFmpeg release branches
+(shallow, one `git fetch` per branch) into a single repository and uploads it as one artifact. All
+12 `ffmpeg-*-linux-build`/`ffmpeg-*-windows-build` jobs download that artifact and just
+`git checkout release/X.Y` locally, instead of each cloning FFmpeg over the network. Falls back to
+the original clone-with-retry logic if the pre-fetched artifact is unavailable.
+
+## Path filters
+
+`base_build`, `ffmpeg_plugin_build` and `gstreamer_plugin_build` each have a `changes` job using
+`dorny/paths-filter` against `.github/config/path_filters.yaml` to skip work when nothing relevant
+changed. `ffmpeg_plugin_build`/`gstreamer_plugin_build`'s filters include `Source/Lib/**` (the
+actual codec) as well as their own plugin-specific paths, so a core codec change always exercises
+the plugin integration tests too.
+
+## Windows CI performance notes
+
+The 7 Windows/MinGW jobs (`windows-mingw-lib-build` + 6 `ffmpeg-*-windows-build`) each:
+
+- Cache the MSYS2/pacman package install (`cache: true` on `msys2/setup-msys2`) instead of
+  re-downloading the toolchain every run.
+- Disable Windows Defender real-time scanning before building, since many-small-file MinGW builds
+  are heavily penalized by real-time AV scanning on GitHub-hosted Windows runners.
+
+## Known gotchas
+
+- `Build/linux/build.sh`'s `build()` always does a clean rebuild (`rm -rf $build_type`). Adding an
+  `install` step after a build must be part of the *same* `build.sh` invocation
+  (`./build.sh --all --test install --prefix X`), not a separate one, or it silently triggers a
+  full extra rebuild before installing.
+- `Build/linux/build.sh`'s `install_build()` probes for `sudo` via a helper that returns a
+  non-zero "not found" sentinel by design. Because `set -e` is active, that sentinel used to abort
+  the whole install step whenever `sudo` was genuinely absent (e.g. Windows/MSYS2) - fixed with
+  `sudo=$(check_executable -p sudo) || true`.

--- a/ffmpeg-plugin/readme.md
+++ b/ffmpeg-plugin/readme.md
@@ -188,6 +188,34 @@ install-dir
 make -j10
 ```
 
+# Adding support for a new FFmpeg version
+
+Every currently supported version (6.1, 7.0, 7.1, 8.0, 8.1, 9.0) is hardcoded in several places.
+Adding a new one requires touching all of these:
+
+- `.github/scripts/build_ffmpeg_plugin.sh` and `.github/scripts/build_ffmpeg_plugin_msys.sh`:
+  add the new version to the `FFMPEG_VERSION` validation list (`if [[ "$FFMPEG_VERSION" != ... ]]`),
+  and to the `COPY_FILES` auto-disable check if the new version ships `libsvtjpegxs*` natively
+  upstream (like 8.1/9.0 do - no `cp .../libsvtjpegxs*` needed for those).
+- `.github/workflows/ffmpeg_plugin_build.yaml`:
+  - `ffmpeg-source-fetch` job: add the new version to the `for v in 6.1 7.0 7.1 8.0 8.1 9.0; do ...`
+    loop - this is the stage that clones/fetches and checks out each supported FFmpeg release
+    branch once, shared by every build job (see
+    [documentation/ci-cd/README.md](../documentation/ci-cd/README.md)).
+  - Add a new `ffmpeg-X-Y-linux-build` job (copy an existing one, update the version/patch args
+    passed to `build_ffmpeg_plugin.sh`) and its matching `ffmpeg-X-Y-linux-tests` job.
+  - Add a new `ffmpeg-X-Y-windows-build` job (copy an existing one, update the version passed to
+    `build_ffmpeg_plugin_msys.sh`).
+  - Add new `LINUX_ARTIFACTS_X_Y`/`WINDOWS_ARTIFACTS_X_Y` entries to the workflow's `env:` block.
+  - If the new version becomes the latest one, move the `ffmpeg-9-0-performance-tests` job (and
+    its `needs`/artifact references) to point at the new version instead.
+- `ffmpeg-plugin/<X.Y>/`: add the new version's patch directory (native plugin patches, following
+  the 8.1/9.0 pattern) or `libsvtjpegxs*` copy-file pattern (6.1-8.0 pattern).
+- `tests/scripts/FFmpeg*.sh` and `tests/scripts/PerformanceTestFfmpegPlugin.sh`: update if the new
+  version needs different test coverage or performance baselines.
+- `documentation/ci-cd/README.md`: update the version list mentioned in the workflow description
+  table.
+
 # How to use ffmpeg with jpeg-xs
 
 ## Supported pixel formats


### PR DESCRIPTION
Core library was being rebuilt from scratch up to 17 times per CI run across base_build, ffmpeg_plugin_build, gstreamer_plugin_build, and fuzzy-tests, with no artifact reuse between them. This collapses that down to 3 real builds (linux gcc, windows MSVC, windows MinGW):

- base_build: linux-build now also installs a shared Release tree (folded into the same build.sh invocation as --all --test, avoiding a redundant rebuild) and uploads it as a fixed-name artifact for reuse.

- ffmpeg-plugin: 6 independent Linux rebuilds collapsed into a single shared linux-lib-build job; 6 independent Windows MinGW rebuilds collapsed into a single shared windows-mingw-lib-build job. build_ffmpeg_plugin_msys.sh now calls build.sh (which already has MinGW support) instead of a separate hand-rolled cmake invocation. Dropped the unused configure.ps1/Visual Studio 2022 install step and dead ASM_NASM export from all 6 Windows jobs (build_ffmpeg_plugin_msys.sh never referenced ASM_NASM/MSVC). Added msys2/setup-msys2 pacman caching and disabled Windows Defender real-time scanning to speed up the remaining MinGW builds.

- gstreamer-plugin: build_gstreamer_plugin.sh now skips its own build.sh install when a pre-built artifact is already present (also removed an unconditional rm -rf that would have deleted a reused artifact before checking for it).

- fuzzy-tests: decoder/encoder jobs' independent rebuilds collapsed into a single shared build-lib job. fuzzy_tests.sh now accepts SVT_INSTALL_DIR and skips rebuilding when a pre-built artifact exists.

All three downstream workflows switched from push/pull_request to workflow_run (Base Build) + workflow_dispatch, so they can reuse base_build's installed artifact directly (falls back to a local build if unavailable). Checkout steps pin ref to the workflow_run head_sha, and dorny/paths-filter is given the same explicit ref since its default (github.ref) isn't guaranteed to match under workflow_run.

Note: workflow_run-triggered workflows always execute using the workflow YAML committed on the default branch, so this new trigger only takes effect - and becomes testable - after merging to main.