### PR TITLE
fix(ci): derive PKG_CONFIG_PATH from actual SvtJpegxs.pc location

### DIFF
--- a/.github/config/path_filters.yaml
+++ b/.github/config/path_filters.yaml
@@ -10,7 +10,8 @@ base_build: &base_build
 
 ffmpeg_plugin_build: &ffmpeg_plugin_build
   - 'ffmpeg-plugin/**'
-  - '.github/scripts/build_ffmpeg_plugin*'
+  - '.github/scripts/build_ffmpeg_plugin.sh'
+  - '.github/scripts/build_ffmpeg_plugin_msys.sh'
   - 'Source/API/**'
   - 'Source/Lib/**'
   - 'third_party/**'

--- a/.github/scripts/build_ffmpeg_plugin.sh
+++ b/.github/scripts/build_ffmpeg_plugin.sh
@@ -42,8 +42,14 @@ else
 fi
 
 echo "=== 2. Export installation location ==="
-export LD_LIBRARY_PATH="$INSTALL_DIR/lib:${LD_LIBRARY_PATH}"
-export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig:${PKG_CONFIG_PATH}"
+SVT_PC_FILE=$(find "$INSTALL_DIR" -name 'SvtJpegxs.pc' | head -1)
+if [ -z "$SVT_PC_FILE" ]; then
+    echo "FATAL: SvtJpegxs.pc not found under $INSTALL_DIR" >&2
+    exit 1
+fi
+SVT_LIBDIR=$(dirname "$(dirname "$SVT_PC_FILE")")
+export LD_LIBRARY_PATH="$SVT_LIBDIR:${LD_LIBRARY_PATH}"
+export PKG_CONFIG_PATH="$SVT_LIBDIR/pkgconfig:${PKG_CONFIG_PATH}"
 
 echo "=== 3. Download/Compile FFmpeg ==="
 cd "$PWD"

--- a/.github/scripts/build_ffmpeg_plugin_msys.sh
+++ b/.github/scripts/build_ffmpeg_plugin_msys.sh
@@ -36,8 +36,14 @@ else
 fi
 
 # 2. Set PKG_CONFIG_PATH
-export LD_LIBRARY_PATH="$INSTALL_DIR/lib:${LD_LIBRARY_PATH}"
-export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig:${PKG_CONFIG_PATH}"
+SVT_PC_FILE=$(find "$INSTALL_DIR" -name 'SvtJpegxs.pc' | head -1)
+if [ -z "$SVT_PC_FILE" ]; then
+    echo "FATAL: SvtJpegxs.pc not found under $INSTALL_DIR" >&2
+    exit 1
+fi
+SVT_LIBDIR=$(dirname "$(dirname "$SVT_PC_FILE")")
+export LD_LIBRARY_PATH="$SVT_LIBDIR:${LD_LIBRARY_PATH}"
+export PKG_CONFIG_PATH="$SVT_LIBDIR/pkgconfig:${PKG_CONFIG_PATH}"
 
 # 3. Download/Compile FFmpeg
 cd "$PWD"


### PR DESCRIPTION
Both ffmpeg-plugin build scripts hardcoded lib/pkgconfig, but GNUInstallDirs picks lib64 (or a multiarch path) on some distros, so pkg-config can't find SvtJpegxs and FFmpeg's configure fails with "SvtJpegxs >= 0.10.0 not found using pkg-config" on non-Debian build hosts. Locate the .pc file and derive the libdir dynamically, matching the approach already used in build_gstreamer_plugin.sh.