### PR TITLE
Avx512 optimize

### DIFF
--- a/Source/API/SvtJpegxs.h
+++ b/Source/API/SvtJpegxs.h
@@ -188,11 +188,12 @@ typedef uint64_t CPU_FLAGS;
 #define CPU_FLAGS_AVX512PF (1 << 13)
 #define CPU_FLAGS_AVX512BW (1 << 14)
 #define CPU_FLAGS_AVX512VL (1 << 15)
-/* Not an instruction set of its own: the AVX-512 kernels are compiled with
- * -mpopcnt for the whole directory, so the processor has to be asked about it
- * separately from AVX-512 itself. */
+/* Not instruction sets of their own: the AVX-512 kernels are compiled with
+ * -mpopcnt and -mbmi2 for the whole directory, so the processor has to be asked
+ * about those separately from AVX-512 itself. */
 #define CPU_FLAGS_POPCNT   (1 << 16)
-#define CPU_FLAGS_ALL      ((CPU_FLAGS_POPCNT << 1) - 1)
+#define CPU_FLAGS_BMI2     (1 << 17)
+#define CPU_FLAGS_ALL      ((CPU_FLAGS_BMI2 << 1) - 1)
 #define CPU_FLAGS_INVALID  (1ULL << (sizeof(CPU_FLAGS) * 8ULL - 1ULL))
 
 /**

--- a/Source/API/SvtJpegxs.h
+++ b/Source/API/SvtJpegxs.h
@@ -188,7 +188,11 @@ typedef uint64_t CPU_FLAGS;
 #define CPU_FLAGS_AVX512PF (1 << 13)
 #define CPU_FLAGS_AVX512BW (1 << 14)
 #define CPU_FLAGS_AVX512VL (1 << 15)
-#define CPU_FLAGS_ALL      ((CPU_FLAGS_AVX512VL << 1) - 1)
+/* Not an instruction set of its own: the AVX-512 kernels are compiled with
+ * -mpopcnt for the whole directory, so the processor has to be asked about it
+ * separately from AVX-512 itself. */
+#define CPU_FLAGS_POPCNT   (1 << 16)
+#define CPU_FLAGS_ALL      ((CPU_FLAGS_POPCNT << 1) - 1)
 #define CPU_FLAGS_INVALID  (1ULL << (sizeof(CPU_FLAGS) * 8ULL - 1ULL))
 
 /**

--- a/Source/App/DecApp/DecParamParser.c
+++ b/Source/App/DecApp/DecParamParser.c
@@ -107,8 +107,8 @@ static void set_asm_type(const char* value, DecoderConfig_t* cfg) {
         {"8", (CPU_FLAGS_AVX << 1) - 1},
         {"avx2", (CPU_FLAGS_AVX2 << 1) - 1},
         {"9", (CPU_FLAGS_AVX2 << 1) - 1},
-        {"avx512", (CPU_FLAGS_AVX512VL << 1) - 1},
-        {"10", (CPU_FLAGS_AVX512VL << 1) - 1},
+        {"avx512", CPU_FLAGS_ALL},
+        {"10", CPU_FLAGS_ALL},
         {"max", CPU_FLAGS_ALL},
         {"11", CPU_FLAGS_ALL},
     };

--- a/Source/App/EncApp/EncAppConfig.c
+++ b/Source/App/EncApp/EncAppConfig.c
@@ -321,8 +321,8 @@ static void set_asm_type(const char *value, EncoderConfig_t *cfg) {
         {"8", (CPU_FLAGS_AVX << 1) - 1},
         {"avx2", (CPU_FLAGS_AVX2 << 1) - 1},
         {"9", (CPU_FLAGS_AVX2 << 1) - 1},
-        {"avx512", (CPU_FLAGS_AVX512VL << 1) - 1},
-        {"10", (CPU_FLAGS_AVX512VL << 1) - 1},
+        {"avx512", CPU_FLAGS_ALL},
+        {"10", CPU_FLAGS_ALL},
         {"max", CPU_FLAGS_ALL},
         {"11", CPU_FLAGS_ALL},
     };

--- a/Source/Lib/Common/Codec/SvtUtility.h
+++ b/Source/Lib/Common/Codec/SvtUtility.h
@@ -26,6 +26,20 @@ void assert_err(uint32_t condition, char* err_msg);
 #define DIV_ROUND_UP(val, round)   (((val) + (round)-1) / (round))
 #define DIV_ROUND_DOWN(val, round) ((val) / (round))
 
+/* Index of the lowest set bit. The wrapper exists for MSVC, which has no
+ * __builtin_ctzll. TZCNT cannot be assumed either - BMI1 is not enabled for
+ * every target - but BSF returns the same index for a non-zero mask. */
+static INLINE uint32_t svt_first_set_bit(uint64_t mask) {
+    assert(mask != 0);
+#if defined(_MSC_VER)
+    unsigned long index;
+    _BitScanForward64(&index, mask);
+    return (uint32_t)index;
+#else
+    return (uint32_t)__builtin_ctzll(mask);
+#endif
+}
+
 static INLINE void get_current_time(uint64_t* const seconds, uint64_t* const mseconds) {
 #ifdef _WIN32
     struct _timeb curr_time;

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -30,6 +30,7 @@ CPU_FLAGS get_cpu_flags() {
     flags |= cpuinfo_has_x86_sse4_1() ? CPU_FLAGS_SSE4_1 : 0;
     flags |= cpuinfo_has_x86_sse4_2() ? CPU_FLAGS_SSE4_2 : 0;
     flags |= cpuinfo_has_x86_popcnt() ? CPU_FLAGS_POPCNT : 0;
+    flags |= cpuinfo_has_x86_bmi2() ? CPU_FLAGS_BMI2 : 0;
 
     flags |= cpuinfo_has_x86_avx() ? CPU_FLAGS_AVX : 0;
     flags |= cpuinfo_has_x86_avx2() ? CPU_FLAGS_AVX2 : 0;

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -29,6 +29,7 @@ CPU_FLAGS get_cpu_flags() {
     flags |= cpuinfo_has_x86_ssse3() ? CPU_FLAGS_SSSE3 : 0;
     flags |= cpuinfo_has_x86_sse4_1() ? CPU_FLAGS_SSE4_1 : 0;
     flags |= cpuinfo_has_x86_sse4_2() ? CPU_FLAGS_SSE4_2 : 0;
+    flags |= cpuinfo_has_x86_popcnt() ? CPU_FLAGS_POPCNT : 0;
 
     flags |= cpuinfo_has_x86_avx() ? CPU_FLAGS_AVX : 0;
     flags |= cpuinfo_has_x86_avx2() ? CPU_FLAGS_AVX2 : 0;

--- a/Source/Lib/Decoder/ASM_AVX2/Dwt53Decoder_AVX2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/Dwt53Decoder_AVX2.c
@@ -16,8 +16,14 @@ void idwt_horizontal_line_lf32_hf16_avx2(const int32_t *lf_ptr, const int16_t *h
     /* UBSan fix: use LSHIFT32 to avoid UB when left-shifting negative wavelet coefficients. */
     int32_t prev_even = lf_ptr[0] - (((LSHIFT32(hf_ptr[0], shift)) + 1) >> 1);
 
-    const __m256i reg_permutevar_mask_move_right = _mm256_setr_epi32(0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06);
     const __m256i two = _mm256_set1_epi32(2);
+    /* The carry of the last even sample into the next block stays in a vector.
+     * It used to travel through a general purpose register - extract from the
+     * vector, then broadcast back - four extra operations per iteration for a
+     * single value. vperm2i128 plus vpalignr take the element straight out of
+     * the previous iteration's vector, so the previous "even" itself serves as
+     * the carry. */
+    __m256i prev_vec = _mm256_set1_epi32(prev_even);
 
     int32_t simd_batch = (len - 2) / 16;
 
@@ -31,9 +37,8 @@ void idwt_horizontal_line_lf32_hf16_avx2(const int32_t *lf_ptr, const int16_t *h
         even = _mm256_srai_epi32(even, 2);
         even = _mm256_sub_epi32(lf_avx2, even);
 
-        int32_t next_even = _mm256_extract_epi32(even, 7);
-        __m256i even_m1 = _mm256_permutevar8x32_epi32(even, reg_permutevar_mask_move_right);
-        even_m1 = _mm256_insert_epi32(even_m1, prev_even, 0);
+        const __m256i shifted = _mm256_permute2x128_si256(prev_vec, even, 0x21);
+        const __m256i even_m1 = _mm256_alignr_epi8(even, shifted, 12);
 
         //out[0] + out[2]
         __m256i odd = _mm256_add_epi32(even_m1, even);
@@ -48,12 +53,13 @@ void idwt_horizontal_line_lf32_hf16_avx2(const int32_t *lf_ptr, const int16_t *h
         _mm_storeu_si128((__m128i *)(out_ptr + 8), _mm256_extracti128_si256(unpack1_avx2, 0x1));
         _mm_storeu_si128((__m128i *)(out_ptr + 12), _mm256_extracti128_si256(unpack2_avx2, 0x1));
 
-        prev_even = next_even;
+        prev_vec = even;
 
         out_ptr += 16;
         lf_ptr += 8;
         hf_ptr += 8;
     }
+    prev_even = _mm256_extract_epi32(prev_vec, 7);
     out_ptr[0] = prev_even;
     for (uint32_t i = simd_batch * 16 + 1; i < (len - 2); i += 2) {
         out_ptr[2] = lf_ptr[1] - (((LSHIFT32(hf_ptr[0], shift)) + LSHIFT32(hf_ptr[1], shift) + 2) >> 2);
@@ -79,8 +85,14 @@ void idwt_horizontal_line_lf16_hf16_avx2(const int16_t *lf_ptr, const int16_t *h
     /* UBSan fix: use LSHIFT32 to avoid UB when left-shifting negative wavelet coefficients. */
     int32_t prev_even = LSHIFT32(lf_ptr[0], shift) - (((LSHIFT32(hf_ptr[0], shift)) + 1) >> 1);
 
-    const __m256i reg_permutevar_mask_move_right = _mm256_setr_epi32(0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06);
     const __m256i two = _mm256_set1_epi32(2);
+    /* The carry of the last even sample into the next block stays in a vector.
+     * It used to travel through a general purpose register - extract from the
+     * vector, then broadcast back - four extra operations per iteration for a
+     * single value. vperm2i128 plus vpalignr take the element straight out of
+     * the previous iteration's vector, so the previous "even" itself serves as
+     * the carry. */
+    __m256i prev_vec = _mm256_set1_epi32(prev_even);
 
     int32_t simd_batch = (len - 2) / 16;
 
@@ -94,9 +106,8 @@ void idwt_horizontal_line_lf16_hf16_avx2(const int16_t *lf_ptr, const int16_t *h
         even = _mm256_srai_epi32(even, 2);
         even = _mm256_sub_epi32(lf_avx2, even);
 
-        int32_t next_even = _mm256_extract_epi32(even, 7);
-        __m256i even_m1 = _mm256_permutevar8x32_epi32(even, reg_permutevar_mask_move_right);
-        even_m1 = _mm256_insert_epi32(even_m1, prev_even, 0);
+        const __m256i shifted = _mm256_permute2x128_si256(prev_vec, even, 0x21);
+        const __m256i even_m1 = _mm256_alignr_epi8(even, shifted, 12);
 
         //out[0] + out[2]
         __m256i odd = _mm256_add_epi32(even_m1, even);
@@ -111,12 +122,13 @@ void idwt_horizontal_line_lf16_hf16_avx2(const int16_t *lf_ptr, const int16_t *h
         _mm_storeu_si128((__m128i *)(out_ptr + 8), _mm256_extracti128_si256(unpack1_avx2, 0x1));
         _mm_storeu_si128((__m128i *)(out_ptr + 12), _mm256_extracti128_si256(unpack2_avx2, 0x1));
 
-        prev_even = next_even;
+        prev_vec = even;
 
         out_ptr += 16;
         lf_ptr += 8;
         hf_ptr += 8;
     }
+    prev_even = _mm256_extract_epi32(prev_vec, 7);
     out_ptr[0] = prev_even;
     for (uint32_t i = simd_batch * 16 + 1; i < (len - 2); i += 2) {
         out_ptr[2] = LSHIFT32(lf_ptr[1], shift) - (((LSHIFT32(hf_ptr[0], shift)) + LSHIFT32(hf_ptr[1], shift) + 2) >> 2);

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -13,11 +13,6 @@ DECLARE_ALIGNED(16, static const uint32_t, sign_shift[4]) = {BITSTREAM_BIT_POSIT
                                                              BITSTREAM_BIT_POSITION_SIGN - 1,
                                                              BITSTREAM_BIT_POSITION_SIGN};
 
-typedef struct reader_short {
-    uint8_t* mem;
-    uint8_t bits_used;
-} reader_short_t;
-
 uint8_t read_4_bits_align4_fast(reader_short_t* r) {
     if (r->bits_used) {
         r->bits_used = 0;
@@ -76,8 +71,9 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
     }
 }
 
-SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,
-                                   uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num, int32_t* precinct_bits_left) {
+SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
+                                     uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
+                                     int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign) {
     UNUSED(group_size);
     assert(group_size == GROUP_SIZE);
     assert((bitstream->bits_used != 0) || (bitstream->bits_used != 4));
@@ -118,12 +114,12 @@ SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf,
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        unpack_n_groups(gclis, gtli, &reader, buf, group_num);
+        groups_sign(gclis, gtli, &reader, buf, group_num);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;
             uint16_t buf_tmp[GROUP_SIZE];
-            unpack_n_groups(gclis, gtli, &reader, buf_tmp, 1);
+            groups_sign(gclis, gtli, &reader, buf_tmp, 1);
             memcpy(buf, buf_tmp, sizeof(uint16_t) * (leftover));
         }
         bitstream->offset = (uint32_t)(reader.mem - bitstream->mem);
@@ -158,12 +154,12 @@ SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf,
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        unpack_n_groups_nosign(gclis, gtli, &reader, buf, group_num);
+        groups_nosign(gclis, gtli, &reader, buf, group_num);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;
             uint16_t buf_tmp[GROUP_SIZE];
-            unpack_n_groups_nosign(gclis, gtli, &reader, buf_tmp, 1);
+            groups_nosign(gclis, gtli, &reader, buf_tmp, 1);
             *leftover_signs_num = 0;
             for (uint32_t leftover_id = leftover; leftover_id < GROUP_SIZE; leftover_id++) {
                 *leftover_signs_num += !!buf_tmp[leftover_id];
@@ -175,4 +171,19 @@ SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf,
     }
 
     return SvtJxsErrorNone;
+}
+
+SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,
+                                   uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num, int32_t* precinct_bits_left) {
+    return unpack_data_common(bitstream,
+                              buf,
+                              w,
+                              gclis,
+                              group_size,
+                              gtli,
+                              sign_flag,
+                              leftover_signs_num,
+                              precinct_bits_left,
+                              unpack_n_groups,
+                              unpack_n_groups_nosign);
 }

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -45,14 +45,14 @@ static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
 void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     /* Fast path: a group's position in the stream comes from adding up lengths
      * rather than from finishing the previous group, so the group loads are
      * independent of each other. */
     for (; group < n_groups; group++) {
-        if ((nib >> 1) > byte_limit) {
+        if ((nib >> 1) >= fast_bytes) {
             break;
         }
         uint64_t out = 0;
@@ -97,11 +97,11 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
                             uint32_t total_nibbles) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     for (; group < n_groups; group++) {
-        if ((nib >> 1) > byte_limit) {
+        if ((nib >> 1) >= fast_bytes) {
             break;
         }
         uint64_t out = 0;

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -17,7 +17,15 @@ uint8_t read_4_bits_align4_fast(reader_short_t* r) {
     return (*r->mem >> 4);
 }
 
-void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t safe_bytes) {
+/* Shared walk for unpack_n_groups/unpack_n_groups_nosign: the two differ only in
+ * whether a sign nibble is read alongside the planes. has_sign is a parameter
+ * rather than two separate bodies, but both call sites below pass a compile-time
+ * constant (0 or 1), so the compiler specializes this into the same two variants
+ * that used to be written out by hand, with no runtime branch inside either loop -
+ * the same reasoning pack_groups_masked's emit_signs parameter already relies on, on
+ * the encoder side (see pack_group_helper.h). */
+static INLINE void unpack_n_groups_impl(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                                        uint32_t safe_bytes, const int has_sign) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
@@ -60,14 +68,16 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
              * bit planes than the single load can take - fifteen - and the
              * shift that would extract it would be undefined, so the group is
              * left to the sequential reader below. */
-            if (size > TRUNCATION_MAX || ((nib + 1) >> 1) >= safe_bytes) {
+            if (size > TRUNCATION_MAX || ((nib + (uint32_t)has_sign) >> 1) >= safe_bytes) {
                 group += k;
                 goto tail;
             }
-            const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
-            const uint64_t out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib + 1, size), gtli) | signs;
+            uint64_t out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib + (uint32_t)has_sign, size), gtli);
+            if (has_sign) {
+                out |= unpack_sign_spread[unpack_one_nibble(base, nib)];
+            }
             memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
-            nib += size + 1;
+            nib += size + (uint32_t)has_sign;
             todo &= todo - 1;
         }
         group += chunk;
@@ -83,7 +93,10 @@ tail:
     for (; group < n_groups; group++) {
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
-            const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            uint64_t signs = 0;
+            if (has_sign) {
+                signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            }
             /* A corrupt stream can carry a GCLI far above the truncation maximum: the
              * unary code yields up to thirty-one, and vertical prediction can wrap it
              * to anything up to two hundred and fifty-five. The fast path above
@@ -102,83 +115,13 @@ tail:
     }
 }
 
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t safe_bytes) {
+    unpack_n_groups_impl(gclis, gtli, r, buf, n_groups, safe_bytes, 1);
+}
+
 void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
                             uint32_t safe_bytes) {
-    uint8_t* const base = r->mem;
-    uint32_t nib = r->bits_used ? 1u : 0u;
-    uint32_t group = 0;
-
-    /* The vast majority of groups are empty: about eighty-seven per cent on
-     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
-     * compare, a poorly predicted branch and a store of eight zeroes. Now the
-     * output is zeroed in one pass and the walk follows the bits of a non-empty
-     * mask, so an empty group costs nothing and the per-group branch is gone.
-     *
-     * The mask comes from a saturating subtract: subs_epu8 yields zero exactly
-     * where GCLI does not exceed the truncation level. Testing that result for
-     * equality with zero and inverting the mask is therefore an exact unsigned
-     * comparison, which a signed compare against zero would not be: a corrupt
-     * stream can put any byte value into GCLI, and AVX-512 tests it unsigned. */
-    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
-
-    const __m256i gtli_vec = _mm256_set1_epi8((char)gtli);
-    const __m256i zero = _mm256_setzero_si256();
-    while (group < n_groups) {
-        const uint32_t chunk = MIN(n_groups - group, 32u);
-        __m256i gcli_vec;
-        if (chunk >= 32) {
-            gcli_vec = _mm256_loadu_si256((const __m256i*)(gclis + group));
-        }
-        else {
-            uint8_t padded[32] = {0};
-            memcpy(padded, gclis + group, chunk);
-            gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
-        }
-        uint64_t todo = (uint32_t)~_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
-        while (todo) {
-            const uint32_t k = svt_first_set_bit(todo);
-            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
-            /* A corrupt stream can carry a GCLI above the truncation maximum:
-             * the unary code yields up to thirty-one. Such a group holds more
-             * bit planes than the single load can take - fifteen - and the
-             * shift that would extract it would be undefined, so the group is
-             * left to the sequential reader below. */
-            if (size > TRUNCATION_MAX || (nib >> 1) >= safe_bytes) {
-                group += k;
-                goto tail;
-            }
-            const uint64_t out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib, size), gtli);
-            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
-            nib += size;
-            todo &= todo - 1;
-        }
-        group += chunk;
-    }
-
-tail:
-    r->mem = base + (nib >> 1);
-    r->bits_used = (uint8_t)((nib & 1) * 4);
-    buf += (size_t)group * GROUP_SIZE;
-
-    for (; group < n_groups; group++) {
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        if (size > 0) {
-            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
-             * unary code yields up to thirty-one, and vertical prediction can wrap it
-             * to anything up to two hundred and fifty-five. The fast path above
-             * already declines to touch such a group at all; this sequential reader
-             * has to decline the same way, or it reads size nibbles - unbounded by
-             * anything - straight past the end of whatever buffer backs it. */
-            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
-            uint64_t acc = 0;
-            for (int32_t i = 0; i < read_planes; i++) {
-                acc = (acc << 4) | read_4_bits_align4_fast(r);
-            }
-            const uint64_t out = unpack_planes_to_lanes_sse(acc, gtli);
-            memcpy(buf, &out, sizeof(out));
-        }
-        buf += GROUP_SIZE;
-    }
+    unpack_n_groups_impl(gclis, gtli, r, buf, n_groups, safe_bytes, 0);
 }
 
 SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -78,7 +78,7 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
         }
         uint64_t todo = (uint32_t)~_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
         while (todo) {
-            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t k = svt_first_set_bit(todo);
             const uint32_t size = (uint32_t)gclis[group + k] - gtli;
             /* A corrupt stream can carry a GCLI above the truncation maximum:
              * the unary code yields up to thirty-one. Such a group holds more
@@ -154,7 +154,7 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
         }
         uint64_t todo = (uint32_t)~_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
         while (todo) {
-            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t k = svt_first_set_bit(todo);
             const uint32_t size = (uint32_t)gclis[group + k] - gtli;
             /* A corrupt stream can carry a GCLI above the truncation maximum:
              * the unary code yields up to thirty-one. Such a group holds more

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -4,14 +4,9 @@
 */
 
 #include "UnPack_avx2.h"
+#include "unpack_common.h"
 #include "SvtUtility.h"
-
-DECLARE_ALIGNED(16, static const uint32_t, shift_data[4]) = {3, 2, 1, 0};
-DECLARE_ALIGNED(16, static const uint32_t, bits_offset[4]) = {8, 4, 2, 1};
-DECLARE_ALIGNED(16, static const uint32_t, sign_shift[4]) = {BITSTREAM_BIT_POSITION_SIGN - 3,
-                                                             BITSTREAM_BIT_POSITION_SIGN - 2,
-                                                             BITSTREAM_BIT_POSITION_SIGN - 1,
-                                                             BITSTREAM_BIT_POSITION_SIGN};
+#include "EncDec.h" /* TRUNCATION_MAX: the single load holds fifteen planes at most */
 
 uint8_t read_4_bits_align4_fast(reader_short_t* r) {
     if (r->bits_used) {
@@ -22,54 +17,124 @@ uint8_t read_4_bits_align4_fast(reader_short_t* r) {
     return (*r->mem >> 4);
 }
 
-static INLINE void unpack_data_single_group_avx2(reader_short_t* r, __m128i* vals, int32_t size, int8_t gtli) {
-    __m128i val;
+/* Spreads count nibbles, right aligned, into four coefficients.
+ *
+ * PEXT would do this in four instructions, but this path also runs on Zen 1 and
+ * Zen 2 where it is microcoded and costs tens of cycles. So the nibbles are
+ * first unpacked one per byte (byte j holds nibble j), and then, for each
+ * coefficient, the required bit of every byte is raised into the sign position
+ * and collected by VPMOVMSKB. The value is exactly the same: bit j of the
+ * result is bit (3 - k) of nibble j, that is, the plane with weight 2^j.
+ *
+ * Nibbles past count are zero in acc, so the result needs no masking. */
+static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
+    const __m128i lo_mask = _mm_set1_epi8(0x0F);
+    const __m128i packed = _mm_cvtsi64_si128((int64_t)acc);
+    const __m128i lo = _mm_and_si128(packed, lo_mask);
+    const __m128i hi = _mm_and_si128(_mm_srli_epi16(packed, 4), lo_mask);
+    /* byte 2i is the low nibble of source byte i, byte 2i+1 is the high one */
+    const __m128i nibbles = _mm_unpacklo_epi8(lo, hi);
 
-    for (int32_t bits = 0; bits < (size - 1); bits++) {
-        val = _mm_set1_epi32(read_4_bits_align4_fast(r));
-        val = _mm_and_si128(val, *(__m128i*)bits_offset);
-        *vals = _mm_or_si128(*vals, val);
-        *vals = _mm_slli_epi32(*vals, 1);
-    }
-    val = _mm_set1_epi32(read_4_bits_align4_fast(r));
-    val = _mm_and_si128(val, *(__m128i*)bits_offset);
-    *vals = _mm_or_si128(*vals, val);
-    *vals = _mm_srlv_epi32(*vals, *(__m128i*)shift_data);
-    *vals = _mm_slli_epi32(*vals, gtli);
+    const uint64_t v0 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 4));
+    const uint64_t v1 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 5));
+    const uint64_t v2 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 6));
+    const uint64_t v3 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 7));
+    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
 }
 
 void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles) {
-    UNUSED(total_nibbles);
-    __m128i vals;
-    for (uint32_t group = 0; group < n_groups; group++) {
-        vals = _mm_setzero_si128();
-        int32_t bitplanes_size = gclis[group] - gtli;
-        if (bitplanes_size > 0) {
-            __m128i signs = _mm_set1_epi32(read_4_bits_align4_fast(r));
-            signs = _mm_and_si128(signs, *(__m128i*)bits_offset);
-            signs = _mm_sllv_epi32(signs, *(__m128i*)sign_shift);
-            unpack_data_single_group_avx2(r, &vals, bitplanes_size, gtli);
+    uint8_t* const base = r->mem;
+    uint32_t nib = r->bits_used ? 1u : 0u;
+    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    uint32_t group = 0;
 
-            vals = _mm_or_si128(vals, signs);
-            vals = _mm_packus_epi32(vals, vals);
+    /* Fast path: a group's position in the stream comes from adding up lengths
+     * rather than from finishing the previous group, so the group loads are
+     * independent of each other. */
+    for (; group < n_groups; group++) {
+        if ((nib >> 1) > byte_limit) {
+            break;
         }
-        _mm_storel_epi64((__m128i*)buf, vals);
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        /* A corrupt stream can carry a GCLI above the truncation maximum: the
+         * unary code yields up to thirty-one. Such a group holds more bit
+         * planes than the single load can take, so it is left to the sequential
+         * reader below. */
+        if (size > TRUNCATION_MAX) {
+            break;
+        }
+        if (size > 0) {
+            const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
+            out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib + 1, (uint32_t)size), gtli) | signs;
+            nib += (uint32_t)size + 1;
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+
+    r->mem = base + (nib >> 1);
+    r->bits_used = (uint8_t)((nib & 1) * 4);
+
+    /* End of the line is read sequentially so the load never runs past the data. */
+    for (; group < n_groups; group++) {
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        if (size > 0) {
+            const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            uint64_t acc = 0;
+            for (int32_t i = 0; i < size; i++) {
+                acc = (acc << 4) | read_4_bits_align4_fast(r);
+            }
+            out = unpack_planes_to_lanes_sse(acc, gtli) | signs;
+        }
+        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }
 
 void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
                             uint32_t total_nibbles) {
-    UNUSED(total_nibbles);
-    __m128i vals;
-    for (uint32_t group = 0; group < n_groups; group++) {
-        vals = _mm_setzero_si128();
-        int32_t bitplanes_size = gclis[group] - gtli;
-        if (bitplanes_size > 0) {
-            unpack_data_single_group_avx2(r, &vals, bitplanes_size, gtli);
-            vals = _mm_packus_epi32(vals, vals);
+    uint8_t* const base = r->mem;
+    uint32_t nib = r->bits_used ? 1u : 0u;
+    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    uint32_t group = 0;
+
+    for (; group < n_groups; group++) {
+        if ((nib >> 1) > byte_limit) {
+            break;
         }
-        _mm_storel_epi64((__m128i*)buf, vals);
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        /* A corrupt stream can carry a GCLI above the truncation maximum: the
+         * unary code yields up to thirty-one. Such a group holds more bit
+         * planes than the single load can take, so it is left to the sequential
+         * reader below. */
+        if (size > TRUNCATION_MAX) {
+            break;
+        }
+        if (size > 0) {
+            out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib, (uint32_t)size), gtli);
+            nib += (uint32_t)size;
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+
+    r->mem = base + (nib >> 1);
+    r->bits_used = (uint8_t)((nib & 1) * 4);
+
+    for (; group < n_groups; group++) {
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        if (size > 0) {
+            uint64_t acc = 0;
+            for (int32_t i = 0; i < size; i++) {
+                acc = (acc << 4) | read_4_bits_align4_fast(r);
+            }
+            out = unpack_planes_to_lanes_sse(acc, gtli);
+        }
+        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -197,7 +197,8 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         //Calculate how many bits will be used from bitstream to avoid reading out of memory allocation
         {
             uint8_t* gclis_ptr = gclis;
-            __m256i sum_epi16_avx2 = _mm256_setzero_si256();
+            const __m256i zero = _mm256_setzero_si256();
+            __m256i sum_epi32 = zero;
             for (uint32_t group = 0; group < (group_num / 16); group++) {
                 __m128i bits_epu8 = _mm_subs_epu8(_mm_loadu_si128((__m128i*)gclis_ptr), gtli_const);
                 /* Unsigned widening: subs_epu8 is an unsigned saturating subtract, so on a
@@ -205,27 +206,29 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                  * would make such a group subtract from the budget instead of adding to it,
                  * and the bitstream would not be rejected. */
                 __m256i bits_epu16 = _mm256_cvtepu8_epi16(bits_epu8);
-                __m256i signs = _mm256_cmpgt_epi16(bits_epu16, _mm256_setzero_si256());
+                __m256i signs = _mm256_cmpgt_epi16(bits_epu16, zero);
                 signs = _mm256_srli_epi16(signs, 15);
-                sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, bits_epu16);
-                sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, signs);
+                /* Cost of one group: its planes plus one nibble of signs. At most 256, so
+                 * the per-group value still fits a 16-bit lane; the running total does not
+                 * and is widened before it is added. */
+                __m256i group_bits = _mm256_add_epi16(bits_epu16, signs);
+                sum_epi32 = _mm256_add_epi32(sum_epi32, _mm256_unpacklo_epi16(group_bits, zero));
+                sum_epi32 = _mm256_add_epi32(sum_epi32, _mm256_unpackhi_epi16(group_bits, zero));
                 gclis_ptr += 16;
             }
-            __m128i sum_epi16_sse = _mm_hadd_epi16(_mm256_castsi256_si128(sum_epi16_avx2),
-                                                   _mm256_extracti128_si256(sum_epi16_avx2, 0x1)); // 0..7 16bit
-            sum_epi16_sse = _mm_hadd_epi16(sum_epi16_sse, sum_epi16_sse);                          // 0..3, 0..3 16bit
-            sum_epi16_sse = _mm_unpacklo_epi16(sum_epi16_sse, _mm_setzero_si128());                //0..3 32bit
-            sum_epi16_sse = _mm_hadd_epi32(sum_epi16_sse, sum_epi16_sse);                          // 0..1, 0..1 32bit
-            uint32_t bits_sum = _mm_cvtsi128_si32(sum_epi16_sse) + _mm_extract_epi32(sum_epi16_sse, 1);
+            uint32_t bits_sum = unpack_budget_hsum_epi32(sum_epi32);
             for (uint32_t group = 0; group < (group_num % 16) + !!leftover; group++) {
                 if (gclis_ptr[group] > gtli) {
                     bits_sum += (gclis_ptr[group] - gtli) + 1;
                 }
             }
-            *precinct_bits_left -= (int32_t)(bits_sum * 4);
-            if (*precinct_bits_left < 0) {
+            /* The cost is compared before it is subtracted, so that the widened sum
+             * cannot be lost again in the last step: a line whose nibble count exceeds
+             * what int32_t holds is rejected rather than wrapped into a small debit. */
+            if (*precinct_bits_left < 0 || (uint64_t)bits_sum * 4 > (uint64_t)*precinct_bits_left) {
                 return SvtJxsErrorDecoderInvalidBitstream;
             }
+            *precinct_bits_left -= (int32_t)(bits_sum * 4);
         }
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
@@ -245,28 +248,30 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         //Calculate how many bits will be used from bitstream to avoid reading out of memory allocation
         {
             uint8_t* gclis_ptr = gclis;
-            __m256i sum_epi16_avx2 = _mm256_setzero_si256();
+            const __m256i zero = _mm256_setzero_si256();
+            __m256i sum_epi32 = zero;
             for (uint32_t group = 0; group < (group_num / 16); group++) {
                 __m128i bits_epu8 = _mm_subs_epu8(_mm_loadu_si128((__m128i*)gclis_ptr), gtli_const);
-                /* Unsigned widening, for the same reason as in the branch above. */
-                sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, _mm256_cvtepu8_epi16(bits_epu8));
+                /* Unsigned widening, and 32-bit accumulation, for the same reasons as in
+                 * the branch above. */
+                __m256i group_bits = _mm256_cvtepu8_epi16(bits_epu8);
+                sum_epi32 = _mm256_add_epi32(sum_epi32, _mm256_unpacklo_epi16(group_bits, zero));
+                sum_epi32 = _mm256_add_epi32(sum_epi32, _mm256_unpackhi_epi16(group_bits, zero));
                 gclis_ptr += 16;
             }
-            __m128i sum_epi16_sse = _mm_hadd_epi16(_mm256_castsi256_si128(sum_epi16_avx2),
-                                                   _mm256_extracti128_si256(sum_epi16_avx2, 0x1)); // 0..7 16bit
-            sum_epi16_sse = _mm_hadd_epi16(sum_epi16_sse, sum_epi16_sse);                          // 0..3, 0..3 16bit
-            sum_epi16_sse = _mm_unpacklo_epi16(sum_epi16_sse, _mm_setzero_si128());                //0..3 32bit
-            sum_epi16_sse = _mm_hadd_epi32(sum_epi16_sse, sum_epi16_sse);                          // 0..1, 0..1 32bit
-            uint32_t bits_sum = _mm_cvtsi128_si32(sum_epi16_sse) + _mm_extract_epi32(sum_epi16_sse, 1);
+            uint32_t bits_sum = unpack_budget_hsum_epi32(sum_epi32);
             for (uint32_t group = 0; group < (group_num % 16) + !!leftover; group++) {
                 if (gclis_ptr[group] > gtli) {
                     bits_sum += (gclis_ptr[group] - gtli);
                 }
             }
-            *precinct_bits_left -= (int32_t)(bits_sum * 4);
-            if (*precinct_bits_left < 0) {
+            /* The cost is compared before it is subtracted, so that the widened sum
+             * cannot be lost again in the last step: a line whose nibble count exceeds
+             * what int32_t holds is rejected rather than wrapped into a small debit. */
+            if (*precinct_bits_left < 0 || (uint64_t)bits_sum * 4 > (uint64_t)*precinct_bits_left) {
                 return SvtJxsErrorDecoderInvalidBitstream;
             }
+            *precinct_bits_left -= (int32_t)(bits_sum * 4);
         }
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -17,31 +17,6 @@ uint8_t read_4_bits_align4_fast(reader_short_t* r) {
     return (*r->mem >> 4);
 }
 
-/* Spreads count nibbles, right aligned, into four coefficients.
- *
- * PEXT would do this in four instructions, but this path also runs on Zen 1 and
- * Zen 2 where it is microcoded and costs tens of cycles. So the nibbles are
- * first unpacked one per byte (byte j holds nibble j), and then, for each
- * coefficient, the required bit of every byte is raised into the sign position
- * and collected by VPMOVMSKB. The value is exactly the same: bit j of the
- * result is bit (3 - k) of nibble j, that is, the plane with weight 2^j.
- *
- * Nibbles past count are zero in acc, so the result needs no masking. */
-static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
-    const __m128i lo_mask = _mm_set1_epi8(0x0F);
-    const __m128i packed = _mm_cvtsi64_si128((int64_t)acc);
-    const __m128i lo = _mm_and_si128(packed, lo_mask);
-    const __m128i hi = _mm_and_si128(_mm_srli_epi16(packed, 4), lo_mask);
-    /* byte 2i is the low nibble of source byte i, byte 2i+1 is the high one */
-    const __m128i nibbles = _mm_unpacklo_epi8(lo, hi);
-
-    const uint64_t v0 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 4));
-    const uint64_t v1 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 5));
-    const uint64_t v2 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 6));
-    const uint64_t v3 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 7));
-    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
-}
-
 void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t safe_bytes) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -47,37 +47,65 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
 
+    /* The vast majority of groups are empty: about eighty-seven per cent on
+     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
+     * compare, a poorly predicted branch and a store of eight zeroes. Now the
+     * output is zeroed in one pass and the walk follows the bits of a non-empty
+     * mask, so an empty group costs nothing and the per-group branch is gone.
+     *
+     * The mask comes from a saturating subtract: subs_epu8 yields zero exactly
+     * where GCLI does not exceed the truncation level. Testing that result for
+     * equality with zero and inverting the mask is therefore an exact unsigned
+     * comparison, which a signed compare against zero would not be: a corrupt
+     * stream can put any byte value into GCLI, and AVX-512 tests it unsigned. */
+    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
+
     /* Fast path: a group's position in the stream comes from adding up lengths
      * rather than from finishing the previous group, so the group loads are
      * independent of each other. */
-    for (; group < n_groups; group++) {
-        if ((nib >> 1) >= safe_bytes) {
-            break;
+    const __m256i gtli_vec = _mm256_set1_epi8((char)gtli);
+    const __m256i zero = _mm256_setzero_si256();
+    while (group < n_groups) {
+        const uint32_t chunk = MIN(n_groups - group, 32u);
+        __m256i gcli_vec;
+        if (chunk >= 32) {
+            gcli_vec = _mm256_loadu_si256((const __m256i*)(gclis + group));
         }
-        uint64_t out = 0;
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        /* A corrupt stream can carry a GCLI above the truncation maximum: the
-         * unary code yields up to thirty-one. Such a group holds more bit
-         * planes than the single load can take, so it is left to the sequential
-         * reader below. */
-        if (size > TRUNCATION_MAX) {
-            break;
+        else {
+            uint8_t padded[32] = {0};
+            memcpy(padded, gclis + group, chunk);
+            gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
         }
-        if (size > 0) {
+        uint64_t todo = (uint32_t)~_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
+        while (todo) {
+            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
+            /* A corrupt stream can carry a GCLI above the truncation maximum:
+             * the unary code yields up to thirty-one. Such a group holds more
+             * bit planes than the single load can take - fifteen - and the
+             * shift that would extract it would be undefined, so the group is
+             * left to the sequential reader below. */
+            if (size > TRUNCATION_MAX || ((nib + 1) >> 1) >= safe_bytes) {
+                group += k;
+                goto tail;
+            }
             const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
-            out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib + 1, (uint32_t)size), gtli) | signs;
-            nib += (uint32_t)size + 1;
+            const uint64_t out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib + 1, size), gtli) | signs;
+            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
+            nib += size + 1;
+            todo &= todo - 1;
         }
-        memcpy(buf, &out, sizeof(out));
-        buf += GROUP_SIZE;
+        group += chunk;
     }
 
+tail:
     r->mem = base + (nib >> 1);
     r->bits_used = (uint8_t)((nib & 1) * 4);
+    buf += (size_t)group * GROUP_SIZE;
 
-    /* End of the line is read sequentially so the load never runs past the data. */
+    /* End of the line is read sequentially so the load never runs past the data.
+     * Zeroes need not be written: the buffer is already cleared. */
     for (; group < n_groups; group++) {
-        uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
@@ -85,9 +113,9 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
             for (int32_t i = 0; i < size; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
-            out = unpack_planes_to_lanes_sse(acc, gtli) | signs;
+            const uint64_t out = unpack_planes_to_lanes_sse(acc, gtli) | signs;
+            memcpy(buf, &out, sizeof(out));
         }
-        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }
@@ -98,41 +126,68 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
 
-    for (; group < n_groups; group++) {
-        if ((nib >> 1) >= safe_bytes) {
-            break;
+    /* The vast majority of groups are empty: about eighty-seven per cent on
+     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
+     * compare, a poorly predicted branch and a store of eight zeroes. Now the
+     * output is zeroed in one pass and the walk follows the bits of a non-empty
+     * mask, so an empty group costs nothing and the per-group branch is gone.
+     *
+     * The mask comes from a saturating subtract: subs_epu8 yields zero exactly
+     * where GCLI does not exceed the truncation level. Testing that result for
+     * equality with zero and inverting the mask is therefore an exact unsigned
+     * comparison, which a signed compare against zero would not be: a corrupt
+     * stream can put any byte value into GCLI, and AVX-512 tests it unsigned. */
+    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
+
+    const __m256i gtli_vec = _mm256_set1_epi8((char)gtli);
+    const __m256i zero = _mm256_setzero_si256();
+    while (group < n_groups) {
+        const uint32_t chunk = MIN(n_groups - group, 32u);
+        __m256i gcli_vec;
+        if (chunk >= 32) {
+            gcli_vec = _mm256_loadu_si256((const __m256i*)(gclis + group));
         }
-        uint64_t out = 0;
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        /* A corrupt stream can carry a GCLI above the truncation maximum: the
-         * unary code yields up to thirty-one. Such a group holds more bit
-         * planes than the single load can take, so it is left to the sequential
-         * reader below. */
-        if (size > TRUNCATION_MAX) {
-            break;
+        else {
+            uint8_t padded[32] = {0};
+            memcpy(padded, gclis + group, chunk);
+            gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
         }
-        if (size > 0) {
-            out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib, (uint32_t)size), gtli);
-            nib += (uint32_t)size;
+        uint64_t todo = (uint32_t)~_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
+        while (todo) {
+            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
+            /* A corrupt stream can carry a GCLI above the truncation maximum:
+             * the unary code yields up to thirty-one. Such a group holds more
+             * bit planes than the single load can take - fifteen - and the
+             * shift that would extract it would be undefined, so the group is
+             * left to the sequential reader below. */
+            if (size > TRUNCATION_MAX || (nib >> 1) >= safe_bytes) {
+                group += k;
+                goto tail;
+            }
+            const uint64_t out = unpack_planes_to_lanes_sse(unpack_load_nibbles(base, nib, size), gtli);
+            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
+            nib += size;
+            todo &= todo - 1;
         }
-        memcpy(buf, &out, sizeof(out));
-        buf += GROUP_SIZE;
+        group += chunk;
     }
 
+tail:
     r->mem = base + (nib >> 1);
     r->bits_used = (uint8_t)((nib & 1) * 4);
+    buf += (size_t)group * GROUP_SIZE;
 
     for (; group < n_groups; group++) {
-        uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             uint64_t acc = 0;
             for (int32_t i = 0; i < size; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
-            out = unpack_planes_to_lanes_sse(acc, gtli);
+            const uint64_t out = unpack_planes_to_lanes_sse(acc, gtli);
+            memcpy(buf, &out, sizeof(out));
         }
-        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -38,7 +38,8 @@ static INLINE void unpack_data_single_group_avx2(reader_short_t* r, __m128i* val
     *vals = _mm_slli_epi32(*vals, gtli);
 }
 
-void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles) {
+    UNUSED(total_nibbles);
     __m128i vals;
     for (uint32_t group = 0; group < n_groups; group++) {
         vals = _mm_setzero_si128();
@@ -57,7 +58,9 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
     }
 }
 
-void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
+void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                            uint32_t total_nibbles) {
+    UNUSED(total_nibbles);
     __m128i vals;
     for (uint32_t group = 0; group < n_groups; group++) {
         vals = _mm_setzero_si128();
@@ -74,6 +77,7 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
 SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
                                      uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
                                      int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign) {
+    uint32_t bits_sum_total = 0;
     UNUSED(group_size);
     assert(group_size == GROUP_SIZE);
     assert((bitstream->bits_used != 0) || (bitstream->bits_used != 4));
@@ -106,6 +110,7 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                     bits_sum += (gclis_ptr[group] - gtli) + 1;
                 }
             }
+            bits_sum_total = bits_sum;
             *precinct_bits_left -= (int32_t)(bits_sum * 4);
             if (*precinct_bits_left < 0) {
                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -114,12 +119,12 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        groups_sign(gclis, gtli, &reader, buf, group_num);
+        groups_sign(gclis, gtli, &reader, buf, group_num, bits_sum_total);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;
             uint16_t buf_tmp[GROUP_SIZE];
-            groups_sign(gclis, gtli, &reader, buf_tmp, 1);
+            groups_sign(gclis, gtli, &reader, buf_tmp, 1, 0);
             memcpy(buf, buf_tmp, sizeof(uint16_t) * (leftover));
         }
         bitstream->offset = (uint32_t)(reader.mem - bitstream->mem);
@@ -146,6 +151,7 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                     bits_sum += (gclis_ptr[group] - gtli);
                 }
             }
+            bits_sum_total = bits_sum;
             *precinct_bits_left -= (int32_t)(bits_sum * 4);
             if (*precinct_bits_left < 0) {
                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -154,12 +160,12 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        groups_nosign(gclis, gtli, &reader, buf, group_num);
+        groups_nosign(gclis, gtli, &reader, buf, group_num, bits_sum_total);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;
             uint16_t buf_tmp[GROUP_SIZE];
-            groups_nosign(gclis, gtli, &reader, buf_tmp, 1);
+            groups_nosign(gclis, gtli, &reader, buf_tmp, 1, 0);
             *leftover_signs_num = 0;
             for (uint32_t leftover_id = leftover; leftover_id < GROUP_SIZE; leftover_id++) {
                 *leftover_signs_num += !!buf_tmp[leftover_id];

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -211,7 +211,11 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
             __m256i sum_epi16_avx2 = _mm256_setzero_si256();
             for (uint32_t group = 0; group < (group_num / 16); group++) {
                 __m128i bits_epu8 = _mm_subs_epu8(_mm_loadu_si128((__m128i*)gclis_ptr), gtli_const);
-                __m256i bits_epu16 = _mm256_cvtepi8_epi16(bits_epu8);
+                /* Unsigned widening: subs_epu8 is an unsigned saturating subtract, so on a
+                 * corrupt stream the byte can be anything up to 255. Widening it as signed
+                 * would make such a group subtract from the budget instead of adding to it,
+                 * and the bitstream would not be rejected. */
+                __m256i bits_epu16 = _mm256_cvtepu8_epi16(bits_epu8);
                 __m256i signs = _mm256_cmpgt_epi16(bits_epu16, _mm256_setzero_si256());
                 signs = _mm256_srli_epi16(signs, 15);
                 sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, bits_epu16);
@@ -255,7 +259,8 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
             __m256i sum_epi16_avx2 = _mm256_setzero_si256();
             for (uint32_t group = 0; group < (group_num / 16); group++) {
                 __m128i bits_epu8 = _mm_subs_epu8(_mm_loadu_si128((__m128i*)gclis_ptr), gtli_const);
-                sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, _mm256_cvtepi8_epi16(bits_epu8));
+                /* Unsigned widening, for the same reason as in the branch above. */
+                sum_epi16_avx2 = _mm256_add_epi16(sum_epi16_avx2, _mm256_cvtepu8_epi16(bits_epu8));
                 gclis_ptr += 16;
             }
             __m128i sum_epi16_sse = _mm_hadd_epi16(_mm256_castsi256_si128(sum_epi16_avx2),

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -42,17 +42,16 @@ static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
     return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
 }
 
-void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles) {
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t safe_bytes) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     /* Fast path: a group's position in the stream comes from adding up lengths
      * rather than from finishing the previous group, so the group loads are
      * independent of each other. */
     for (; group < n_groups; group++) {
-        if ((nib >> 1) >= fast_bytes) {
+        if ((nib >> 1) >= safe_bytes) {
             break;
         }
         uint64_t out = 0;
@@ -94,14 +93,13 @@ void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* 
 }
 
 void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                            uint32_t total_nibbles) {
+                            uint32_t safe_bytes) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     for (; group < n_groups; group++) {
-        if ((nib >> 1) >= fast_bytes) {
+        if ((nib >> 1) >= safe_bytes) {
             break;
         }
         uint64_t out = 0;
@@ -142,13 +140,14 @@ void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
 SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
                                      uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
                                      int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign) {
-    uint32_t bits_sum_total = 0;
     UNUSED(group_size);
     assert(group_size == GROUP_SIZE);
     assert((bitstream->bits_used != 0) || (bitstream->bits_used != 4));
     const uint32_t group_num = w / GROUP_SIZE;
     const uint32_t leftover = w % GROUP_SIZE;
     const __m128i gtli_const = _mm_set1_epi8(gtli);
+    const uint32_t safe_bytes = unpack_safe_byte_count(bitstream->size > bitstream->offset ? bitstream->size - bitstream->offset
+                                                                                           : 0);
 
     if (sign_flag == 0) {
         //Calculate how many bits will be used from bitstream to avoid reading out of memory allocation
@@ -175,7 +174,6 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                     bits_sum += (gclis_ptr[group] - gtli) + 1;
                 }
             }
-            bits_sum_total = bits_sum;
             *precinct_bits_left -= (int32_t)(bits_sum * 4);
             if (*precinct_bits_left < 0) {
                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -184,7 +182,7 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        groups_sign(gclis, gtli, &reader, buf, group_num, bits_sum_total);
+        groups_sign(gclis, gtli, &reader, buf, group_num, safe_bytes);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;
@@ -216,7 +214,6 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                     bits_sum += (gclis_ptr[group] - gtli);
                 }
             }
-            bits_sum_total = bits_sum;
             *precinct_bits_left -= (int32_t)(bits_sum * 4);
             if (*precinct_bits_left < 0) {
                 return SvtJxsErrorDecoderInvalidBitstream;
@@ -225,7 +222,7 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
         reader_short_t reader;
         reader.mem = (uint8_t*)(bitstream->mem) + bitstream->offset;
         reader.bits_used = bitstream->bits_used;
-        groups_nosign(gclis, gtli, &reader, buf, group_num, bits_sum_total);
+        groups_nosign(gclis, gtli, &reader, buf, group_num, safe_bytes);
         if (leftover) {
             buf += group_num * GROUP_SIZE;
             gclis += group_num;

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.c
@@ -84,8 +84,15 @@ tail:
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
+             * unary code yields up to thirty-one, and vertical prediction can wrap it
+             * to anything up to two hundred and fifty-five. The fast path above
+             * already declines to touch such a group at all; this sequential reader
+             * has to decline the same way, or it reads size nibbles - unbounded by
+             * anything - straight past the end of whatever buffer backs it. */
+            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
             uint64_t acc = 0;
-            for (int32_t i = 0; i < size; i++) {
+            for (int32_t i = 0; i < read_planes; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
             const uint64_t out = unpack_planes_to_lanes_sse(acc, gtli) | signs;
@@ -156,8 +163,15 @@ tail:
     for (; group < n_groups; group++) {
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
+            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
+             * unary code yields up to thirty-one, and vertical prediction can wrap it
+             * to anything up to two hundred and fifty-five. The fast path above
+             * already declines to touch such a group at all; this sequential reader
+             * has to decline the same way, or it reads size nibbles - unbounded by
+             * anything - straight past the end of whatever buffer backs it. */
+            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
             uint64_t acc = 0;
-            for (int32_t i = 0; i < size; i++) {
+            for (int32_t i = 0; i < read_planes; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
             const uint64_t out = unpack_planes_to_lanes_sse(acc, gtli);

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
@@ -15,6 +15,27 @@
 extern "C" {
 #endif
 
+typedef struct reader_short {
+    uint8_t* mem;
+    uint8_t bits_used;
+} reader_short_t;
+
+/* The group parser differs between instruction sets, but the surrounding logic
+ * (counting the consumed bits, the end of the line, handing the position back
+ * to the common reader) does not. So the surrounding logic exists once and the
+ * parser is passed in: it is called once per line, which makes the indirect
+ * call free. */
+typedef void (*unpack_groups_fn)(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
+
+uint8_t read_4_bits_align4_fast(reader_short_t* r);
+
+SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
+                                     uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
+                                     int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign);
+
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
+void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
+
 SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,
                                    uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num, int32_t* precinct_bits_left);
 #ifdef __cplusplus

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
@@ -26,7 +26,7 @@ typedef struct reader_short {
  * parser is passed in: it is called once per line, which makes the indirect
  * call free. */
 typedef void (*unpack_groups_fn)(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                                 uint32_t total_nibbles);
+                                 uint32_t safe_bytes);
 
 uint8_t read_4_bits_align4_fast(reader_short_t* r);
 
@@ -34,9 +34,9 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                                      uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
                                      int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign);
 
-void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles);
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t safe_bytes);
 void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                            uint32_t total_nibbles);
+                            uint32_t safe_bytes);
 
 SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,
                                    uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num, int32_t* precinct_bits_left);

--- a/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
+++ b/Source/Lib/Decoder/ASM_AVX2/UnPack_avx2.h
@@ -25,7 +25,8 @@ typedef struct reader_short {
  * to the common reader) does not. So the surrounding logic exists once and the
  * parser is passed in: it is called once per line, which makes the indirect
  * call free. */
-typedef void (*unpack_groups_fn)(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
+typedef void (*unpack_groups_fn)(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                                 uint32_t total_nibbles);
 
 uint8_t read_4_bits_align4_fast(reader_short_t* r);
 
@@ -33,8 +34,9 @@ SvtJxsErrorType_t unpack_data_common(bitstream_reader_t* bitstream, uint16_t* bu
                                      uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
                                      int32_t* precinct_bits_left, unpack_groups_fn groups_sign, unpack_groups_fn groups_nosign);
 
-void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
-void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups);
+void unpack_n_groups(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups, uint32_t total_nibbles);
+void unpack_n_groups_nosign(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                            uint32_t total_nibbles);
 
 SvtJxsErrorType_t unpack_data_avx2(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,
                                    uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num, int32_t* precinct_bits_left);

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -78,4 +78,29 @@ static INLINE uint32_t unpack_safe_byte_count(uint32_t bytes_left) {
     return bytes_left >= 8 ? bytes_left - 7 : 0;
 }
 
+/* Spreads count nibbles, right aligned, into four coefficients.
+ *
+ * PEXT would do this in four instructions, but this path also runs on Zen 1 and
+ * Zen 2 where it is microcoded and costs tens of cycles. So the nibbles are
+ * first unpacked one per byte (byte j holds nibble j), and then, for each
+ * coefficient, the required bit of every byte is raised into the sign position
+ * and collected by VPMOVMSKB. The value is exactly the same: bit j of the
+ * result is bit (3 - k) of nibble j, that is, the plane with weight 2^j.
+ *
+ * Nibbles past count are zero in acc, so the result needs no masking. */
+static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
+    const __m128i lo_mask = _mm_set1_epi8(0x0F);
+    const __m128i packed = _mm_cvtsi64_si128((int64_t)acc);
+    const __m128i lo = _mm_and_si128(packed, lo_mask);
+    const __m128i hi = _mm_and_si128(_mm_srli_epi16(packed, 4), lo_mask);
+    /* byte 2i is the low nibble of source byte i, byte 2i+1 is the high one */
+    const __m128i nibbles = _mm_unpacklo_epi8(lo, hi);
+
+    const uint64_t v0 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 4));
+    const uint64_t v1 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 5));
+    const uint64_t v2 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 6));
+    const uint64_t v3 = (uint32_t)_mm_movemask_epi8(_mm_slli_epi16(nibbles, 7));
+    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
+}
+
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -1,0 +1,70 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __UNPACK_COMMON_H__
+#define __UNPACK_COMMON_H__
+
+#include <string.h>
+#include "UnPack_avx2.h"
+
+#if defined(_MSC_VER)
+#define UNPACK_BSWAP64(x) _byteswap_uint64(x)
+#else
+#define UNPACK_BSWAP64(x) __builtin_bswap64(x)
+#endif
+
+/* Sign nibble: its bit (3 - i) belongs to coefficient i and has to become the
+ * top bit of the i-th 16-bit word. The table replaces four shifts. */
+static const uint64_t unpack_sign_spread[16] = {
+    0x0000000000000000ULL,
+    0x8000000000000000ULL,
+    0x0000800000000000ULL,
+    0x8000800000000000ULL,
+    0x0000000080000000ULL,
+    0x8000000080000000ULL,
+    0x0000800080000000ULL,
+    0x8000800080000000ULL,
+    0x0000000000008000ULL,
+    0x8000000000008000ULL,
+    0x0000800000008000ULL,
+    0x8000800000008000ULL,
+    0x0000000080008000ULL,
+    0x8000000080008000ULL,
+    0x0000800080008000ULL,
+    0x8000800080008000ULL,
+};
+
+/* Reads count nibbles starting at nibble number nib and returns them right
+ * aligned: nibble nib becomes the most significant of the count, that is the
+ * top bit plane, and the low nibble of the result is the lowest plane.
+ *
+ * The point is that the whole group is taken with a single eight-byte load
+ * instead of a chain of per-nibble accesses. Bytes arrive high nibble first, so
+ * the word is reversed with BSWAP. The shift inside a byte is at most one
+ * nibble and count is at most fifteen, so 4 + 60 = 64 bits fit exactly into one
+ * word.
+ *
+ * The load reads up to eight bytes ahead, so it may only be used where that
+ * many bytes are known to follow the start of the group; the end of the line is
+ * read sequentially. */
+static INLINE uint64_t unpack_load_nibbles(const uint8_t* mem, uint32_t nib, uint32_t count) {
+    uint64_t w;
+    memcpy(&w, mem + (nib >> 1), sizeof(w));
+    w = UNPACK_BSWAP64(w);
+    w <<= (nib & 1) * 4;
+    return w >> (64 - 4 * count);
+}
+
+static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
+    return (uint32_t)((mem[nib >> 1] >> (4 - (nib & 1) * 4)) & 0xF);
+}
+
+/* The bound up to which an over-reading load stays inside the line's data. */
+static INLINE uint32_t unpack_fast_byte_limit(uint32_t nib0, uint32_t total_nibbles) {
+    const uint32_t last_byte = (nib0 + total_nibbles + 1) >> 1;
+    return last_byte >= 8 ? last_byte - 8 : 0;
+}
+
+#endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include "UnPack_avx2.h"
+#include "SvtUtility.h"
 
 #if defined(_MSC_VER)
 #define UNPACK_BSWAP64(x) _byteswap_uint64(x)
@@ -75,20 +76,6 @@ static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
  * at all", whereas index zero would also mean "byte zero is allowed". */
 static INLINE uint32_t unpack_safe_byte_count(uint32_t bytes_left) {
     return bytes_left >= 8 ? bytes_left - 7 : 0;
-}
-
-/* Index of the lowest set bit. The wrapper exists for MSVC, which has no
- * __builtin_ctzll, and TZCNT cannot be assumed either - BMI1 is not enabled for
- * this target, only -mbmi2. */
-static INLINE uint32_t unpack_first_set_bit(uint64_t mask) {
-    assert(mask != 0);
-#if defined(_MSC_VER)
-    unsigned long index;
-    _BitScanForward64(&index, mask);
-    return (uint32_t)index;
-#else
-    return (uint32_t)__builtin_ctzll(mask);
-#endif
 }
 
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -77,4 +77,18 @@ static INLINE uint32_t unpack_safe_byte_count(uint32_t bytes_left) {
     return bytes_left >= 8 ? bytes_left - 7 : 0;
 }
 
+/* Index of the lowest set bit. The wrapper exists for MSVC, which has no
+ * __builtin_ctzll, and TZCNT cannot be assumed either - BMI1 is not enabled for
+ * this target, only -mbmi2. */
+static INLINE uint32_t unpack_first_set_bit(uint64_t mask) {
+    assert(mask != 0);
+#if defined(_MSC_VER)
+    unsigned long index;
+    _BitScanForward64(&index, mask);
+    return (uint32_t)index;
+#else
+    return (uint32_t)__builtin_ctzll(mask);
+#endif
+}
+
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -61,17 +61,20 @@ static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
     return (uint32_t)((mem[nib >> 1] >> (4 - (nib & 1) * 4)) & 0xF);
 }
 
-/* How many leading bytes of the line may start an over-reading load: eight
- * bytes of data must remain past the start of the group.
+/* How many leading bytes from the current position may start an over-reading
+ * load: eight readable bytes must remain past the start of the group.
  *
- * A count is returned rather than the last allowed index: for short lines (less
- * than eight bytes of data, and such lines exist - bands of the upper
- * decomposition levels are narrow) the answer is zero and the whole line falls
- * back to the sequential path. An index would give zero both for "not at all"
- * and for "byte zero only". */
-static INLINE uint32_t unpack_fast_byte_count(uint32_t nib0, uint32_t total_nibbles) {
-    const uint32_t last_byte = (nib0 + total_nibbles + 1) >> 1;
-    return last_byte >= 8 ? last_byte - 7 : 0;
+ * The bound comes from the end of the buffer, not from the length of the line
+ * being parsed. Extra bytes that land in the word are masked off by the plane
+ * count anyway, so the parser never leaves its own data; the only question here
+ * is the right to touch the memory. The former per-line bound pushed forty per
+ * cent of all groups onto the slow path, because bands of the upper
+ * decomposition levels are shorter than eight bytes in their entirety.
+ *
+ * A count is returned rather than the last allowed index: zero has to mean "not
+ * at all", whereas index zero would also mean "byte zero is allowed". */
+static INLINE uint32_t unpack_safe_byte_count(uint32_t bytes_left) {
+    return bytes_left >= 8 ? bytes_left - 7 : 0;
 }
 
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -103,4 +103,18 @@ static INLINE uint64_t unpack_planes_to_lanes_sse(uint64_t acc, uint8_t gtli) {
     return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
 }
 
+/* Horizontal sum of eight 32-bit lanes.
+ *
+ * The budget of a band line is accumulated in 32-bit lanes and not in 16-bit
+ * ones. A single group costs at most 256, which a 16-bit lane holds, but a line
+ * of a couple of thousand groups does not, and the fold of a wrapped sum reads
+ * as a cheap line: a corrupt stream would pass the budget check instead of
+ * being rejected. Lines that wide occur at 8K and above. */
+static INLINE uint32_t unpack_budget_hsum_epi32(__m256i sum_epi32) {
+    __m128i sum_sse = _mm_add_epi32(_mm256_castsi256_si128(sum_epi32), _mm256_extracti128_si256(sum_epi32, 0x1));
+    sum_sse = _mm_add_epi32(sum_sse, _mm_shuffle_epi32(sum_sse, 0x4E)); /* lanes 0+2 and 1+3 */
+    sum_sse = _mm_add_epi32(sum_sse, _mm_shuffle_epi32(sum_sse, 0xB1)); /* all four */
+    return (uint32_t)_mm_cvtsi128_si32(sum_sse);
+}
+
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
+++ b/Source/Lib/Decoder/ASM_AVX2/unpack_common.h
@@ -61,10 +61,17 @@ static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
     return (uint32_t)((mem[nib >> 1] >> (4 - (nib & 1) * 4)) & 0xF);
 }
 
-/* The bound up to which an over-reading load stays inside the line's data. */
-static INLINE uint32_t unpack_fast_byte_limit(uint32_t nib0, uint32_t total_nibbles) {
+/* How many leading bytes of the line may start an over-reading load: eight
+ * bytes of data must remain past the start of the group.
+ *
+ * A count is returned rather than the last allowed index: for short lines (less
+ * than eight bytes of data, and such lines exist - bands of the upper
+ * decomposition levels are narrow) the answer is zero and the whole line falls
+ * back to the sequential path. An index would give zero both for "not at all"
+ * and for "byte zero only". */
+static INLINE uint32_t unpack_fast_byte_count(uint32_t nib0, uint32_t total_nibbles) {
     const uint32_t last_byte = (nib0 + total_nibbles + 1) >> 1;
-    return last_byte >= 8 ? last_byte - 8 : 0;
+    return last_byte >= 8 ? last_byte - 7 : 0;
 }
 
 #endif /*__UNPACK_COMMON_H__*/

--- a/Source/Lib/Decoder/ASM_AVX512/CMakeLists.txt
+++ b/Source/Lib/Decoder/ASM_AVX512/CMakeLists.txt
@@ -18,7 +18,8 @@ check_both_flags_add(
     -mavx512f
     -mavx512bw
     -mavx512dq
-    -mavx512vl)
+    -mavx512vl
+    -mbmi2)
 
 if(MSVC)
     check_both_flags_add(/arch:AVX512)

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -38,10 +38,9 @@ static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
 }
 
 void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                            uint32_t total_nibbles) {
+                            uint32_t safe_bytes) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     /* Fast path. A group's address comes from adding up lengths rather than
@@ -49,7 +48,7 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
      * chain of single-cycle additions while the loads and the parsing itself
      * proceed in parallel. */
     for (; group < n_groups; group++) {
-        if ((nib >> 1) >= fast_bytes) {
+        if ((nib >> 1) >= safe_bytes) {
             break;
         }
         uint64_t out = 0;
@@ -91,14 +90,13 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
 }
 
 void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                                   uint32_t total_nibbles) {
+                                   uint32_t safe_bytes) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     for (; group < n_groups; group++) {
-        if ((nib >> 1) >= fast_bytes) {
+        if ((nib >> 1) >= safe_bytes) {
             break;
         }
         uint64_t out = 0;

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -9,6 +9,7 @@
 #include "unpack_common.h"
 #include "Definitions.h"
 #include "EncDec.h" /* TRUNCATION_MAX: the single load holds fifteen planes at most */
+#include "SvtUtility.h"
 
 /* Parsing a group is the inverse of packing it: every nibble of a bit plane
  * carries one bit of all four coefficients, most significant plane first.
@@ -43,38 +44,51 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
 
+    /* The vast majority of groups are empty: about eighty-seven per cent on
+     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
+     * compare, a poorly predicted branch and a store of eight zeroes. Now the
+     * output is zeroed in one pass and the walk follows the bits of a non-empty
+     * mask, so an empty group costs nothing and the per-group branch is gone. */
+    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
+
     /* Fast path. A group's address comes from adding up lengths rather than
      * from reading the previous group, so the dependency between groups is a
      * chain of single-cycle additions while the loads and the parsing itself
      * proceed in parallel. */
-    for (; group < n_groups; group++) {
-        if ((nib >> 1) >= safe_bytes) {
-            break;
-        }
-        uint64_t out = 0;
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        /* A corrupt stream can carry a GCLI above the truncation maximum: the
-         * unary code yields up to thirty-one. Such a group holds more bit
-         * planes than the single load can take, so it is left to the sequential
-         * reader below. */
-        if (size > TRUNCATION_MAX) {
-            break;
-        }
-        if (size > 0) {
+    const __m512i gtli_vec = _mm512_set1_epi8((char)gtli);
+    while (group < n_groups) {
+        const uint32_t chunk = MIN(n_groups - group, 64u);
+        const __mmask64 valid = (chunk >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << chunk) - 1);
+        __mmask64 todo = _mm512_mask_cmpgt_epu8_mask(valid, _mm512_maskz_loadu_epi8(valid, gclis + group), gtli_vec);
+        while (todo) {
+            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
+            /* A corrupt stream can carry a GCLI above the truncation maximum:
+             * the unary code yields up to thirty-one. Such a group holds more
+             * bit planes than the single load can take - fifteen - and the
+             * shift that would extract it would be undefined, so the group is
+             * left to the sequential reader below. */
+            if (size > TRUNCATION_MAX || ((nib + 1) >> 1) >= safe_bytes) {
+                group += k;
+                goto tail;
+            }
             const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
-            out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib + 1, (uint32_t)size), gtli) | signs;
-            nib += (uint32_t)size + 1;
+            const uint64_t out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib + 1, size), gtli) | signs;
+            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
+            nib += size + 1;
+            todo &= todo - 1;
         }
-        memcpy(buf, &out, sizeof(out));
-        buf += GROUP_SIZE;
+        group += chunk;
     }
 
+tail:
     r->mem = base + (nib >> 1);
     r->bits_used = (uint8_t)((nib & 1) * 4);
+    buf += (size_t)group * GROUP_SIZE;
 
-    /* End of the line is read sequentially, without reading past the data. */
+    /* End of the line is read sequentially, without reading past the data.
+     * Zeroes need not be written: the buffer is already cleared. */
     for (; group < n_groups; group++) {
-        uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
@@ -82,9 +96,9 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
             for (int32_t i = 0; i < size; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
-            out = unpack_planes_to_lanes(acc, gtli) | signs;
+            const uint64_t out = unpack_planes_to_lanes(acc, gtli) | signs;
+            memcpy(buf, &out, sizeof(out));
         }
-        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }
@@ -95,41 +109,53 @@ void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t*
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
 
-    for (; group < n_groups; group++) {
-        if ((nib >> 1) >= safe_bytes) {
-            break;
+    /* The vast majority of groups are empty: about eighty-seven per cent on
+     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
+     * compare, a poorly predicted branch and a store of eight zeroes. Now the
+     * output is zeroed in one pass and the walk follows the bits of a non-empty
+     * mask, so an empty group costs nothing and the per-group branch is gone. */
+    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
+
+    const __m512i gtli_vec = _mm512_set1_epi8((char)gtli);
+    while (group < n_groups) {
+        const uint32_t chunk = MIN(n_groups - group, 64u);
+        const __mmask64 valid = (chunk >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << chunk) - 1);
+        __mmask64 todo = _mm512_mask_cmpgt_epu8_mask(valid, _mm512_maskz_loadu_epi8(valid, gclis + group), gtli_vec);
+        while (todo) {
+            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
+            /* A corrupt stream can carry a GCLI above the truncation maximum:
+             * the unary code yields up to thirty-one. Such a group holds more
+             * bit planes than the single load can take - fifteen - and the
+             * shift that would extract it would be undefined, so the group is
+             * left to the sequential reader below. */
+            if (size > TRUNCATION_MAX || (nib >> 1) >= safe_bytes) {
+                group += k;
+                goto tail;
+            }
+            const uint64_t out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib, size), gtli);
+            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
+            nib += size;
+            todo &= todo - 1;
         }
-        uint64_t out = 0;
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        /* A corrupt stream can carry a GCLI above the truncation maximum: the
-         * unary code yields up to thirty-one. Such a group holds more bit
-         * planes than the single load can take, so it is left to the sequential
-         * reader below. */
-        if (size > TRUNCATION_MAX) {
-            break;
-        }
-        if (size > 0) {
-            out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib, (uint32_t)size), gtli);
-            nib += (uint32_t)size;
-        }
-        memcpy(buf, &out, sizeof(out));
-        buf += GROUP_SIZE;
+        group += chunk;
     }
 
+tail:
     r->mem = base + (nib >> 1);
     r->bits_used = (uint8_t)((nib & 1) * 4);
+    buf += (size_t)group * GROUP_SIZE;
 
     for (; group < n_groups; group++) {
-        uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             uint64_t acc = 0;
             for (int32_t i = 0; i < size; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
-            out = unpack_planes_to_lanes(acc, gtli);
+            const uint64_t out = unpack_planes_to_lanes(acc, gtli);
+            memcpy(buf, &out, sizeof(out));
         }
-        memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -61,7 +61,7 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
         const __mmask64 valid = (chunk >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << chunk) - 1);
         __mmask64 todo = _mm512_mask_cmpgt_epu8_mask(valid, _mm512_maskz_loadu_epi8(valid, gclis + group), gtli_vec);
         while (todo) {
-            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t k = svt_first_set_bit(todo);
             const uint32_t size = (uint32_t)gclis[group + k] - gtli;
             /* A corrupt stream can carry a GCLI above the truncation maximum:
              * the unary code yields up to thirty-one. Such a group holds more
@@ -122,7 +122,7 @@ void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t*
         const __mmask64 valid = (chunk >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << chunk) - 1);
         __mmask64 todo = _mm512_mask_cmpgt_epu8_mask(valid, _mm512_maskz_loadu_epi8(valid, gclis + group), gtli_vec);
         while (todo) {
-            const uint32_t k = unpack_first_set_bit(todo);
+            const uint32_t k = svt_first_set_bit(todo);
             const uint32_t size = (uint32_t)gclis[group + k] - gtli;
             /* A corrupt stream can carry a GCLI above the truncation maximum:
              * the unary code yields up to thirty-one. Such a group holds more

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -41,7 +41,7 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
                             uint32_t total_nibbles) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     /* Fast path. A group's address comes from adding up lengths rather than
@@ -49,7 +49,7 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
      * chain of single-cycle additions while the loads and the parsing itself
      * proceed in parallel. */
     for (; group < n_groups; group++) {
-        if ((nib >> 1) > byte_limit) {
+        if ((nib >> 1) >= fast_bytes) {
             break;
         }
         uint64_t out = 0;
@@ -94,11 +94,11 @@ void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t*
                                    uint32_t total_nibbles) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
-    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    const uint32_t fast_bytes = unpack_fast_byte_count(nib, total_nibbles);
     uint32_t group = 0;
 
     for (; group < n_groups; group++) {
-        if ((nib >> 1) > byte_limit) {
+        if ((nib >> 1) >= fast_bytes) {
             break;
         }
         uint64_t out = 0;

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -8,6 +8,7 @@
 #include "UnPack_avx512.h"
 #include "UnPack_avx2.h"
 #include "Definitions.h"
+#include "EncDec.h" /* TRUNCATION_MAX: the single load holds fifteen planes at most */
 
 /* Parsing a group is the inverse of packing it: every nibble of a bit plane
  * carries one bit of all four coefficients, most significant plane first.
@@ -48,43 +49,145 @@ static const uint64_t unpack_sign_spread[16] = {
     0x8000800080008000ULL,
 };
 
-/* Returns the four coefficients of a group packed into a 64-bit word, sixteen
- * bits per coefficient, already shifted by gtli. */
-static INLINE uint64_t unpack_group_magnitudes_avx512(reader_short_t* r, int32_t size, uint8_t gtli) {
-    uint64_t acc = 0;
-    for (int32_t i = 0; i < size; i++) {
-        acc = (acc << 4) | read_4_bits_align4_fast(r);
-    }
+#if defined(_MSC_VER)
+#define UNPACK_BSWAP64(x) _byteswap_uint64(x)
+#else
+#define UNPACK_BSWAP64(x) __builtin_bswap64(x)
+#endif
+
+/* Reads count nibbles starting at nibble number nib and returns them right
+ * aligned: nibble nib becomes the most significant of the count.
+ *
+ * The point is that the whole group is taken with a single eight-byte load
+ * instead of a chain of per-nibble accesses. Bytes in the stream are stored
+ * high nibble first, so the word is reversed with BSWAP. The shift inside a
+ * byte is at most one nibble and count is at most fifteen, so 4 + 60 = 64 bits
+ * fit exactly into one word.
+ *
+ * The load reads up to eight bytes ahead, so it may only be called where that
+ * many bytes are known to follow the start of the group; the end of the line
+ * goes through the sequential path. */
+static INLINE uint64_t unpack_load_nibbles(const uint8_t* mem, uint32_t nib, uint32_t count) {
+    uint64_t w;
+    memcpy(&w, mem + (nib >> 1), sizeof(w));
+    w = UNPACK_BSWAP64(w);
+    w <<= (nib & 1) * 4;
+    return w >> (64 - 4 * count);
+}
+
+static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
+    return (uint32_t)((mem[nib >> 1] >> (4 - (nib & 1) * 4)) & 0xF);
+}
+
+/* Spreads count nibbles, right aligned, into four coefficients. */
+static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
     const uint64_t v0 = _pext_u64(acc, 0x8888888888888888ULL);
     const uint64_t v1 = _pext_u64(acc, 0x4444444444444444ULL);
     const uint64_t v2 = _pext_u64(acc, 0x2222222222222222ULL);
     const uint64_t v3 = _pext_u64(acc, 0x1111111111111111ULL);
-    /* After the shift a coefficient occupies at most gcli <= 15 bits, so a
-     * common shift of the packed word never carries bits into a neighbouring
-     * lane. */
     return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
 }
 
-void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
-    for (uint32_t group = 0; group < n_groups; group++) {
+/* How many groups may be taken by the fast path: for the last groups of a line
+ * an over-reading load would run past the data. */
+static INLINE uint32_t unpack_fast_byte_limit(uint32_t nib0, uint32_t total_nibbles) {
+    const uint32_t last_byte = (nib0 + total_nibbles + 1) >> 1;
+    return last_byte >= 8 ? last_byte - 8 : 0;
+}
+
+void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                            uint32_t total_nibbles) {
+    uint8_t* const base = r->mem;
+    uint32_t nib = r->bits_used ? 1u : 0u;
+    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    uint32_t group = 0;
+
+    /* Fast path. A group's address comes from adding up lengths rather than
+     * from reading the previous group, so the dependency between groups is a
+     * chain of single-cycle additions while the loads and the parsing itself
+     * proceed in parallel. */
+    for (; group < n_groups; group++) {
+        if ((nib >> 1) > byte_limit) {
+            break;
+        }
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        /* A corrupt stream can carry a GCLI above the truncation maximum: the
+         * unary code yields up to thirty-one. Such a group holds more bit
+         * planes than the single load can take, so it is left to the sequential
+         * reader below. */
+        if (size > TRUNCATION_MAX) {
+            break;
+        }
+        if (size > 0) {
+            const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
+            out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib + 1, (uint32_t)size), gtli) | signs;
+            nib += (uint32_t)size + 1;
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+
+    r->mem = base + (nib >> 1);
+    r->bits_used = (uint8_t)((nib & 1) * 4);
+
+    /* End of the line is read sequentially, without reading past the data. */
+    for (; group < n_groups; group++) {
         uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
-            /* Signs precede the group data in the stream. */
             const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
-            out = unpack_group_magnitudes_avx512(r, size, gtli) | signs;
+            uint64_t acc = 0;
+            for (int32_t i = 0; i < size; i++) {
+                acc = (acc << 4) | read_4_bits_align4_fast(r);
+            }
+            out = unpack_planes_to_lanes(acc, gtli) | signs;
         }
         memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;
     }
 }
 
-void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
-    for (uint32_t group = 0; group < n_groups; group++) {
+void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                                   uint32_t total_nibbles) {
+    uint8_t* const base = r->mem;
+    uint32_t nib = r->bits_used ? 1u : 0u;
+    const uint32_t byte_limit = unpack_fast_byte_limit(nib, total_nibbles);
+    uint32_t group = 0;
+
+    for (; group < n_groups; group++) {
+        if ((nib >> 1) > byte_limit) {
+            break;
+        }
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        /* A corrupt stream can carry a GCLI above the truncation maximum: the
+         * unary code yields up to thirty-one. Such a group holds more bit
+         * planes than the single load can take, so it is left to the sequential
+         * reader below. */
+        if (size > TRUNCATION_MAX) {
+            break;
+        }
+        if (size > 0) {
+            out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib, (uint32_t)size), gtli);
+            nib += (uint32_t)size;
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+
+    r->mem = base + (nib >> 1);
+    r->bits_used = (uint8_t)((nib & 1) * 4);
+
+    for (; group < n_groups; group++) {
         uint64_t out = 0;
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
-            out = unpack_group_magnitudes_avx512(r, size, gtli);
+            uint64_t acc = 0;
+            for (int32_t i = 0; i < size; i++) {
+                acc = (acc << 4) | read_4_bits_align4_fast(r);
+            }
+            out = unpack_planes_to_lanes(acc, gtli);
         }
         memcpy(buf, &out, sizeof(out));
         buf += GROUP_SIZE;

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -7,6 +7,7 @@
 #include <immintrin.h>
 #include "UnPack_avx512.h"
 #include "unpack_common.h"
+#include "unpack_common_avx512.h"
 #include "Definitions.h"
 #include "EncDec.h" /* TRUNCATION_MAX: the single load holds fifteen planes at most */
 #include "SvtUtility.h"
@@ -28,15 +29,6 @@
  * PEXT is used here without hesitation: it is microcoded and slow only on Zen 1
  * and Zen 2, and this function is only reached when AVX-512 is present, that is
  * on Skylake-X and newer or Zen 4 and newer, where PEXT is a single uop. */
-
-/* Spreads count nibbles, right aligned, into four coefficients. */
-static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
-    const uint64_t v0 = _pext_u64(acc, 0x8888888888888888ULL);
-    const uint64_t v1 = _pext_u64(acc, 0x4444444444444444ULL);
-    const uint64_t v2 = _pext_u64(acc, 0x2222222222222222ULL);
-    const uint64_t v3 = _pext_u64(acc, 0x1111111111111111ULL);
-    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
-}
 
 void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
                             uint32_t safe_bytes) {

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <immintrin.h>
 #include "UnPack_avx512.h"
-#include "UnPack_avx2.h"
+#include "unpack_common.h"
 #include "Definitions.h"
 #include "EncDec.h" /* TRUNCATION_MAX: the single load holds fifteen planes at most */
 
@@ -28,57 +28,6 @@
  * and Zen 2, and this function is only reached when AVX-512 is present, that is
  * on Skylake-X and newer or Zen 4 and newer, where PEXT is a single uop. */
 
-/* Sign nibble: its bit (3 - i) belongs to coefficient i and has to become the
- * top bit of the i-th 16-bit word. The table replaces four shifts. */
-static const uint64_t unpack_sign_spread[16] = {
-    0x0000000000000000ULL,
-    0x8000000000000000ULL,
-    0x0000800000000000ULL,
-    0x8000800000000000ULL,
-    0x0000000080000000ULL,
-    0x8000000080000000ULL,
-    0x0000800080000000ULL,
-    0x8000800080000000ULL,
-    0x0000000000008000ULL,
-    0x8000000000008000ULL,
-    0x0000800000008000ULL,
-    0x8000800000008000ULL,
-    0x0000000080008000ULL,
-    0x8000000080008000ULL,
-    0x0000800080008000ULL,
-    0x8000800080008000ULL,
-};
-
-#if defined(_MSC_VER)
-#define UNPACK_BSWAP64(x) _byteswap_uint64(x)
-#else
-#define UNPACK_BSWAP64(x) __builtin_bswap64(x)
-#endif
-
-/* Reads count nibbles starting at nibble number nib and returns them right
- * aligned: nibble nib becomes the most significant of the count.
- *
- * The point is that the whole group is taken with a single eight-byte load
- * instead of a chain of per-nibble accesses. Bytes in the stream are stored
- * high nibble first, so the word is reversed with BSWAP. The shift inside a
- * byte is at most one nibble and count is at most fifteen, so 4 + 60 = 64 bits
- * fit exactly into one word.
- *
- * The load reads up to eight bytes ahead, so it may only be called where that
- * many bytes are known to follow the start of the group; the end of the line
- * goes through the sequential path. */
-static INLINE uint64_t unpack_load_nibbles(const uint8_t* mem, uint32_t nib, uint32_t count) {
-    uint64_t w;
-    memcpy(&w, mem + (nib >> 1), sizeof(w));
-    w = UNPACK_BSWAP64(w);
-    w <<= (nib & 1) * 4;
-    return w >> (64 - 4 * count);
-}
-
-static INLINE uint32_t unpack_one_nibble(const uint8_t* mem, uint32_t nib) {
-    return (uint32_t)((mem[nib >> 1] >> (4 - (nib & 1) * 4)) & 0xF);
-}
-
 /* Spreads count nibbles, right aligned, into four coefficients. */
 static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
     const uint64_t v0 = _pext_u64(acc, 0x8888888888888888ULL);
@@ -86,13 +35,6 @@ static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
     const uint64_t v2 = _pext_u64(acc, 0x2222222222222222ULL);
     const uint64_t v3 = _pext_u64(acc, 0x1111111111111111ULL);
     return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
-}
-
-/* How many groups may be taken by the fast path: for the last groups of a line
- * an over-reading load would run past the data. */
-static INLINE uint32_t unpack_fast_byte_limit(uint32_t nib0, uint32_t total_nibbles) {
-    const uint32_t last_byte = (nib0 + total_nibbles + 1) >> 1;
-    return last_byte >= 8 ? last_byte - 8 : 0;
 }
 
 void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -1,0 +1,108 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <string.h>
+#include <immintrin.h>
+#include "UnPack_avx512.h"
+#include "UnPack_avx2.h"
+#include "Definitions.h"
+
+/* Parsing a group is the inverse of packing it: every nibble of a bit plane
+ * carries one bit of all four coefficients, most significant plane first.
+ *
+ * The former parser handled one plane per pass: the nibble was broadcast across
+ * the vector lanes (VPBROADCASTD out of a general purpose register), spread
+ * over the bits by a mask and merged into an accumulator with a shift. That
+ * gave a long dependent chain per group, and the broadcast out of a general
+ * purpose register is an expensive operation in itself.
+ *
+ * Here the nibbles are first collected in an ordinary 64-bit word: there are at
+ * most fifteen planes, that is sixty bits, so everything fits. Splitting them
+ * into four coefficients is then one instruction per coefficient - PEXT gathers
+ * the bits selected by a mask into the low positions.
+ *
+ * PEXT is used here without hesitation: it is microcoded and slow only on Zen 1
+ * and Zen 2, and this function is only reached when AVX-512 is present, that is
+ * on Skylake-X and newer or Zen 4 and newer, where PEXT is a single uop. */
+
+/* Sign nibble: its bit (3 - i) belongs to coefficient i and has to become the
+ * top bit of the i-th 16-bit word. The table replaces four shifts. */
+static const uint64_t unpack_sign_spread[16] = {
+    0x0000000000000000ULL,
+    0x8000000000000000ULL,
+    0x0000800000000000ULL,
+    0x8000800000000000ULL,
+    0x0000000080000000ULL,
+    0x8000000080000000ULL,
+    0x0000800080000000ULL,
+    0x8000800080000000ULL,
+    0x0000000000008000ULL,
+    0x8000000000008000ULL,
+    0x0000800000008000ULL,
+    0x8000800000008000ULL,
+    0x0000000080008000ULL,
+    0x8000000080008000ULL,
+    0x0000800080008000ULL,
+    0x8000800080008000ULL,
+};
+
+/* Returns the four coefficients of a group packed into a 64-bit word, sixteen
+ * bits per coefficient, already shifted by gtli. */
+static INLINE uint64_t unpack_group_magnitudes_avx512(reader_short_t* r, int32_t size, uint8_t gtli) {
+    uint64_t acc = 0;
+    for (int32_t i = 0; i < size; i++) {
+        acc = (acc << 4) | read_4_bits_align4_fast(r);
+    }
+    const uint64_t v0 = _pext_u64(acc, 0x8888888888888888ULL);
+    const uint64_t v1 = _pext_u64(acc, 0x4444444444444444ULL);
+    const uint64_t v2 = _pext_u64(acc, 0x2222222222222222ULL);
+    const uint64_t v3 = _pext_u64(acc, 0x1111111111111111ULL);
+    /* After the shift a coefficient occupies at most gcli <= 15 bits, so a
+     * common shift of the packed word never carries bits into a neighbouring
+     * lane. */
+    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
+}
+
+void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
+    for (uint32_t group = 0; group < n_groups; group++) {
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        if (size > 0) {
+            /* Signs precede the group data in the stream. */
+            const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            out = unpack_group_magnitudes_avx512(r, size, gtli) | signs;
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+}
+
+void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups) {
+    for (uint32_t group = 0; group < n_groups; group++) {
+        uint64_t out = 0;
+        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
+        if (size > 0) {
+            out = unpack_group_magnitudes_avx512(r, size, gtli);
+        }
+        memcpy(buf, &out, sizeof(out));
+        buf += GROUP_SIZE;
+    }
+}
+
+SvtJxsErrorType_t unpack_data_avx512(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
+                                     uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
+                                     int32_t* precinct_bits_left) {
+    return unpack_data_common(bitstream,
+                              buf,
+                              w,
+                              gclis,
+                              group_size,
+                              gtli,
+                              sign_flag,
+                              leftover_signs_num,
+                              precinct_bits_left,
+                              unpack_n_groups_avx512,
+                              unpack_n_groups_nosign_avx512);
+}

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -30,8 +30,11 @@
  * and Zen 2, and this function is only reached when AVX-512 is present, that is
  * on Skylake-X and newer or Zen 4 and newer, where PEXT is a single uop. */
 
-void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
-                            uint32_t safe_bytes) {
+/* Shared walk for unpack_n_groups_avx512/unpack_n_groups_nosign_avx512: same
+ * merge as unpack_n_groups_impl in UnPack_avx2.c, for the same reason - see
+ * that file's comment. */
+static INLINE void unpack_n_groups_avx512_impl(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf,
+                                               uint32_t n_groups, uint32_t safe_bytes, const int has_sign) {
     uint8_t* const base = r->mem;
     uint32_t nib = r->bits_used ? 1u : 0u;
     uint32_t group = 0;
@@ -60,14 +63,16 @@ void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uin
              * bit planes than the single load can take - fifteen - and the
              * shift that would extract it would be undefined, so the group is
              * left to the sequential reader below. */
-            if (size > TRUNCATION_MAX || ((nib + 1) >> 1) >= safe_bytes) {
+            if (size > TRUNCATION_MAX || ((nib + (uint32_t)has_sign) >> 1) >= safe_bytes) {
                 group += k;
                 goto tail;
             }
-            const uint64_t signs = unpack_sign_spread[unpack_one_nibble(base, nib)];
-            const uint64_t out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib + 1, size), gtli) | signs;
+            uint64_t out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib + (uint32_t)has_sign, size), gtli);
+            if (has_sign) {
+                out |= unpack_sign_spread[unpack_one_nibble(base, nib)];
+            }
             memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
-            nib += size + 1;
+            nib += size + (uint32_t)has_sign;
             todo &= todo - 1;
         }
         group += chunk;
@@ -83,7 +88,10 @@ tail:
     for (; group < n_groups; group++) {
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
-            const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            uint64_t signs = 0;
+            if (has_sign) {
+                signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            }
             /* A corrupt stream can carry a GCLI far above the truncation maximum: the
              * unary code yields up to thirty-one, and vertical prediction can wrap it
              * to anything up to two hundred and fifty-five. The fast path above
@@ -102,68 +110,14 @@ tail:
     }
 }
 
+void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                            uint32_t safe_bytes) {
+    unpack_n_groups_avx512_impl(gclis, gtli, r, buf, n_groups, safe_bytes, 1);
+}
+
 void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
                                    uint32_t safe_bytes) {
-    uint8_t* const base = r->mem;
-    uint32_t nib = r->bits_used ? 1u : 0u;
-    uint32_t group = 0;
-
-    /* The vast majority of groups are empty: about eighty-seven per cent on
-     * 1080p at 4 bits per pixel. Each of them used to cost a GCLI load, a
-     * compare, a poorly predicted branch and a store of eight zeroes. Now the
-     * output is zeroed in one pass and the walk follows the bits of a non-empty
-     * mask, so an empty group costs nothing and the per-group branch is gone. */
-    memset(buf, 0, (size_t)n_groups * GROUP_SIZE * sizeof(uint16_t));
-
-    const __m512i gtli_vec = _mm512_set1_epi8((char)gtli);
-    while (group < n_groups) {
-        const uint32_t chunk = MIN(n_groups - group, 64u);
-        const __mmask64 valid = (chunk >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << chunk) - 1);
-        __mmask64 todo = _mm512_mask_cmpgt_epu8_mask(valid, _mm512_maskz_loadu_epi8(valid, gclis + group), gtli_vec);
-        while (todo) {
-            const uint32_t k = svt_first_set_bit(todo);
-            const uint32_t size = (uint32_t)gclis[group + k] - gtli;
-            /* A corrupt stream can carry a GCLI above the truncation maximum:
-             * the unary code yields up to thirty-one. Such a group holds more
-             * bit planes than the single load can take - fifteen - and the
-             * shift that would extract it would be undefined, so the group is
-             * left to the sequential reader below. */
-            if (size > TRUNCATION_MAX || (nib >> 1) >= safe_bytes) {
-                group += k;
-                goto tail;
-            }
-            const uint64_t out = unpack_planes_to_lanes(unpack_load_nibbles(base, nib, size), gtli);
-            memcpy(buf + (size_t)(group + k) * GROUP_SIZE, &out, sizeof(out));
-            nib += size;
-            todo &= todo - 1;
-        }
-        group += chunk;
-    }
-
-tail:
-    r->mem = base + (nib >> 1);
-    r->bits_used = (uint8_t)((nib & 1) * 4);
-    buf += (size_t)group * GROUP_SIZE;
-
-    for (; group < n_groups; group++) {
-        const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
-        if (size > 0) {
-            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
-             * unary code yields up to thirty-one, and vertical prediction can wrap it
-             * to anything up to two hundred and fifty-five. The fast path above
-             * already declines to touch such a group at all; this sequential reader
-             * has to decline the same way, or it reads size nibbles - unbounded by
-             * anything - straight past the end of whatever buffer backs it. */
-            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
-            uint64_t acc = 0;
-            for (int32_t i = 0; i < read_planes; i++) {
-                acc = (acc << 4) | read_4_bits_align4_fast(r);
-            }
-            const uint64_t out = unpack_planes_to_lanes(acc, gtli);
-            memcpy(buf, &out, sizeof(out));
-        }
-        buf += GROUP_SIZE;
-    }
+    unpack_n_groups_avx512_impl(gclis, gtli, r, buf, n_groups, safe_bytes, 0);
 }
 
 SvtJxsErrorType_t unpack_data_avx512(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.c
@@ -84,8 +84,15 @@ tail:
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
             const uint64_t signs = unpack_sign_spread[read_4_bits_align4_fast(r)];
+            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
+             * unary code yields up to thirty-one, and vertical prediction can wrap it
+             * to anything up to two hundred and fifty-five. The fast path above
+             * already declines to touch such a group at all; this sequential reader
+             * has to decline the same way, or it reads size nibbles - unbounded by
+             * anything - straight past the end of whatever buffer backs it. */
+            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
             uint64_t acc = 0;
-            for (int32_t i = 0; i < size; i++) {
+            for (int32_t i = 0; i < read_planes; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
             const uint64_t out = unpack_planes_to_lanes(acc, gtli) | signs;
@@ -141,8 +148,15 @@ tail:
     for (; group < n_groups; group++) {
         const int32_t size = (int32_t)gclis[group] - (int32_t)gtli;
         if (size > 0) {
+            /* A corrupt stream can carry a GCLI far above the truncation maximum: the
+             * unary code yields up to thirty-one, and vertical prediction can wrap it
+             * to anything up to two hundred and fifty-five. The fast path above
+             * already declines to touch such a group at all; this sequential reader
+             * has to decline the same way, or it reads size nibbles - unbounded by
+             * anything - straight past the end of whatever buffer backs it. */
+            const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
             uint64_t acc = 0;
-            for (int32_t i = 0; i < size; i++) {
+            for (int32_t i = 0; i < read_planes; i++) {
                 acc = (acc << 4) | read_4_bits_align4_fast(r);
             }
             const uint64_t out = unpack_planes_to_lanes(acc, gtli);

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.h
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.h
@@ -8,10 +8,16 @@
 
 #include "SvtJpegxsDec.h"
 #include "BitstreamReader.h"
+#include "UnPack_avx2.h" /* reader_short_t, shared with the AVX2 parser */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void unpack_n_groups_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                            uint32_t safe_bytes);
+void unpack_n_groups_nosign_avx512(uint8_t* gclis, uint8_t gtli, reader_short_t* r, uint16_t* buf, uint32_t n_groups,
+                                   uint32_t safe_bytes);
 
 SvtJxsErrorType_t unpack_data_avx512(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
                                      uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,

--- a/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.h
+++ b/Source/Lib/Decoder/ASM_AVX512/UnPack_avx512.h
@@ -1,0 +1,24 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __UNPACK_AVX512_H__
+#define __UNPACK_AVX512_H__
+
+#include "SvtJpegxsDec.h"
+#include "BitstreamReader.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SvtJxsErrorType_t unpack_data_avx512(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
+                                     uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
+                                     int32_t* precinct_bits_left);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__UNPACK_AVX512_H__

--- a/Source/Lib/Decoder/ASM_AVX512/idwt-avx512.c
+++ b/Source/Lib/Decoder/ASM_AVX512/idwt-avx512.c
@@ -13,6 +13,7 @@ uint32_t loop_short_lf32_hf16(uint32_t len, const int32_t** lf_ptr, const int16_
                               uint8_t shift) {
     const uint32_t batch = (len - 2) / 8;
     const __m128i two = _mm_set1_epi32(2);
+    __m128i prev_vec = _mm_set1_epi32(*prev_even);
 
     for (uint32_t i = 0; i < batch; i++) {
         const __m128i lf_ = _mm_loadu_si128((__m128i*)(*lf_ptr + 1));
@@ -24,9 +25,7 @@ uint32_t loop_short_lf32_hf16(uint32_t len, const int32_t** lf_ptr, const int16_
         even = _mm_srai_epi32(even, 2);
         even = _mm_sub_epi32(lf_, even);
 
-        int32_t next_even = _mm_extract_epi32(even, 3);
-        __m128i even_m1 = _mm_bslli_si128(even, 4);
-        even_m1 = _mm_insert_epi32(even_m1, *prev_even, 0);
+        const __m128i even_m1 = _mm_alignr_epi8(even, prev_vec, 12);
 
         //out[0] + out[2]
         __m128i odd = _mm_add_epi32(even_m1, even);
@@ -39,12 +38,13 @@ uint32_t loop_short_lf32_hf16(uint32_t len, const int32_t** lf_ptr, const int16_
         _mm_storeu_si128((__m128i*)(*out_ptr + 0), unpack1);
         _mm_storeu_si128((__m128i*)(*out_ptr + 4), unpack2);
 
-        *prev_even = next_even;
+        prev_vec = even;
 
         *out_ptr += 8;
         *lf_ptr += 4;
         *hf_ptr += 4;
     }
+    *prev_even = _mm_extract_epi32(prev_vec, 3);
     return batch;
 }
 
@@ -55,8 +55,13 @@ void idwt_horizontal_line_lf32_hf16_avx512(const int32_t* lf_ptr, const int16_t*
     /* UBSan fix: use LSHIFT32 to avoid UB when left-shifting negative wavelet coefficients. */
     int32_t prev_even = lf_ptr[0] - (((LSHIFT32(hf_ptr[0], shift)) + 1) >> 1);
 
-    const __m512i permutevar_mask = _mm512_setr_epi32(
-        0x10, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e);
+    /* The carry of the last even sample into the next block stays in a vector.
+     * It used to travel through a general purpose register - extract from the
+     * vector, then broadcast back - four extra operations per iteration for a
+     * single value. valignd takes the element straight out of the previous
+     * iteration's vector, so the previous "even" itself serves as the carry. */
+    __m512i prev_vec = _mm512_set1_epi32(prev_even);
+
     const __m512i store1_perm = _mm512_setr_epi64(0x00, 0x01, 0x08, 0x09, 0x02, 0x03, 0x0a, 0x0b);
     const __m512i store2_perm = _mm512_setr_epi64(0x04, 0x05, 0x0c, 0x0d, 0x06, 0x07, 0x0e, 0x0f);
 
@@ -74,10 +79,7 @@ void idwt_horizontal_line_lf32_hf16_avx512(const int32_t* lf_ptr, const int16_t*
         even = _mm512_srai_epi32(even, 2);
         even = _mm512_sub_epi32(lf_avx2, even);
 
-        int32_t next_even = _mm_extract_epi32(_mm512_extracti32x4_epi32(even, 3), 3);
-
-        __m512i duplicate = _mm512_set1_epi32(prev_even);
-        __m512i even_m1 = _mm512_permutex2var_epi32(even, permutevar_mask, duplicate);
+        const __m512i even_m1 = _mm512_alignr_epi32(even, prev_vec, 15);
 
         //out[0] + out[2]
         __m512i odd = _mm512_add_epi32(even_m1, even);
@@ -93,12 +95,14 @@ void idwt_horizontal_line_lf32_hf16_avx512(const int32_t* lf_ptr, const int16_t*
         _mm512_storeu_si512(out_ptr, store1);
         _mm512_storeu_si512(out_ptr + 16, store2);
 
-        prev_even = next_even;
+        prev_vec = even;
 
         out_ptr += 32;
         lf_ptr += 16;
         hf_ptr += 16;
     }
+
+    prev_even = _mm_extract_epi32(_mm512_extracti32x4_epi32(prev_vec, 3), 3);
 
     uint32_t leftover = len - simd_batch_512 * 32;
     if (leftover > 8) {
@@ -127,6 +131,7 @@ uint32_t loop_short_lf16_hf16(uint32_t len, const int16_t** lf_ptr, const int16_
                               uint8_t shift) {
     const uint32_t batch = (len - 2) / 8;
     const __m128i two = _mm_set1_epi32(2);
+    __m128i prev_vec = _mm_set1_epi32(*prev_even);
 
     for (uint32_t i = 0; i < batch; i++) {
         const __m128i lf_ = _mm_slli_epi32(_mm_cvtepi16_epi32(_mm_loadl_epi64((__m128i*)(*lf_ptr + 1))), shift);
@@ -138,9 +143,7 @@ uint32_t loop_short_lf16_hf16(uint32_t len, const int16_t** lf_ptr, const int16_
         even = _mm_srai_epi32(even, 2);
         even = _mm_sub_epi32(lf_, even);
 
-        int32_t next_even = _mm_extract_epi32(even, 3);
-        __m128i even_m1 = _mm_bslli_si128(even, 4);
-        even_m1 = _mm_insert_epi32(even_m1, *prev_even, 0);
+        const __m128i even_m1 = _mm_alignr_epi8(even, prev_vec, 12);
 
         //out[0] + out[2]
         __m128i odd = _mm_add_epi32(even_m1, even);
@@ -153,12 +156,13 @@ uint32_t loop_short_lf16_hf16(uint32_t len, const int16_t** lf_ptr, const int16_
         _mm_storeu_si128((__m128i*)(*out_ptr + 0), unpack1);
         _mm_storeu_si128((__m128i*)(*out_ptr + 4), unpack2);
 
-        *prev_even = next_even;
+        prev_vec = even;
 
         *out_ptr += 8;
         *lf_ptr += 4;
         *hf_ptr += 4;
     }
+    *prev_even = _mm_extract_epi32(prev_vec, 3);
     return batch;
 }
 
@@ -169,8 +173,13 @@ void idwt_horizontal_line_lf16_hf16_avx512(const int16_t* lf_ptr, const int16_t*
     /* UBSan fix: use LSHIFT32 to avoid UB when left-shifting negative wavelet coefficients. */
     int32_t prev_even = LSHIFT32(lf_ptr[0], shift) - (((LSHIFT32(hf_ptr[0], shift)) + 1) >> 1);
 
-    const __m512i permutevar_mask = _mm512_setr_epi32(
-        0x10, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e);
+    /* The carry of the last even sample into the next block stays in a vector.
+     * It used to travel through a general purpose register - extract from the
+     * vector, then broadcast back - four extra operations per iteration for a
+     * single value. valignd takes the element straight out of the previous
+     * iteration's vector, so the previous "even" itself serves as the carry. */
+    __m512i prev_vec = _mm512_set1_epi32(prev_even);
+
     const __m512i store1_perm = _mm512_setr_epi64(0x00, 0x01, 0x08, 0x09, 0x02, 0x03, 0x0a, 0x0b);
     const __m512i store2_perm = _mm512_setr_epi64(0x04, 0x05, 0x0c, 0x0d, 0x06, 0x07, 0x0e, 0x0f);
 
@@ -188,10 +197,7 @@ void idwt_horizontal_line_lf16_hf16_avx512(const int16_t* lf_ptr, const int16_t*
         even = _mm512_srai_epi32(even, 2);
         even = _mm512_sub_epi32(lf_avx2, even);
 
-        int32_t next_even = _mm_extract_epi32(_mm512_extracti32x4_epi32(even, 3), 3);
-
-        __m512i duplicate = _mm512_set1_epi32(prev_even);
-        __m512i even_m1 = _mm512_permutex2var_epi32(even, permutevar_mask, duplicate);
+        const __m512i even_m1 = _mm512_alignr_epi32(even, prev_vec, 15);
 
         //out[0] + out[2]
         __m512i odd = _mm512_add_epi32(even_m1, even);
@@ -207,12 +213,14 @@ void idwt_horizontal_line_lf16_hf16_avx512(const int16_t* lf_ptr, const int16_t*
         _mm512_storeu_si512(out_ptr, store1);
         _mm512_storeu_si512(out_ptr + 16, store2);
 
-        prev_even = next_even;
+        prev_vec = even;
 
         out_ptr += 32;
         lf_ptr += 16;
         hf_ptr += 16;
     }
+
+    prev_even = _mm_extract_epi32(_mm512_extracti32x4_epi32(prev_vec, 3), 3);
 
     uint32_t leftover = len - simd_batch_512 * 32;
     if (leftover > 8) {

--- a/Source/Lib/Decoder/ASM_AVX512/unpack_common_avx512.h
+++ b/Source/Lib/Decoder/ASM_AVX512/unpack_common_avx512.h
@@ -1,0 +1,21 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __UNPACK_COMMON_AVX512_H__
+#define __UNPACK_COMMON_AVX512_H__
+
+#include <immintrin.h>
+#include "Definitions.h"
+
+/* Spreads count nibbles, right aligned, into four coefficients. */
+static INLINE uint64_t unpack_planes_to_lanes(uint64_t acc, uint8_t gtli) {
+    const uint64_t v0 = _pext_u64(acc, 0x8888888888888888ULL);
+    const uint64_t v1 = _pext_u64(acc, 0x4444444444444444ULL);
+    const uint64_t v2 = _pext_u64(acc, 0x2222222222222222ULL);
+    const uint64_t v3 = _pext_u64(acc, 0x1111111111111111ULL);
+    return (v0 | (v1 << 16) | (v2 << 32) | (v3 << 48)) << gtli;
+}
+
+#endif /*__UNPACK_COMMON_AVX512_H__*/

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -39,6 +39,22 @@ static INLINE uint32_t vlc_reader_end(vlc_reader_t* vlc_reader, bitstream_reader
     return vlc_reader->bits_used;
 }
 
+/* The length of a unary code is the number of leading zeroes plus one.
+ *
+ * This used to call svt_log2_32, which is dispatched: every decoded symbol paid
+ * for an indirect call to reach a single bit-scan instruction. There are
+ * hundreds of symbols per line, and the call costs more than the work. */
+static INLINE int8_t vlc_leading_run(uint32_t v) {
+    assert(v != 0);
+#if defined(_MSC_VER)
+    unsigned long idx;
+    _BitScanReverse(&idx, v);
+    return (int8_t)(32 - idx);
+#else
+    return (int8_t)(1 + __builtin_clz(v));
+#endif
+}
+
 static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
     if (!(vlc_reader->register64 >> 32)) { //Because can not be more than 32 bits for test
         if (vlc_reader->register_bits <= 32) {
@@ -108,7 +124,7 @@ static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
         }
     }
 
-    int8_t res = 32 - svt_log2_32(vlc_reader->register64 >> 32); //Possible values: 1-32
+    int8_t res = vlc_leading_run((uint32_t)(vlc_reader->register64 >> 32)); //Possible values: 1-32
     vlc_reader->register_bits -= res;
     vlc_reader->bits_used += res;
     vlc_reader->register64 <<= res;

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -10,6 +10,13 @@
 #include "Codestream.h"
 #include "decoder_dsp_rtcd.h"
 #include "SvtLog.h"
+#include <string.h>
+
+#if defined(_MSC_VER)
+#define VLC_BSWAP64(x) _byteswap_uint64(x)
+#else
+#define VLC_BSWAP64(x) __builtin_bswap64(x)
+#endif
 
 typedef struct vlc_reader {
     uint8_t const* mem;
@@ -58,7 +65,25 @@ static INLINE int8_t vlc_leading_run(uint32_t v) {
 static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
     if (!(vlc_reader->register64 >> 32)) { //Because can not be more than 32 bits for test
         if (vlc_reader->register_bits <= 32) {
-            if (vlc_reader->bits_to_use >= vlc_reader->bits_used + 64) {
+            /* One 64-bit load instead of "32 bits, then a loop of 16-bit top-ups".
+             * The bytes of a code run from most to least significant, so the word is
+             * reversed with bswap rather than assembled from bytes by shifts. The
+             * condition is stricter than the former one by exactly register_bits:
+             * eight bytes are read only when they are certainly there, and the end
+             * of the stream keeps the previous careful path. */
+            if (vlc_reader->bits_to_use >= vlc_reader->bits_used + vlc_reader->register_bits + 64) {
+                uint64_t word;
+                memcpy(&word, vlc_reader->mem, sizeof(word));
+                word = ~VLC_BSWAP64(word);
+                /* Only whole bytes are appended: the positions below register_bits must
+                 * stay zero, otherwise the next refill would land on top of them. */
+                const uint32_t add = (64 - vlc_reader->register_bits) & ~7u;
+                const uint64_t keep = (add == 64) ? word : ((word >> (64 - add)) << (64 - add));
+                vlc_reader->register64 |= keep >> vlc_reader->register_bits;
+                vlc_reader->mem += add >> 3;
+                vlc_reader->register_bits += add;
+            }
+            else if (vlc_reader->bits_to_use >= vlc_reader->bits_used + 64) {
                 //Load 32
                 vlc_reader->register64 |= ((uint64_t)((uint32_t)~(
                                               (((uint32_t)vlc_reader->mem[0]) << 24) | (((uint32_t)vlc_reader->mem[1]) << 16) |

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -46,22 +46,6 @@ static INLINE uint32_t vlc_reader_end(vlc_reader_t* vlc_reader, bitstream_reader
     return vlc_reader->bits_used;
 }
 
-/* The length of a unary code is the number of leading zeroes plus one.
- *
- * This used to call svt_log2_32, which is dispatched: every decoded symbol paid
- * for an indirect call to reach a single bit-scan instruction. There are
- * hundreds of symbols per line, and the call costs more than the work. */
-static INLINE int8_t vlc_leading_run(uint32_t v) {
-    assert(v != 0);
-#if defined(_MSC_VER)
-    unsigned long idx;
-    _BitScanReverse(&idx, v);
-    return (int8_t)(32 - idx);
-#else
-    return (int8_t)(1 + __builtin_clz(v));
-#endif
-}
-
 static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
     if (!(vlc_reader->register64 >> 32)) { //Because can not be more than 32 bits for test
         if (vlc_reader->register_bits <= 32) {

--- a/Source/Lib/Decoder/Codec/Packing.c
+++ b/Source/Lib/Decoder/Codec/Packing.c
@@ -143,7 +143,14 @@ static INLINE int8_t vlc_reader_get_next_value(vlc_reader_t* vlc_reader) {
 static void unpack_data_single_group(bitstream_reader_t* bitstream, uint16_t* buf, int32_t size, int8_t gtli) {
     uint8_t val;
     uint32_t tmp_buf[4] = {0};
-    for (int32_t bits = 0; bits < (size - 1); bits++) {
+    /* A corrupt stream can carry a GCLI far above the truncation maximum: the caller's
+     * budget check only verifies that the declared cost fits the remaining bits, not that
+     * a single group's plane count is sane, so size can arrive here as large as 254. The
+     * AVX2 and AVX512 sequential readers cap their equivalent read at TRUNCATION_MAX for
+     * exactly this reason (see UnPack_avx2.c/UnPack_avx512.c); this scalar path needs the
+     * same bound, or it reads far past the plane count any real group can have. */
+    const int32_t read_planes = (size > TRUNCATION_MAX) ? TRUNCATION_MAX : size;
+    for (int32_t bits = 0; bits < (read_planes - 1); bits++) {
         val = read_4_bits_align4(bitstream);
         tmp_buf[3] = (tmp_buf[3] | (val & 1)) << 1;
         tmp_buf[2] = (tmp_buf[2] | (val & 2)) << 1;

--- a/Source/Lib/Decoder/Codec/Packing.h
+++ b/Source/Lib/Decoder/Codec/Packing.h
@@ -13,6 +13,22 @@
 extern "C" {
 #endif
 
+/* The length of a unary code is the number of leading zeroes plus one.
+ *
+ * This used to call svt_log2_32, which is dispatched: every decoded symbol paid
+ * for an indirect call to reach a single bit-scan instruction. There are
+ * hundreds of symbols per line, and the call costs more than the work. */
+static INLINE int8_t vlc_leading_run(uint32_t v) {
+    assert(v != 0);
+#if defined(_MSC_VER)
+    unsigned long idx;
+    _BitScanReverse(&idx, v);
+    return (int8_t)(32 - idx);
+#else
+    return (int8_t)(1 + __builtin_clz(v));
+#endif
+}
+
 SvtJxsErrorType_t unpack_precinct(bitstream_reader_t* bitstream, precinct_t* prec, precinct_t* prec_top, const pi_t* pi,
                                   const picture_header_dynamic_t* picture_header_dynamic, uint32_t verbose);
 SvtJxsErrorType_t unpack_data_c(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis, uint32_t group_size,

--- a/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
+++ b/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
@@ -13,6 +13,7 @@
 #include "NltDec_AVX2.h"
 #include "Precinct.h"
 #include "UnPack_avx2.h"
+#include "UnPack_avx512.h"
 #include "Packing.h"
 #include "idwt-avx512.h"
 #include "NltDec_avx512.h"
@@ -85,6 +86,13 @@ void setup_decoder_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
       but for safe limiting cpu flags again. */
     flags &= get_cpu_flags();
+    /* The AVX-512 kernels are built with -mbmi2 for the whole directory, so
+     * the compiler is free to emit those instructions anywhere in them, not
+     * only where an intrinsic asks for them. Without a processor to back
+     * them the whole tier has to stay unused. */
+    if (!(flags & CPU_FLAGS_BMI2)) {
+        flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX512F;
+    }
     // to use C: flags=0
 #else
     (void)flags;
@@ -107,7 +115,7 @@ void setup_decoder_rtcd_internal(CPU_FLAGS flags) {
                     linear_output_scaling_16bit_line_msb_avx512);
 
     SET_AVX2(inv_sign, inv_sign_c, inv_sign_avx2);
-    SET_AVX2(unpack_data, unpack_data_c, unpack_data_avx2);
+    SET_AVX2_AVX512(unpack_data, unpack_data_c, unpack_data_avx2, unpack_data_avx512);
     SET_AVX2_AVX512(idwt_horizontal_line_lf16_hf16,
                     idwt_horizontal_line_lf16_hf16_c,
                     idwt_horizontal_line_lf16_hf16_avx2,

--- a/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
+++ b/Source/Lib/Decoder/Codec/decoder_dsp_rtcd.c
@@ -85,12 +85,17 @@ void setup_decoder_rtcd_internal(CPU_FLAGS flags) {
 #ifdef ARCH_X86_64
     /** Should be done during library initialization,
       but for safe limiting cpu flags again. */
-    flags &= get_cpu_flags();
+    const CPU_FLAGS host_flags = get_cpu_flags();
+    flags &= host_flags;
     /* The AVX-512 kernels are built with -mbmi2 for the whole directory, so
      * the compiler is free to emit those instructions anywhere in them, not
      * only where an intrinsic asks for them. Without a processor to back
-     * them the whole tier has to stay unused. */
-    if (!(flags & CPU_FLAGS_BMI2)) {
+     * them the whole tier has to stay unused.
+     *
+     * The test is on the host, not on the caller's request: a caller built
+     * against an older header passes a mask with these bits clear, and it must
+     * not lose AVX-512 on hardware that supports it. */
+    if (!(host_flags & CPU_FLAGS_BMI2)) {
         flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX512F;
     }
     // to use C: flags=0

--- a/Source/Lib/Encoder/ASM_AVX2/CMakeLists.txt
+++ b/Source/Lib/Encoder/ASM_AVX2/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(
     )
 
 check_both_flags_add(-mavx2)
+check_both_flags_add(-mpopcnt)
 
 if(MSVC)
     check_both_flags_add(/arch:AVX2)

--- a/Source/Lib/Encoder/ASM_AVX2/Dwt_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/Dwt_AVX2.c
@@ -21,7 +21,12 @@ void dwt_horizontal_line_avx2(int32_t* out_lf, int32_t* out_hf, const int32_t* i
     const uint32_t count = ((len - 1) / 2);
     const __m256i two = _mm256_set1_epi32(2);
     const uint32_t count_all = (count - 1) / 8;
-    const __m256i reg_permutevar_mask_move_right = _mm256_setr_epi32(0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06);
+    /* The previous high-frequency sample stays in a vector instead of being
+     * re-read from out_hf. Every iteration used to load the value from the very
+     * cell the vector had just been stored to: the load waited on its own store,
+     * and store-to-load forwarding costs about a dozen cycles. The element is
+     * already sitting in the last lane of the previous iteration's result. */
+    __m256i prev_hf = _mm256_set1_epi32(out_hf[0]);
     const __m256i reg_permutevar_mask_move_left = _mm256_setr_epi32(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x07);
     const __m256i reg_permutevar_mask_A = _mm256_setr_epi32(0x00, 0x02, 0x04, 0x06, 0x01, 0x03, 0x05, 0x07);
     const __m256i reg_permutevar_mask_B = _mm256_setr_epi32(0x01, 0x03, 0x05, 0x07, 0x00, 0x02, 0x04, 0x06);
@@ -45,8 +50,9 @@ void dwt_horizontal_line_avx2(int32_t* out_lf, int32_t* out_hf, const int32_t* i
         hf_out = _mm256_sub_epi32(in_1, hf_out);
         _mm256_storeu_si256((__m256i*)(out_hf + id), hf_out); //out_hf[id]
 
-        __m256i hf_m1 = _mm256_permutevar8x32_epi32(hf_out, reg_permutevar_mask_move_right);
-        hf_m1 = _mm256_insert_epi32(hf_m1, out_hf[id - 1], 0);
+        const __m256i shifted = _mm256_permute2x128_si256(prev_hf, hf_out, 0x21);
+        const __m256i hf_m1 = _mm256_alignr_epi8(hf_out, shifted, 12);
+        prev_hf = hf_out;
 
         __m256i lf = _mm256_add_epi32(hf_out, hf_m1);
         lf = _mm256_add_epi32(lf, two);

--- a/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.c
@@ -1,0 +1,11 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include "Pack_avx2.h"
+#include "pack_group_helper.h"
+
+void pack_data_single_group_avx2(bitstream_writer_t* bitstream, uint16_t* buf, uint8_t gcli, uint8_t gtli) {
+    pack_data_single_group_sse(bitstream, buf, gcli, gtli);
+}

--- a/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.c
@@ -9,3 +9,8 @@
 void pack_data_single_group_avx2(bitstream_writer_t* bitstream, uint16_t* buf, uint8_t gcli, uint8_t gtli) {
     pack_data_single_group_sse(bitstream, buf, gcli, gtli);
 }
+
+void pack_data_groups_avx2(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups, uint8_t gtli,
+                           uint8_t sign_flag) {
+    pack_data_groups_sse(bitstream, buf_16bit, gclis, groups, gtli, sign_flag);
+}

--- a/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.h
@@ -13,6 +13,9 @@
 extern "C" {
 #endif
 
+void pack_data_groups_avx2(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups, uint8_t gtli,
+                           uint8_t sign_flag);
+
 void pack_data_single_group_avx2(bitstream_writer_t* bitstream, uint16_t* buf, uint8_t gcli, uint8_t gtli);
 
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/Pack_avx2.h
@@ -1,0 +1,22 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __PACK_AVX2_H__
+#define __PACK_AVX2_H__
+
+#include "Definitions.h"
+#include "BitstreamWriter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void pack_data_single_group_avx2(bitstream_writer_t* bitstream, uint16_t* buf, uint8_t gcli, uint8_t gtli);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__PACK_AVX2_H__*/

--- a/Source/Lib/Encoder/ASM_AVX2/RateControl_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/RateControl_avx2.c
@@ -8,6 +8,7 @@
 #include "rate_control_helper_avx2.h"
 #include "encoder_dsp_rtcd.h"
 #include "EncDec.h"
+#include <string.h>
 
 uint32_t rate_control_calc_vpred_cost_nosigf_avx2(uint32_t gcli_width, uint8_t *gcli_data_top_ptr, uint8_t *gcli_data_ptr,
                                                   uint8_t *vpred_bits_pack, uint8_t gtli, uint8_t gtli_max) {
@@ -306,5 +307,61 @@ void convert_packed_to_planar_rgb_16bit_avx2(const void *in_rgb, void *out_comp1
         out_c2++;
         out_c3++;
         in += 3;
+    }
+}
+
+/* Histogram of sixteen bins over bytes from [0, TRUNCATION_MAX].
+ *
+ * Every bin is counted as the population of a compare mask. This variant was
+ * chosen not for peak throughput on long lines but because it has neither a
+ * prologue nor an epilogue: sixteen byte accumulators would have to be cleared
+ * and folded, which is some fifty extra operations per call. Meanwhile on a
+ * 1080p422 frame more than half of the calls arrive with a width below sixteen
+ * (bands of the upper decomposition levels are narrow), and there the fixed
+ * cost decides everything.
+ *
+ * The tail is copied into a buffer padded with 0xFF: that value matches no bin,
+ * so the extra bytes land nowhere and no separate scalar tail is needed - which
+ * is essential for narrow bands, where the whole array is the tail. */
+#define GC_HIST_BIN_AVX2(v, K) \
+    total[K] += (uint32_t)_mm_popcnt_u32((uint32_t)_mm256_movemask_epi8(_mm256_cmpeq_epi8((v), _mm256_set1_epi8((char)(K)))))
+
+#define GC_HIST_ALL_AVX2(v)      \
+    do {                         \
+        GC_HIST_BIN_AVX2(v, 0);  \
+        GC_HIST_BIN_AVX2(v, 1);  \
+        GC_HIST_BIN_AVX2(v, 2);  \
+        GC_HIST_BIN_AVX2(v, 3);  \
+        GC_HIST_BIN_AVX2(v, 4);  \
+        GC_HIST_BIN_AVX2(v, 5);  \
+        GC_HIST_BIN_AVX2(v, 6);  \
+        GC_HIST_BIN_AVX2(v, 7);  \
+        GC_HIST_BIN_AVX2(v, 8);  \
+        GC_HIST_BIN_AVX2(v, 9);  \
+        GC_HIST_BIN_AVX2(v, 10); \
+        GC_HIST_BIN_AVX2(v, 11); \
+        GC_HIST_BIN_AVX2(v, 12); \
+        GC_HIST_BIN_AVX2(v, 13); \
+        GC_HIST_BIN_AVX2(v, 14); \
+        GC_HIST_BIN_AVX2(v, 15); \
+    } while (0)
+
+void gc_histogram_16_avx2(const uint8_t *data, uint32_t width, uint16_t *hist) {
+    uint32_t total[TRUNCATION_MAX + 1] = {0};
+    uint32_t i = 0;
+
+    for (; i + 32 <= width; i += 32) {
+        const __m256i v = _mm256_loadu_si256((const __m256i *)(data + i));
+        GC_HIST_ALL_AVX2(v);
+    }
+    if (i < width) {
+        uint8_t tail[32];
+        memset(tail, 0xFF, sizeof(tail));
+        memcpy(tail, data + i, width - i);
+        const __m256i v = _mm256_loadu_si256((const __m256i *)tail);
+        GC_HIST_ALL_AVX2(v);
+    }
+    for (uint32_t k = 0; k <= TRUNCATION_MAX; ++k) {
+        hist[k] = (uint16_t)total[k];
     }
 }

--- a/Source/Lib/Encoder/ASM_AVX2/RateControl_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/RateControl_avx2.h
@@ -15,6 +15,8 @@ extern "C" {
 uint32_t rate_control_calc_vpred_cost_nosigf_avx2(uint32_t gcli_width, uint8_t* gcli_data_top_ptr, uint8_t* gcli_data_ptr,
                                                   uint8_t* vpred_bits_pack, uint8_t gtli, uint8_t gtli_max);
 
+void gc_histogram_16_avx2(const uint8_t* data, uint32_t width, uint16_t* hist);
+
 void gc_precinct_stage_scalar_avx2(uint8_t* gcli_data_ptr, uint16_t* coeff_data_ptr_16bit, uint32_t group_size, uint32_t width);
 
 void convert_packed_to_planar_rgb_8bit_avx2(const void* in_rgb, void* out_comp1, void* out_comp2, void* out_comp3,

--- a/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
@@ -10,6 +10,8 @@
 #include "Definitions.h"
 #include "Codestream.h"
 #include "BitstreamWriter.h"
+#include "SvtUtility.h"
+#include <string.h>
 
 /* Packing one group of four coefficients is a transposition of bit planes: each
  * plane contributes one nibble to the stream, assembled from the same-numbered
@@ -59,6 +61,52 @@ static INLINE void pack_group_planes_nibw(nib_writer_t* w, __m128i reversed, uin
     }
 }
 
+/* Walk over the groups of a line driven by a mask of the non-empty ones.
+ *
+ * Empty groups - those whose GCLI does not exceed the truncation level - are
+ * the vast majority: about eighty-seven per cent on 1080p at four bits per
+ * pixel. With such a skew the per-group "is there anything to write" branch
+ * predicts badly, and it costs more than the write itself. Here the mask is
+ * built for thirty-two groups at a time and the walk follows only its set bits:
+ * an empty group costs nothing.
+ *
+ * The mask comes from a saturating subtract: subs_epu8 yields zero exactly
+ * where GCLI does not exceed the truncation level. A signed compare against
+ * zero is valid afterwards because GCLI never exceeds fifteen.
+ *
+ * emit_signs is a parameter rather than a field: both call sites pass a
+ * constant, so the compiler expands the function into two variants with no
+ * branch inside the loop. */
+static INLINE void pack_groups_masked(nib_writer_t* w, const uint16_t* buf_16bit, const uint8_t* gclis, uint32_t groups,
+                                      uint8_t gtli, const int emit_signs) {
+    const __m256i gtli_vec = _mm256_set1_epi8((char)gtli);
+    const __m256i zero = _mm256_setzero_si256();
+
+    for (uint32_t base = 0; base < groups; base += 32) {
+        const uint32_t chunk = MIN(groups - base, 32u);
+        __m256i gcli_vec;
+        if (chunk >= 32) {
+            gcli_vec = _mm256_loadu_si256((const __m256i*)(gclis + base));
+        }
+        else {
+            uint8_t padded[32] = {0};
+            memcpy(padded, gclis + base, chunk);
+            gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
+        }
+        uint64_t todo = (uint32_t)_mm256_movemask_epi8(_mm256_cmpgt_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
+        while (todo) {
+            const uint32_t group = base + svt_first_set_bit(todo);
+            todo &= todo - 1;
+            const __m128i reversed = pack_group_load_reversed(buf_16bit + (size_t)group * GROUP_SIZE);
+            if (emit_signs) {
+                /* the signs are the same top bits of the same lanes */
+                nibw_put(w, pack_group_nibble(reversed));
+            }
+            pack_group_planes_nibw(w, reversed, gclis[group], gtli);
+        }
+    }
+}
+
 /* The whole loop over the full groups of a line.
  *
  * It is dispatched as a whole for two reasons: the nibble writer must live from
@@ -70,23 +118,10 @@ static INLINE void pack_data_groups_sse(bitstream_writer_t* bitstream, uint16_t*
     nib_writer_t w;
     nibw_init(&w, bitstream);
     if (sign_flag == 0) {
-        for (uint32_t group = 0; group < groups; group++) {
-            if (gclis[group] > gtli) {
-                const __m128i reversed = pack_group_load_reversed(buf_16bit);
-                /* the signs are the same top bits of the same lanes */
-                nibw_put(&w, pack_group_nibble(reversed));
-                pack_group_planes_nibw(&w, reversed, gclis[group], gtli);
-            }
-            buf_16bit += GROUP_SIZE;
-        }
+        pack_groups_masked(&w, buf_16bit, gclis, groups, gtli, 1);
     }
     else {
-        for (uint32_t group = 0; group < groups; group++) {
-            if (gclis[group] > gtli) {
-                pack_group_planes_nibw(&w, pack_group_load_reversed(buf_16bit), gclis[group], gtli);
-            }
-            buf_16bit += GROUP_SIZE;
-        }
+        pack_groups_masked(&w, buf_16bit, gclis, groups, gtli, 0);
     }
     nibw_finish(&w, bitstream);
 }

--- a/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
@@ -80,23 +80,25 @@ static INLINE uint64_t pack_group_planes_word(__m128i reversed, uint8_t gcli, ui
  * emit_signs is a parameter rather than a field: both call sites pass a
  * constant, so the compiler expands the function into two variants with no
  * branch inside the loop. */
+static INLINE uint64_t pack_nonempty_mask(const uint8_t* gclis, uint32_t chunk, uint8_t gtli) {
+    __m256i gcli_vec;
+    if (chunk >= 32) {
+        gcli_vec = _mm256_loadu_si256((const __m256i*)gclis);
+    }
+    else {
+        uint8_t padded[32] = {0};
+        memcpy(padded, gclis, chunk);
+        gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
+    }
+    return (uint32_t)_mm256_movemask_epi8(
+        _mm256_cmpgt_epi8(_mm256_subs_epu8(gcli_vec, _mm256_set1_epi8((char)gtli)), _mm256_setzero_si256()));
+}
+
 static INLINE void pack_groups_masked(nib_writer_t* w, const uint16_t* buf_16bit, const uint8_t* gclis, uint32_t groups,
                                       uint8_t gtli, const int emit_signs) {
-    const __m256i gtli_vec = _mm256_set1_epi8((char)gtli);
-    const __m256i zero = _mm256_setzero_si256();
-
     for (uint32_t base = 0; base < groups; base += 32) {
         const uint32_t chunk = MIN(groups - base, 32u);
-        __m256i gcli_vec;
-        if (chunk >= 32) {
-            gcli_vec = _mm256_loadu_si256((const __m256i*)(gclis + base));
-        }
-        else {
-            uint8_t padded[32] = {0};
-            memcpy(padded, gclis + base, chunk);
-            gcli_vec = _mm256_loadu_si256((const __m256i*)padded);
-        }
-        uint64_t todo = (uint32_t)_mm256_movemask_epi8(_mm256_cmpgt_epi8(_mm256_subs_epu8(gcli_vec, gtli_vec), zero));
+        uint64_t todo = pack_nonempty_mask(gclis + base, chunk, gtli);
         while (todo) {
             const uint32_t group = base + svt_first_set_bit(todo);
             todo &= todo - 1;

--- a/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
@@ -51,14 +51,17 @@ static INLINE void pack_data_single_group_sse(bitstream_writer_t* bitstream, con
     }
 }
 
-/* Splits the planes of a group and feeds the nibbles to the shared writer. */
-static INLINE void pack_group_planes_nibw(nib_writer_t* w, __m128i reversed, uint8_t gcli, uint8_t gtli) {
+/* The planes of a group collected into one word: the top plane is the top
+ * nibble. Returning a word beats handing out nibbles one by one: the writer
+ * gets a single call instead of a chain of short dependent steps. */
+static INLINE uint64_t pack_group_planes_word(__m128i reversed, uint8_t gcli, uint8_t gtli) {
     __m128i tmp = _mm_slli_epi16(reversed, 16 - gcli);
+    uint64_t word = 0;
     for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
-        const uint32_t nibble = pack_group_nibble(tmp);
+        word = (word << 4) | pack_group_nibble(tmp);
         tmp = _mm_slli_epi16(tmp, 1);
-        nibw_put(w, nibble);
     }
+    return word;
 }
 
 /* Walk over the groups of a line driven by a mask of the non-empty ones.
@@ -98,11 +101,15 @@ static INLINE void pack_groups_masked(nib_writer_t* w, const uint16_t* buf_16bit
             const uint32_t group = base + svt_first_set_bit(todo);
             todo &= todo - 1;
             const __m128i reversed = pack_group_load_reversed(buf_16bit + (size_t)group * GROUP_SIZE);
+            const uint32_t planes = (uint32_t)gclis[group] - gtli;
+            uint64_t word = pack_group_planes_word(reversed, gclis[group], gtli);
+            uint32_t count = planes;
             if (emit_signs) {
-                /* the signs are the same top bits of the same lanes */
-                nibw_put(w, pack_group_nibble(reversed));
+                /* the signs are the same top bits of the same lanes, and they go first */
+                word |= (uint64_t)pack_group_nibble(reversed) << (4 * planes);
+                count = planes + 1;
             }
-            pack_group_planes_nibw(w, reversed, gclis[group], gtli);
+            nibw_put_group(w, word, count);
         }
     }
 }

--- a/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
@@ -28,18 +28,67 @@
  * Only SSE2 here, nothing wider than 128 bits: there are just 64 bits of data
  * and nothing to widen the register with. That is why one implementation serves
  * both AVX2 and AVX-512. */
+/* Lanes are reversed once: lane 0 receives buf[3], lane 3 receives buf[0]. */
+static INLINE __m128i pack_group_load_reversed(const uint16_t* buf) {
+    return _mm_shufflelo_epi16(_mm_loadl_epi64((const __m128i*)buf), _MM_SHUFFLE(0, 1, 2, 3));
+}
+
+/* Nibble made of the top bits of the four lanes. */
+static INLINE uint32_t pack_group_nibble(__m128i reversed) {
+    return (uint32_t)_mm_movemask_epi8(_mm_packs_epi16(reversed, reversed)) & 0xF;
+}
+
 static INLINE void pack_data_single_group_sse(bitstream_writer_t* bitstream, const uint16_t* buf, uint8_t gcli, uint8_t gtli) {
-    __m128i tmp = _mm_loadl_epi64((const __m128i*)buf);
-    /* lane 0 receives buf[3], lane 3 receives buf[0] */
-    tmp = _mm_shufflelo_epi16(tmp, _MM_SHUFFLE(0, 1, 2, 3));
     /* the top significant plane is moved into the sign bit */
-    tmp = _mm_slli_epi16(tmp, 16 - gcli);
+    __m128i tmp = _mm_slli_epi16(pack_group_load_reversed(buf), 16 - gcli);
 
     for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
-        const uint32_t nibble = (uint32_t)_mm_movemask_epi8(_mm_packs_epi16(tmp, tmp)) & 0xF;
+        const uint32_t nibble = pack_group_nibble(tmp);
         tmp = _mm_slli_epi16(tmp, 1);
         write_4_bits_align4(bitstream, (uint8_t)nibble);
     }
+}
+
+/* Splits the planes of a group and feeds the nibbles to the shared writer. */
+static INLINE void pack_group_planes_nibw(nib_writer_t* w, __m128i reversed, uint8_t gcli, uint8_t gtli) {
+    __m128i tmp = _mm_slli_epi16(reversed, 16 - gcli);
+    for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
+        const uint32_t nibble = pack_group_nibble(tmp);
+        tmp = _mm_slli_epi16(tmp, 1);
+        nibw_put(w, nibble);
+    }
+}
+
+/* The whole loop over the full groups of a line.
+ *
+ * It is dispatched as a whole for two reasons: the nibble writer must live from
+ * the start of the line to its end rather than being set up per group, and the
+ * per-group indirect call disappears along the way - there are hundreds of them
+ * per line. */
+static INLINE void pack_data_groups_sse(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups,
+                                        uint8_t gtli, uint8_t sign_flag) {
+    nib_writer_t w;
+    nibw_init(&w, bitstream);
+    if (sign_flag == 0) {
+        for (uint32_t group = 0; group < groups; group++) {
+            if (gclis[group] > gtli) {
+                const __m128i reversed = pack_group_load_reversed(buf_16bit);
+                /* the signs are the same top bits of the same lanes */
+                nibw_put(&w, pack_group_nibble(reversed));
+                pack_group_planes_nibw(&w, reversed, gclis[group], gtli);
+            }
+            buf_16bit += GROUP_SIZE;
+        }
+    }
+    else {
+        for (uint32_t group = 0; group < groups; group++) {
+            if (gclis[group] > gtli) {
+                pack_group_planes_nibw(&w, pack_group_load_reversed(buf_16bit), gclis[group], gtli);
+            }
+            buf_16bit += GROUP_SIZE;
+        }
+    }
+    nibw_finish(&w, bitstream);
 }
 
 #endif /*__PACK_GROUP_HELPER_H__*/

--- a/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pack_group_helper.h
@@ -1,0 +1,45 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __PACK_GROUP_HELPER_H__
+#define __PACK_GROUP_HELPER_H__
+
+#include <immintrin.h>
+#include "Definitions.h"
+#include "Codestream.h"
+#include "BitstreamWriter.h"
+
+/* Packing one group of four coefficients is a transposition of bit planes: each
+ * plane contributes one nibble to the stream, assembled from the same-numbered
+ * bits of the four values, most significant plane first.
+ *
+ * The key trick: reverse the lane order once on input and the required nibble
+ * becomes exactly the mask of sign bits. PACKSSWB saturates 16-bit values to
+ * 8-bit ones keeping the sign, and VPMOVMSKB gathers the top bits of the bytes
+ * into an integer where bit i is the top bit of lane i. No horizontal summing
+ * is needed at all.
+ *
+ * The former implementation extracted the bit with a shift and folded the lanes
+ * with two PHADDW per plane; those two instructions took about forty per cent
+ * of the function's time - PHADDW is three uops and has a long latency.
+ *
+ * Only SSE2 here, nothing wider than 128 bits: there are just 64 bits of data
+ * and nothing to widen the register with. That is why one implementation serves
+ * both AVX2 and AVX-512. */
+static INLINE void pack_data_single_group_sse(bitstream_writer_t* bitstream, const uint16_t* buf, uint8_t gcli, uint8_t gtli) {
+    __m128i tmp = _mm_loadl_epi64((const __m128i*)buf);
+    /* lane 0 receives buf[3], lane 3 receives buf[0] */
+    tmp = _mm_shufflelo_epi16(tmp, _MM_SHUFFLE(0, 1, 2, 3));
+    /* the top significant plane is moved into the sign bit */
+    tmp = _mm_slli_epi16(tmp, 16 - gcli);
+
+    for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
+        const uint32_t nibble = (uint32_t)_mm_movemask_epi8(_mm_packs_epi16(tmp, tmp)) & 0xF;
+        tmp = _mm_slli_epi16(tmp, 1);
+        write_4_bits_align4(bitstream, (uint8_t)nibble);
+    }
+}
+
+#endif /*__PACK_GROUP_HELPER_H__*/

--- a/Source/Lib/Encoder/ASM_AVX512/CMakeLists.txt
+++ b/Source/Lib/Encoder/ASM_AVX512/CMakeLists.txt
@@ -21,7 +21,8 @@ check_both_flags_add(
     -mavx512bw
     -mavx512cd
     -mavx512dq
-    -mavx512vl)
+    -mavx512vl
+    -mpopcnt)
 
 if(MSVC)
     check_both_flags_add(/arch:AVX512)

--- a/Source/Lib/Encoder/ASM_AVX512/CMakeLists.txt
+++ b/Source/Lib/Encoder/ASM_AVX512/CMakeLists.txt
@@ -22,7 +22,8 @@ check_both_flags_add(
     -mavx512cd
     -mavx512dq
     -mavx512vl
-    -mpopcnt)
+    -mpopcnt
+    -mbmi2)
 
 if(MSVC)
     check_both_flags_add(/arch:AVX512)

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
@@ -92,8 +92,12 @@ void dwt_horizontal_line_avx512(int32_t* out_lf, int32_t* out_hf, const int32_t*
         0x00, 0x02, 0x04, 0x06, 0x08, 0x0a, 0x0c, 0x0e, 0x10, 0x12, 0x14, 0x16, 0x18, 0x1a, 0x1c, 0x1e);
     const __m512i reg1_permutex2var_mask = _mm512_setr_epi32(
         0x01, 0x03, 0x05, 0x07, 0x09, 0x0b, 0x0d, 0x0f, 0x11, 0x13, 0x15, 0x17, 0x19, 0x1b, 0x1d, 0x1f);
-    const __m512i reg_permutevar_mask = _mm512_setr_epi32(
-        0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e);
+    /* The previous high-frequency sample stays in a vector instead of being
+     * re-read from out_hf. Every iteration used to load the value from the very
+     * cell the vector had just been stored to: the load waited on its own store,
+     * and store-to-load forwarding costs about a dozen cycles. The element is
+     * already sitting in the last lane of the previous iteration's result. */
+    __m512i prev_hf = _mm512_set1_epi32(out_hf[0]);
 
     uint32_t id = 1;
 
@@ -117,11 +121,8 @@ void dwt_horizontal_line_avx512(int32_t* out_lf, int32_t* out_hf, const int32_t*
         _mm512_storeu_si512((__m512i*)(out_hf + id), hf);
 
         //out_hf[id - 1]
-        //const __m512i hf_m1 = _mm512_loadu_si512((__m512i*)(out_hf + id - 1));
-        __m512i hf_m1 = _mm512_permutexvar_epi32(reg_permutevar_mask, hf);
-        __m128i tmp = _mm512_castsi512_si128(hf_m1);
-        tmp = _mm_insert_epi32(tmp, out_hf[id - 1], 0);
-        hf_m1 = _mm512_inserti32x4(hf_m1, tmp, 0);
+        const __m512i hf_m1 = _mm512_alignr_epi32(hf, prev_hf, 15);
+        prev_hf = hf;
 
         //out_lf[id] = in[id * 2] + ((out_hf[id - 1] + out_hf[id] + 2) >> 2);
         __m512i lf = _mm512_add_epi32(hf, hf_m1);

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
@@ -200,22 +200,35 @@ void image_shift_avx512(uint16_t* out_coeff_16bit, int32_t* in_coeff_32bit, uint
 
 void linear_input_scaling_line_8bit_avx512(const uint8_t* src, int32_t* dst, uint32_t w, uint8_t shift, int32_t offset) {
     const __m512i offset_avx512 = _mm512_set1_epi32(offset);
-    const uint32_t simd_batch = w / 16;
-    const uint32_t remaining = w % 16;
+    uint32_t j = 0;
 
-    for (uint32_t j = 0; j < simd_batch; j++) {
-        __m128i temp_data = _mm_loadu_si128((__m128i*)src);
-        __m512i data = _mm512_cvtepu8_epi32(temp_data);
+    /* Four vectors per turn: a body of three operations also paid for two
+     * pointer bumps and a branch, so a noticeable share of the work went into
+     * something other than the data. Four independent chains also give the
+     * pipeline something to do while the byte-to-word widening is in flight. */
+    for (; j + 64 <= w; j += 64) {
+        __m512i d0 = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i*)(src + j)));
+        __m512i d1 = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i*)(src + j + 16)));
+        __m512i d2 = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i*)(src + j + 32)));
+        __m512i d3 = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i*)(src + j + 48)));
 
+        d0 = _mm512_sub_epi32(_mm512_slli_epi32(d0, shift), offset_avx512);
+        d1 = _mm512_sub_epi32(_mm512_slli_epi32(d1, shift), offset_avx512);
+        d2 = _mm512_sub_epi32(_mm512_slli_epi32(d2, shift), offset_avx512);
+        d3 = _mm512_sub_epi32(_mm512_slli_epi32(d3, shift), offset_avx512);
+
+        _mm512_storeu_si512(dst + j, d0);
+        _mm512_storeu_si512(dst + j + 16, d1);
+        _mm512_storeu_si512(dst + j + 32, d2);
+        _mm512_storeu_si512(dst + j + 48, d3);
+    }
+    for (; j + 16 <= w; j += 16) {
+        __m512i data = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i*)(src + j)));
         data = _mm512_slli_epi32(data, shift);
         data = _mm512_sub_epi32(data, offset_avx512);
-
-        _mm512_storeu_si512(dst, data);
-
-        src += 16;
-        dst += 16;
+        _mm512_storeu_si512(dst + j, data);
     }
-    for (uint32_t j = 0; j < remaining; j++) {
+    for (; j < w; j++) {
         dst[j] = (int32_t)((uint32_t)src[j] << shift) - (int32_t)offset;
     }
 }

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.c
@@ -725,3 +725,53 @@ void gc_precinct_stage_scalar_avx512(uint8_t* gcli_data_ptr, uint16_t* coeff_dat
         }
     }
 }
+
+/* Histogram of sixteen bins over bytes from [0, TRUNCATION_MAX].
+ *
+ * Built the same way as the AVX2 version (population of a compare mask, no
+ * prologue and no epilogue), except that here the compare mask is a ready k
+ * register rather than the result of VPMOVMSKB, and sixty-four bytes are
+ * handled per pass instead of thirty-two. The tail is read by a masked load
+ * into a vector pre-filled with 0xFF, so no copying into a buffer is needed at
+ * all. */
+#define GC_HIST_BIN_AVX512(v, K) \
+    total[K] += (uint32_t)_mm_popcnt_u64((uint64_t)_mm512_cmpeq_epi8_mask((v), _mm512_set1_epi8((char)(K))))
+
+#define GC_HIST_ALL_AVX512(v)      \
+    do {                           \
+        GC_HIST_BIN_AVX512(v, 0);  \
+        GC_HIST_BIN_AVX512(v, 1);  \
+        GC_HIST_BIN_AVX512(v, 2);  \
+        GC_HIST_BIN_AVX512(v, 3);  \
+        GC_HIST_BIN_AVX512(v, 4);  \
+        GC_HIST_BIN_AVX512(v, 5);  \
+        GC_HIST_BIN_AVX512(v, 6);  \
+        GC_HIST_BIN_AVX512(v, 7);  \
+        GC_HIST_BIN_AVX512(v, 8);  \
+        GC_HIST_BIN_AVX512(v, 9);  \
+        GC_HIST_BIN_AVX512(v, 10); \
+        GC_HIST_BIN_AVX512(v, 11); \
+        GC_HIST_BIN_AVX512(v, 12); \
+        GC_HIST_BIN_AVX512(v, 13); \
+        GC_HIST_BIN_AVX512(v, 14); \
+        GC_HIST_BIN_AVX512(v, 15); \
+    } while (0)
+
+void gc_histogram_16_avx512(const uint8_t* data, uint32_t width, uint16_t* hist) {
+    uint32_t total[TRUNCATION_MAX + 1] = {0};
+    uint32_t i = 0;
+
+    for (; i + 64 <= width; i += 64) {
+        const __m512i v = _mm512_loadu_si512((const void*)(data + i));
+        GC_HIST_ALL_AVX512(v);
+    }
+    if (i < width) {
+        /* Unused lanes stay at 0xFF and land in no bin. */
+        const __mmask64 m = ((__mmask64)1 << (width - i)) - 1;
+        const __m512i v = _mm512_mask_loadu_epi8(_mm512_set1_epi8((char)0xFF), m, data + i);
+        GC_HIST_ALL_AVX512(v);
+    }
+    for (uint32_t k = 0; k <= TRUNCATION_MAX; ++k) {
+        hist[k] = (uint16_t)total[k];
+    }
+}

--- a/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.h
+++ b/Source/Lib/Encoder/ASM_AVX512/Enc_avx512.h
@@ -41,6 +41,8 @@ void convert_packed_to_planar_rgb_8bit_avx512(const void* in_rgb, void* out_comp
 void convert_packed_to_planar_rgb_16bit_avx512(const void* in_rgb, void* out_comp1, void* out_comp2, void* out_comp3,
                                                uint32_t line_width);
 
+void gc_histogram_16_avx512(const uint8_t* data, uint32_t width, uint16_t* hist);
+
 void gc_precinct_stage_scalar_avx512(uint8_t* gcli_data_ptr, uint16_t* coeff_data_ptr_16bit, uint32_t group_size, uint32_t width);
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
@@ -4,6 +4,7 @@
 */
 
 #include "Pack_avx512.h"
+#include "pack_group_helper.h"
 #include "RateControl_avx2.h"
 #include "rate_control_helper_avx2.h"
 #include <immintrin.h>
@@ -11,22 +12,10 @@
 #include "SvtUtility.h"
 
 void pack_data_single_group_avx512(bitstream_writer_t *bitstream, uint16_t *buf, uint8_t gcli, uint8_t gtli) {
-    const __m128i mask = _mm_set1_epi16((short)BITSTREAM_MASK_SIGN);
-    const __m128i shift = _mm_setr_epi16(12, 13, 14, 15, 0, 0, 0, 0);
-
-    __m128i tmp_sse = _mm_loadl_epi64((__m128i *)buf);
-    tmp_sse = _mm_slli_epi16(tmp_sse, 16 - gcli);
-
-    for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
-        __m128i val_sse = _mm_and_si128(tmp_sse, mask);
-        tmp_sse = _mm_slli_epi16(tmp_sse, 1);
-        val_sse = _mm_srlv_epi16(val_sse, shift);
-        val_sse = _mm_hadd_epi16(val_sse, val_sse);
-        val_sse = _mm_hadd_epi16(val_sse, val_sse);
-        uint8_t val = _mm_cvtsi128_si32(val_sse);
-
-        write_4_bits_align4(bitstream, (uint8_t)val);
-    }
+    /* A group is only 64 bits of data and there is nothing to widen the register
+     * with, so this is the same 128-bit implementation as on AVX2 (see
+     * pack_group_helper.h). */
+    pack_data_single_group_sse(bitstream, buf, gcli, gtli);
 }
 
 static INLINE __m512i vlc_encode_get_bits_avx512(__m512i x, __m512i r, __m512i t) {

--- a/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
@@ -18,6 +18,65 @@ void pack_data_single_group_avx512(bitstream_writer_t *bitstream, uint16_t *buf,
     pack_data_single_group_sse(bitstream, buf, gcli, gtli);
 }
 
+/* All sixteen bit planes of a group in one go.
+ *
+ * Packing a group is a transposition of a "four values by sixteen positions"
+ * matrix: the nibble of plane j consists of the j-th bits of the four values,
+ * with the first value contributing the top bit of the nibble. PDEP scatters
+ * the bits of a number over the set bits of a mask, so the mask 0x8888... lays
+ * the positions of the first value exactly on the top bits of all sixteen
+ * nibbles, 0x4444... does the same for the second, and so on; the four results
+ * only have to be ORed together.
+ *
+ * The gain is that the cost stops depending on the number of planes: each one
+ * used to take a saturating pack, a sign-mask extraction and a shift, and a
+ * group can have up to fifteen planes. Here it is always four PDEPs.
+ *
+ * The sign nibble falls out of the same computation for free: the sign is bit
+ * 15, that is the top nibble of the word.
+ *
+ * PDEP is used without hesitation: it is microcoded and slow only on Zen 1 and
+ * Zen 2, and this path is only reached when AVX-512 is present - that is on
+ * Skylake-X and newer or Zen 4 and newer, where it is a single uop. */
+static INLINE uint64_t pack_group_planes_pdep(const uint16_t *buf) {
+    return _pdep_u64(buf[0], 0x8888888888888888ULL) | _pdep_u64(buf[1], 0x4444444444444444ULL) |
+        _pdep_u64(buf[2], 0x2222222222222222ULL) | _pdep_u64(buf[3], 0x1111111111111111ULL);
+}
+
+static INLINE void pack_groups_masked_pdep(nib_writer_t *w, const uint16_t *buf_16bit, const uint8_t *gclis, uint32_t groups,
+                                           uint8_t gtli, const int emit_signs) {
+    for (uint32_t base = 0; base < groups; base += 32) {
+        const uint32_t chunk = MIN(groups - base, 32u);
+        uint64_t todo = pack_nonempty_mask(gclis + base, chunk, gtli);
+        while (todo) {
+            const uint32_t group = base + svt_first_set_bit(todo);
+            todo &= todo - 1;
+            const uint64_t all = pack_group_planes_pdep(buf_16bit + (size_t)group * GROUP_SIZE);
+            const uint32_t planes = (uint32_t)gclis[group] - gtli;
+            uint64_t word = (all >> (4 * gtli)) & (((uint64_t)1 << (4 * planes)) - 1);
+            uint32_t count = planes;
+            if (emit_signs) {
+                word |= (all >> 60) << (4 * planes);
+                count = planes + 1;
+            }
+            nibw_put_group(w, word, count);
+        }
+    }
+}
+
+void pack_data_groups_avx512(bitstream_writer_t *bitstream, uint16_t *buf_16bit, uint8_t *gclis, uint32_t groups, uint8_t gtli,
+                             uint8_t sign_flag) {
+    nib_writer_t w;
+    nibw_init(&w, bitstream);
+    if (sign_flag == 0) {
+        pack_groups_masked_pdep(&w, buf_16bit, gclis, groups, gtli, 1);
+    }
+    else {
+        pack_groups_masked_pdep(&w, buf_16bit, gclis, groups, gtli, 0);
+    }
+    nibw_finish(&w, bitstream);
+}
+
 static INLINE __m512i vlc_encode_get_bits_avx512(__m512i x, __m512i r, __m512i t) {
     //    assert(x < 32);
     //    int32_t max = r - t;

--- a/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.c
@@ -5,6 +5,7 @@
 
 #include "Pack_avx512.h"
 #include "pack_group_helper.h"
+#include "pack_group_helper_avx512.h"
 #include "RateControl_avx2.h"
 #include "rate_control_helper_avx2.h"
 #include <immintrin.h>
@@ -16,52 +17,6 @@ void pack_data_single_group_avx512(bitstream_writer_t *bitstream, uint16_t *buf,
      * with, so this is the same 128-bit implementation as on AVX2 (see
      * pack_group_helper.h). */
     pack_data_single_group_sse(bitstream, buf, gcli, gtli);
-}
-
-/* All sixteen bit planes of a group in one go.
- *
- * Packing a group is a transposition of a "four values by sixteen positions"
- * matrix: the nibble of plane j consists of the j-th bits of the four values,
- * with the first value contributing the top bit of the nibble. PDEP scatters
- * the bits of a number over the set bits of a mask, so the mask 0x8888... lays
- * the positions of the first value exactly on the top bits of all sixteen
- * nibbles, 0x4444... does the same for the second, and so on; the four results
- * only have to be ORed together.
- *
- * The gain is that the cost stops depending on the number of planes: each one
- * used to take a saturating pack, a sign-mask extraction and a shift, and a
- * group can have up to fifteen planes. Here it is always four PDEPs.
- *
- * The sign nibble falls out of the same computation for free: the sign is bit
- * 15, that is the top nibble of the word.
- *
- * PDEP is used without hesitation: it is microcoded and slow only on Zen 1 and
- * Zen 2, and this path is only reached when AVX-512 is present - that is on
- * Skylake-X and newer or Zen 4 and newer, where it is a single uop. */
-static INLINE uint64_t pack_group_planes_pdep(const uint16_t *buf) {
-    return _pdep_u64(buf[0], 0x8888888888888888ULL) | _pdep_u64(buf[1], 0x4444444444444444ULL) |
-        _pdep_u64(buf[2], 0x2222222222222222ULL) | _pdep_u64(buf[3], 0x1111111111111111ULL);
-}
-
-static INLINE void pack_groups_masked_pdep(nib_writer_t *w, const uint16_t *buf_16bit, const uint8_t *gclis, uint32_t groups,
-                                           uint8_t gtli, const int emit_signs) {
-    for (uint32_t base = 0; base < groups; base += 32) {
-        const uint32_t chunk = MIN(groups - base, 32u);
-        uint64_t todo = pack_nonempty_mask(gclis + base, chunk, gtli);
-        while (todo) {
-            const uint32_t group = base + svt_first_set_bit(todo);
-            todo &= todo - 1;
-            const uint64_t all = pack_group_planes_pdep(buf_16bit + (size_t)group * GROUP_SIZE);
-            const uint32_t planes = (uint32_t)gclis[group] - gtli;
-            uint64_t word = (all >> (4 * gtli)) & (((uint64_t)1 << (4 * planes)) - 1);
-            uint32_t count = planes;
-            if (emit_signs) {
-                word |= (all >> 60) << (4 * planes);
-                count = planes + 1;
-            }
-            nibw_put_group(w, word, count);
-        }
-    }
 }
 
 void pack_data_groups_avx512(bitstream_writer_t *bitstream, uint16_t *buf_16bit, uint8_t *gclis, uint32_t groups, uint8_t gtli,

--- a/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.h
+++ b/Source/Lib/Encoder/ASM_AVX512/Pack_avx512.h
@@ -13,6 +13,8 @@ extern "C" {
 #endif
 
 void pack_data_single_group_avx512(bitstream_writer_t *bitstream, uint16_t *buf, uint8_t gcli, uint8_t gtli);
+void pack_data_groups_avx512(bitstream_writer_t *bitstream, uint16_t *buf_16bit, uint8_t *gclis, uint32_t groups, uint8_t gtli,
+                             uint8_t sign_flag);
 uint32_t rate_control_calc_vpred_cost_nosigf_avx512(uint32_t gcli_width, uint8_t *gcli_data_top_ptr, uint8_t *gcli_data_ptr,
                                                     uint8_t *vpred_bits_pack, uint8_t gtli, uint8_t gtli_max);
 void rate_control_calc_vpred_cost_sigf_nosigf_avx512(uint32_t significance_width, uint32_t gcli_width, uint8_t hdr_Rm,

--- a/Source/Lib/Encoder/ASM_AVX512/pack_group_helper_avx512.h
+++ b/Source/Lib/Encoder/ASM_AVX512/pack_group_helper_avx512.h
@@ -1,0 +1,58 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef __PACK_GROUP_HELPER_AVX512_H__
+#define __PACK_GROUP_HELPER_AVX512_H__
+
+#include <immintrin.h>
+#include "pack_group_helper.h"
+
+/* All sixteen bit planes of a group in one go.
+ *
+ * Packing a group is a transposition of a "four values by sixteen positions"
+ * matrix: the nibble of plane j consists of the j-th bits of the four values,
+ * with the first value contributing the top bit of the nibble. PDEP scatters
+ * the bits of a number over the set bits of a mask, so the mask 0x8888... lays
+ * the positions of the first value exactly on the top bits of all sixteen
+ * nibbles, 0x4444... does the same for the second, and so on; the four results
+ * only have to be ORed together.
+ *
+ * The gain is that the cost stops depending on the number of planes: each one
+ * used to take a saturating pack, a sign-mask extraction and a shift, and a
+ * group can have up to fifteen planes. Here it is always four PDEPs.
+ *
+ * The sign nibble falls out of the same computation for free: the sign is bit
+ * 15, that is the top nibble of the word.
+ *
+ * PDEP is used without hesitation: it is microcoded and slow only on Zen 1 and
+ * Zen 2, and this path is only reached when AVX-512 is present - that is on
+ * Skylake-X and newer or Zen 4 and newer, where it is a single uop. */
+static INLINE uint64_t pack_group_planes_pdep(const uint16_t *buf) {
+    return _pdep_u64(buf[0], 0x8888888888888888ULL) | _pdep_u64(buf[1], 0x4444444444444444ULL) |
+        _pdep_u64(buf[2], 0x2222222222222222ULL) | _pdep_u64(buf[3], 0x1111111111111111ULL);
+}
+
+static INLINE void pack_groups_masked_pdep(nib_writer_t *w, const uint16_t *buf_16bit, const uint8_t *gclis, uint32_t groups,
+                                           uint8_t gtli, const int emit_signs) {
+    for (uint32_t base = 0; base < groups; base += 32) {
+        const uint32_t chunk = MIN(groups - base, 32u);
+        uint64_t todo = pack_nonempty_mask(gclis + base, chunk, gtli);
+        while (todo) {
+            const uint32_t group = base + svt_first_set_bit(todo);
+            todo &= todo - 1;
+            const uint64_t all = pack_group_planes_pdep(buf_16bit + (size_t)group * GROUP_SIZE);
+            const uint32_t planes = (uint32_t)gclis[group] - gtli;
+            uint64_t word = (all >> (4 * gtli)) & (((uint64_t)1 << (4 * planes)) - 1);
+            uint32_t count = planes;
+            if (emit_signs) {
+                word |= (all >> 60) << (4 * planes);
+                count = planes + 1;
+            }
+            nibw_put_group(w, word, count);
+        }
+    }
+}
+
+#endif /*__PACK_GROUP_HELPER_AVX512_H__*/

--- a/Source/Lib/Encoder/Codec/BitstreamWriter.h
+++ b/Source/Lib/Encoder/Codec/BitstreamWriter.h
@@ -90,6 +90,43 @@ static INLINE void nibw_put(nib_writer_t* w, uint32_t nibble) {
     }
 }
 
+/* A batch of nibbles at once: value carries count nibbles, right aligned, and
+ * the most significant of them is emitted first. At most eight per call - then
+ * the accumulator certainly cannot overflow (it already holds at most seven). */
+static INLINE void nibw_put_chunk(nib_writer_t* w, uint64_t value, uint32_t count) {
+    assert(count <= 8);
+    w->acc = (w->acc << (4 * count)) | value;
+    w->nnib += count;
+    if (w->nnib >= 8) {
+        const uint32_t rest = w->nnib - 8;
+        const uint32_t be = (uint32_t)(w->acc >> (4 * rest));
+        w->mem[0] = (uint8_t)(be >> 24);
+        w->mem[1] = (uint8_t)(be >> 16);
+        w->mem[2] = (uint8_t)(be >> 8);
+        w->mem[3] = (uint8_t)be;
+        w->mem += 4;
+        w->acc &= ((uint64_t)1 << (4 * rest)) - 1;
+        w->nnib = rest;
+    }
+}
+
+/* All the nibbles of one group in a single call.
+ *
+ * The "have eight accumulated" branch used to be taken per nibble, and a group
+ * has up to sixteen of them. The planes are computed one after another anyway,
+ * so accumulating them in a register is free, and it spares the writer a chain
+ * of short dependent steps. There are never more than sixteen: fifteen planes
+ * and a sign. */
+static INLINE void nibw_put_group(nib_writer_t* w, uint64_t value, uint32_t count) {
+    assert(count <= 16);
+    if (count > 8) {
+        nibw_put_chunk(w, value >> (4 * (count - 8)), 8);
+        count -= 8;
+        value &= ((uint64_t)1 << (4 * count)) - 1;
+    }
+    nibw_put_chunk(w, value, count);
+}
+
 static INLINE void nibw_finish(nib_writer_t* w, bitstream_writer_t* bitstream) {
     uint32_t n = w->nnib;
     const uint64_t a = w->acc;

--- a/Source/Lib/Encoder/Codec/BitstreamWriter.h
+++ b/Source/Lib/Encoder/Codec/BitstreamWriter.h
@@ -40,6 +40,73 @@ void write_4_bits(bitstream_writer_t* bitstream, uint8_t input);
 void write_N_bits(bitstream_writer_t* bitstream, uint32_t input, uint8_t bits);
 void update_N_bits(bitstream_writer_t* bitstream, uint32_t offset_bits, uint32_t input, uint8_t bits);
 
+/* Nibble writer for packing group data.
+ *
+ * At this point the stream always sits on a nibble boundary, and
+ * write_4_bits_align4 relies on that, but every nibble still costs a byte load
+ * from memory in order to fill in its low half. A load-store dependency on one
+ * and the same address is dragged across the whole line, and it takes a quarter
+ * of the packing time.
+ *
+ * Here the nibbles accumulate in a register and are flushed eight at a time by
+ * a single four-byte store. The flush goes straight to memory rather than
+ * through write_N_bits: that one is generic, with branches on alignment and a
+ * per-byte loop, and trading eight cheap stores for one such call would be a
+ * loss.
+ *
+ * If the stream sits on a low nibble, the high half of the current byte is
+ * pulled into the accumulator as the first nibble - everything is byte aligned
+ * from there on. nibw_finish is mandatory before any other write to the same
+ * stream. */
+typedef struct nib_writer {
+    uint8_t* mem;
+    uint64_t acc;
+    uint32_t nnib;
+} nib_writer_t;
+
+static INLINE void nibw_init(nib_writer_t* w, bitstream_writer_t* bitstream) {
+    w->mem = bitstream->mem + bitstream->offset;
+    if (bitstream->bits_used) {
+        w->acc = (uint64_t)(w->mem[0] >> 4);
+        w->nnib = 1;
+    }
+    else {
+        w->acc = 0;
+        w->nnib = 0;
+    }
+}
+
+static INLINE void nibw_put(nib_writer_t* w, uint32_t nibble) {
+    w->acc = (w->acc << 4) | nibble;
+    if (++w->nnib == 8) {
+        const uint32_t be = (uint32_t)w->acc;
+        w->mem[0] = (uint8_t)(be >> 24);
+        w->mem[1] = (uint8_t)(be >> 16);
+        w->mem[2] = (uint8_t)(be >> 8);
+        w->mem[3] = (uint8_t)be;
+        w->mem += 4;
+        w->acc = 0;
+        w->nnib = 0;
+    }
+}
+
+static INLINE void nibw_finish(nib_writer_t* w, bitstream_writer_t* bitstream) {
+    uint32_t n = w->nnib;
+    const uint64_t a = w->acc;
+    while (n >= 2) {
+        w->mem[0] = (uint8_t)((a >> ((n - 2) * 4)) & 0xFF);
+        w->mem++;
+        n -= 2;
+    }
+    if (n == 1) {
+        /* one nibble is left: it is the high half of its byte, the low half is
+         * written later */
+        w->mem[0] = (uint8_t)((a & 0xF) << 4);
+    }
+    bitstream->offset = (uint32_t)(w->mem - bitstream->mem);
+    bitstream->bits_used = n * 4;
+}
+
 /*
 * write_4_bits_align4() Can be used only when bitstream is padded to 0 or 4 bits, otherwise data will be corrupted
 */

--- a/Source/Lib/Encoder/Codec/BitstreamWriter.h
+++ b/Source/Lib/Encoder/Codec/BitstreamWriter.h
@@ -40,6 +40,75 @@ void write_4_bits(bitstream_writer_t* bitstream, uint8_t input);
 void write_N_bits(bitstream_writer_t* bitstream, uint32_t input, uint8_t bits);
 void update_N_bits(bitstream_writer_t* bitstream, uint32_t offset_bits, uint32_t input, uint8_t bits);
 
+/* Bit writer for long runs of unary codes.
+ *
+ * Built like the nibble writer below and for the same reason: the flush is a
+ * direct four-byte store rather than a call to write_N_bits. That one is
+ * generic - a branch on alignment up front and a per-byte loop inside - so
+ * every thirty-two bits cost a call doing four single-byte stores instead of
+ * one word-sized store.
+ *
+ * Bits sit in the accumulator most significant first, right aligned. Before an
+ * append there are fewer than thirty-two of them and a portion is at most
+ * thirty-two bits long, so sixty-four positions are always enough.
+ *
+ * If the stream does not sit on a byte boundary, the already started positions
+ * of the current byte are pulled into the accumulator. bitw_finish is mandatory
+ * before any other write to the same stream. */
+typedef struct bit_writer {
+    uint8_t* mem;
+    uint64_t acc;
+    uint32_t nbits;
+} bit_writer_t;
+
+static INLINE void bitw_init(bit_writer_t* w, bitstream_writer_t* bitstream) {
+    w->mem = bitstream->mem + bitstream->offset;
+    const uint32_t used = bitstream->bits_used;
+    if (used) {
+        w->acc = (uint64_t)(w->mem[0] >> (8 - used));
+        w->nbits = used;
+    }
+    else {
+        w->acc = 0;
+        w->nbits = 0;
+    }
+}
+
+/* len is at most thirty-two; value carries len significant positions on the
+ * right. */
+static INLINE void bitw_put(bit_writer_t* w, uint64_t value, uint32_t len) {
+    assert(len <= 32);
+    w->acc = (w->acc << len) | value;
+    w->nbits += len;
+    if (w->nbits >= 32) {
+        w->nbits -= 32;
+        const uint32_t be = (uint32_t)(w->acc >> w->nbits);
+        w->mem[0] = (uint8_t)(be >> 24);
+        w->mem[1] = (uint8_t)(be >> 16);
+        w->mem[2] = (uint8_t)(be >> 8);
+        w->mem[3] = (uint8_t)be;
+        w->mem += 4;
+        w->acc &= ((uint64_t)1 << w->nbits) - 1;
+    }
+}
+
+static INLINE void bitw_finish(bit_writer_t* w, bitstream_writer_t* bitstream) {
+    uint32_t n = w->nbits;
+    const uint64_t a = w->acc;
+    while (n >= 8) {
+        n -= 8;
+        w->mem[0] = (uint8_t)(a >> n);
+        w->mem++;
+    }
+    if (n) {
+        /* the tail is shorter than a byte: it is the high part of its byte, the
+         * low positions are written later */
+        w->mem[0] = (uint8_t)((a & (((uint64_t)1 << n) - 1)) << (8 - n));
+    }
+    bitstream->offset = (uint32_t)(w->mem - bitstream->mem);
+    bitstream->bits_used = n;
+}
+
 /* Nibble writer for packing group data.
  *
  * At this point the stream always sits on a nibble boundary, and

--- a/Source/Lib/Encoder/Codec/PackPrecinct.c
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.c
@@ -12,17 +12,45 @@
 #include "encoder_dsp_rtcd.h"
 #include "SvtLog.h"
 
+/* Significance flags go out in thirty-two bit words.
+ *
+ * Every flag is a single bit, and write_1_bit spent a call on it: a byte load,
+ * an insert of one position and a check for crossing the boundary. The inner
+ * loop folds the flags into a word with three operations per flag and does not
+ * touch the stream. */
 void pack_significance(bitstream_writer_t* bitstream, uint8_t gtli, uint8_t* significance_data_max_ptr, uint32_t width) {
-    for (uint32_t i = 0; i < width; i++) {
-        /*Flag 0 when used GCLI, 1 when significance group will be empty*/
-        write_1_bit(bitstream, (significance_data_max_ptr[i] <= gtli));
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
+    uint32_t i = 0;
+    for (; i + 32 <= width; i += 32) {
+        uint64_t word = 0;
+        for (uint32_t j = 0; j < 32; j++) {
+            /*Flag 0 when used GCLI, 1 when significance group will be empty*/
+            word = (word << 1) | (uint64_t)(significance_data_max_ptr[i + j] <= gtli);
+        }
+        bitw_put(&writer, word, 32);
     }
+    for (; i < width; i++) {
+        bitw_put(&writer, (uint64_t)(significance_data_max_ptr[i] <= gtli), 1);
+    }
+    bitw_finish(&writer, bitstream);
 }
 
 void pack_significance_compare(bitstream_writer_t* bitstream, uint8_t* significance_flags, uint32_t width) {
-    for (uint32_t i = 0; i < width; i++) {
-        write_1_bit(bitstream, significance_flags[i]);
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
+    uint32_t i = 0;
+    for (; i + 32 <= width; i += 32) {
+        uint64_t word = 0;
+        for (uint32_t j = 0; j < 32; j++) {
+            word = (word << 1) | (uint64_t)(significance_flags[i + j] != 0);
+        }
+        bitw_put(&writer, word, 32);
     }
+    for (; i < width; i++) {
+        bitw_put(&writer, (uint64_t)(significance_flags[i] != 0), 1);
+    }
+    bitw_finish(&writer, bitstream);
 }
 
 static void pack_bitplane_count_raw(bitstream_writer_t* bitstream, uint8_t* bitplane, uint32_t width) {
@@ -32,21 +60,21 @@ static void pack_bitplane_count_raw(bitstream_writer_t* bitstream, uint8_t* bitp
 }
 
 static void pack_bitplane_count_no_significance(bitstream_writer_t* bitstream, uint8_t* bitplane, uint32_t width, int8_t gtli) {
-    vlc_batch_t batch;
-    vlc_batch_init(&batch);
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
     for (uint32_t i = 0; i < width; i++) {
-        vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
+        vlc_put_unary(&writer, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
     }
-    vlc_batch_flush(bitstream, &batch);
+    bitw_finish(&writer, bitstream);
 }
 
 static void pack_bitplane_count_vpred_no_significance(bitstream_writer_t* bitstream, uint8_t* bitplane_bits, uint32_t width) {
-    vlc_batch_t batch;
-    vlc_batch_init(&batch);
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
     for (uint32_t i = 0; i < width; i++) {
-        vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
+        vlc_put_unary(&writer, bitplane_bits[i]);
     }
-    vlc_batch_flush(bitstream, &batch);
+    bitw_finish(&writer, bitstream);
 }
 
 static void pack_bitplane_count_vpred_significance(bitstream_writer_t* bitstream, uint8_t* bitplane_bits, uint32_t width,
@@ -55,22 +83,22 @@ static void pack_bitplane_count_vpred_significance(bitstream_writer_t* bitstream
     assert(group_size == SIGNIFICANCE_GROUP_SIZE);
     uint32_t groups = width / SIGNIFICANCE_GROUP_SIZE;
     uint32_t leftover = width % SIGNIFICANCE_GROUP_SIZE;
-    vlc_batch_t batch;
-    vlc_batch_init(&batch);
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
     for (uint32_t g = 0; g < groups; ++g) {
         if (!significance_flags[g]) {
             for (uint32_t i = 0; i < SIGNIFICANCE_GROUP_SIZE; ++i) {
-                vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
+                vlc_put_unary(&writer, bitplane_bits[i]);
             }
         }
         bitplane_bits += SIGNIFICANCE_GROUP_SIZE;
     }
     if (leftover && !significance_flags[groups]) {
         for (uint32_t i = 0; i < leftover; i++) {
-            vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
+            vlc_put_unary(&writer, bitplane_bits[i]);
         }
     }
-    vlc_batch_flush(bitstream, &batch);
+    bitw_finish(&writer, bitstream);
 }
 
 static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint8_t* bitplane, uint32_t width, int8_t gtli,
@@ -79,12 +107,12 @@ static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint
     assert(group_size == SIGNIFICANCE_GROUP_SIZE);
     uint32_t groups = width / SIGNIFICANCE_GROUP_SIZE;
     uint32_t leftover = width % SIGNIFICANCE_GROUP_SIZE;
-    vlc_batch_t batch;
-    vlc_batch_init(&batch);
+    bit_writer_t writer;
+    bitw_init(&writer, bitstream);
     for (uint32_t g = 0; g < groups; ++g) {
         if (significance_data_max_ptr[g] > gtli) {
             for (uint32_t i = 0; i < SIGNIFICANCE_GROUP_SIZE; ++i) {
-                vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
+                vlc_put_unary(&writer, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
             }
         }
         bitplane += SIGNIFICANCE_GROUP_SIZE;
@@ -92,11 +120,11 @@ static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint
     if (leftover) {
         if (significance_data_max_ptr[groups] > gtli) {
             for (uint32_t i = 0; i < leftover; i++) {
-                vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
+                vlc_put_unary(&writer, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
             }
         }
     }
-    vlc_batch_flush(bitstream, &batch);
+    bitw_finish(&writer, bitstream);
 }
 
 void pack_data_single_group_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t gcli, uint8_t gtli) {

--- a/Source/Lib/Encoder/Codec/PackPrecinct.c
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.c
@@ -123,6 +123,43 @@ void pack_data_single_group_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit
     }
 }
 
+/* The loop over the full groups of a line. It is dispatched as a whole: the
+ * nibble writer must live from the start of the line to its end, otherwise it
+ * would flush for nothing on every group. */
+void pack_data_groups_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups, uint8_t gtli,
+                        uint8_t sign_flag) {
+    nib_writer_t w;
+    nibw_init(&w, bitstream);
+    for (uint32_t group = 0; group < groups; group++) {
+        const uint8_t gcli = gclis[group];
+        if (gcli > gtli) {
+            if (sign_flag == 0) {
+                uint32_t signs = (buf_16bit[0] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 3);
+                signs |= (buf_16bit[1] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 2);
+                signs |= (buf_16bit[2] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 1);
+                signs |= (buf_16bit[3] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 0);
+                nibw_put(&w, signs);
+            }
+            uint16_t tmp[GROUP_SIZE];
+            for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+                tmp[i] = (uint16_t)((unsigned)buf_16bit[i] << ((BITSTREAM_BIT_POSITION_SIGN + 1) - gcli));
+            }
+            for (int32_t bits = ((int32_t)gcli - gtli - 1); bits >= 0; bits--) {
+                uint32_t val = (tmp[0] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 3);
+                val |= (tmp[1] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 2);
+                val |= (tmp[2] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 1);
+                val |= (tmp[3] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 0);
+                for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+                    tmp[i] = (uint16_t)((unsigned)tmp[i] << 1);
+                }
+                nibw_put(&w, val);
+            }
+        }
+        buf_16bit += GROUP_SIZE;
+    }
+    nibw_finish(&w, bitstream);
+}
+
 static void pack_data_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint32_t width, uint8_t* gclis, int32_t group_size,
                         uint8_t gtli, uint8_t sign_flag) {
     UNUSED(group_size);
@@ -130,21 +167,9 @@ static void pack_data_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint
     const uint32_t groups = DIV_ROUND_DOWN(width, GROUP_SIZE);
     const uint32_t leftover = width % GROUP_SIZE;
     if (sign_flag == 0) {
-        uint32_t group = 0;
-        uint8_t signs;
-        for (; group < groups; group++) {
-            if (gclis[group] > gtli) {
-                signs = (buf_16bit[0] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 3);
-                signs |= (buf_16bit[1] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 2);
-                signs |= (buf_16bit[2] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 1);
-                signs |= (buf_16bit[3] & BITSTREAM_MASK_SIGN) >> (BITSTREAM_BIT_POSITION_SIGN - 0);
-
-                write_4_bits_align4(bitstream, signs);
-
-                pack_data_single_group(bitstream, buf_16bit, gclis[group], gtli);
-            }
-            buf_16bit += GROUP_SIZE;
-        }
+        pack_data_groups(bitstream, buf_16bit, gclis, groups, gtli, sign_flag);
+        uint32_t group = groups;
+        buf_16bit += groups * GROUP_SIZE;
 
         if (leftover) {
             if (gclis[group] > gtli) {
@@ -170,13 +195,9 @@ static void pack_data_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint
         }
     }
     else {
-        uint32_t group = 0;
-        for (; group < groups; group++) {
-            if (gclis[group] > gtli) {
-                pack_data_single_group(bitstream, buf_16bit, gclis[group], gtli);
-            }
-            buf_16bit += GROUP_SIZE;
-        }
+        pack_data_groups(bitstream, buf_16bit, gclis, groups, gtli, sign_flag);
+        uint32_t group = groups;
+        buf_16bit += groups * GROUP_SIZE;
 
         if (leftover) {
             if (gclis[group] > gtli) {

--- a/Source/Lib/Encoder/Codec/PackPrecinct.c
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.c
@@ -32,20 +32,21 @@ static void pack_bitplane_count_raw(bitstream_writer_t* bitstream, uint8_t* bitp
 }
 
 static void pack_bitplane_count_no_significance(bitstream_writer_t* bitstream, uint8_t* bitplane, uint32_t width, int8_t gtli) {
+    vlc_batch_t batch;
+    vlc_batch_init(&batch);
     for (uint32_t i = 0; i < width; i++) {
-        if (bitplane[i] > gtli) {
-            vlc_encode_simple(bitstream, bitplane[i] - gtli);
-        }
-        else {
-            vlc_encode_simple(bitstream, 0);
-        }
+        vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
     }
+    vlc_batch_flush(bitstream, &batch);
 }
 
 static void pack_bitplane_count_vpred_no_significance(bitstream_writer_t* bitstream, uint8_t* bitplane_bits, uint32_t width) {
+    vlc_batch_t batch;
+    vlc_batch_init(&batch);
     for (uint32_t i = 0; i < width; i++) {
-        vlc_encode_pack_bits(bitstream, bitplane_bits[i]);
+        vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
     }
+    vlc_batch_flush(bitstream, &batch);
 }
 
 static void pack_bitplane_count_vpred_significance(bitstream_writer_t* bitstream, uint8_t* bitplane_bits, uint32_t width,
@@ -54,19 +55,22 @@ static void pack_bitplane_count_vpred_significance(bitstream_writer_t* bitstream
     assert(group_size == SIGNIFICANCE_GROUP_SIZE);
     uint32_t groups = width / SIGNIFICANCE_GROUP_SIZE;
     uint32_t leftover = width % SIGNIFICANCE_GROUP_SIZE;
+    vlc_batch_t batch;
+    vlc_batch_init(&batch);
     for (uint32_t g = 0; g < groups; ++g) {
         if (!significance_flags[g]) {
             for (uint32_t i = 0; i < SIGNIFICANCE_GROUP_SIZE; ++i) {
-                vlc_encode_pack_bits(bitstream, bitplane_bits[i]);
+                vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
             }
         }
         bitplane_bits += SIGNIFICANCE_GROUP_SIZE;
     }
     if (leftover && !significance_flags[groups]) {
         for (uint32_t i = 0; i < leftover; i++) {
-            vlc_encode_pack_bits(bitstream, bitplane_bits[i]);
+            vlc_batch_put(bitstream, &batch, bitplane_bits[i]);
         }
     }
+    vlc_batch_flush(bitstream, &batch);
 }
 
 static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint8_t* bitplane, uint32_t width, int8_t gtli,
@@ -75,15 +79,12 @@ static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint
     assert(group_size == SIGNIFICANCE_GROUP_SIZE);
     uint32_t groups = width / SIGNIFICANCE_GROUP_SIZE;
     uint32_t leftover = width % SIGNIFICANCE_GROUP_SIZE;
+    vlc_batch_t batch;
+    vlc_batch_init(&batch);
     for (uint32_t g = 0; g < groups; ++g) {
         if (significance_data_max_ptr[g] > gtli) {
             for (uint32_t i = 0; i < SIGNIFICANCE_GROUP_SIZE; ++i) {
-                if (bitplane[i] > gtli) {
-                    vlc_encode_simple(bitstream, bitplane[i] - gtli);
-                }
-                else {
-                    vlc_encode_simple(bitstream, 0);
-                }
+                vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
             }
         }
         bitplane += SIGNIFICANCE_GROUP_SIZE;
@@ -91,15 +92,11 @@ static void pack_bitplane_count_significance(bitstream_writer_t* bitstream, uint
     if (leftover) {
         if (significance_data_max_ptr[groups] > gtli) {
             for (uint32_t i = 0; i < leftover; i++) {
-                if (bitplane[i] > gtli) {
-                    vlc_encode_simple(bitstream, bitplane[i] - gtli);
-                }
-                else {
-                    vlc_encode_simple(bitstream, 0);
-                }
+                vlc_batch_put(bitstream, &batch, bitplane[i] > gtli ? (uint8_t)(bitplane[i] - gtli) : 0);
             }
         }
     }
+    vlc_batch_flush(bitstream, &batch);
 }
 
 void pack_data_single_group_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t gcli, uint8_t gtli) {

--- a/Source/Lib/Encoder/Codec/PackPrecinct.h
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.h
@@ -16,6 +16,9 @@ extern "C" {
 SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinct_enc_t* precinct,
                                 SignHandlingStrategy coding_signs_handling);
 
+void pack_data_groups_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups, uint8_t gtli,
+                        uint8_t sign_flag);
+
 /* Batched writing of unary codes.
  *
  * Every GCLI code is n ones and a terminating zero, that is from one to

--- a/Source/Lib/Encoder/Codec/PackPrecinct.h
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.h
@@ -19,49 +19,15 @@ SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinc
 void pack_data_groups_c(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups, uint8_t gtli,
                         uint8_t sign_flag);
 
-/* Batched writing of unary codes.
+/* A GCLI unary code: nbits ones and a terminating zero.
  *
- * Every GCLI code is n ones and a terminating zero, that is from one to
- * thirty-two bits, and each of them used to reach the stream through its own
- * write_N_bits call: a branch on alignment, a branch on length, a per-byte
- * store. There are hundreds of such calls per line.
- *
- * Here the codes are first glued together in a 64-bit accumulator and the
- * stream is touched once per thirty-two bits, that is about six times more
- * rarely (the average code is shorter than six bits). The accumulator keeps the
- * bits most significant first, right aligned; before an append it holds fewer
- * than thirty-two significant bits and a code is at most thirty-two bits long,
- * so sixty-four are always enough.
- *
- * Flushing the accumulator is mandatory before any other write to the same
- * stream. */
-typedef struct vlc_batch {
-    uint64_t acc;
-    uint32_t nbits;
-} vlc_batch_t;
-
-static INLINE void vlc_batch_init(vlc_batch_t* b) {
-    b->acc = 0;
-    b->nbits = 0;
-}
-
-static INLINE void vlc_batch_put(bitstream_writer_t* bitstream, vlc_batch_t* b, uint8_t nbits) {
+ * Written through bit_writer_t (see BitstreamWriter.h): the codes are glued
+ * together in an accumulator and the stream is touched once per thirty-two
+ * bits, that is about six times more rarely than with a separate call per code
+ * - the average code is shorter than six bits. */
+static INLINE void vlc_put_unary(bit_writer_t* w, uint8_t nbits) {
     assert(nbits < 32);
-    const uint32_t len = (uint32_t)nbits + 1;
-    const uint64_t code = (((uint64_t)1 << nbits) - 1) << 1;
-    b->acc = (b->acc << len) | code;
-    b->nbits += len;
-    if (b->nbits >= 32) {
-        b->nbits -= 32;
-        write_N_bits(bitstream, (uint32_t)(b->acc >> b->nbits), 32);
-    }
-}
-
-static INLINE void vlc_batch_flush(bitstream_writer_t* bitstream, vlc_batch_t* b) {
-    if (b->nbits) {
-        write_N_bits(bitstream, (uint32_t)(b->acc & ((((uint64_t)1) << b->nbits) - 1)), (uint8_t)b->nbits);
-        b->nbits = 0;
-    }
+    bitw_put(w, (((uint64_t)1 << nbits) - 1) << 1, (uint32_t)nbits + 1);
 }
 
 /*Variable Length Coding

--- a/Source/Lib/Encoder/Codec/PackPrecinct.h
+++ b/Source/Lib/Encoder/Codec/PackPrecinct.h
@@ -16,6 +16,51 @@ extern "C" {
 SvtJxsErrorType_t pack_precinct(bitstream_writer_t* bitstream, pi_t* pi, precinct_enc_t* precinct,
                                 SignHandlingStrategy coding_signs_handling);
 
+/* Batched writing of unary codes.
+ *
+ * Every GCLI code is n ones and a terminating zero, that is from one to
+ * thirty-two bits, and each of them used to reach the stream through its own
+ * write_N_bits call: a branch on alignment, a branch on length, a per-byte
+ * store. There are hundreds of such calls per line.
+ *
+ * Here the codes are first glued together in a 64-bit accumulator and the
+ * stream is touched once per thirty-two bits, that is about six times more
+ * rarely (the average code is shorter than six bits). The accumulator keeps the
+ * bits most significant first, right aligned; before an append it holds fewer
+ * than thirty-two significant bits and a code is at most thirty-two bits long,
+ * so sixty-four are always enough.
+ *
+ * Flushing the accumulator is mandatory before any other write to the same
+ * stream. */
+typedef struct vlc_batch {
+    uint64_t acc;
+    uint32_t nbits;
+} vlc_batch_t;
+
+static INLINE void vlc_batch_init(vlc_batch_t* b) {
+    b->acc = 0;
+    b->nbits = 0;
+}
+
+static INLINE void vlc_batch_put(bitstream_writer_t* bitstream, vlc_batch_t* b, uint8_t nbits) {
+    assert(nbits < 32);
+    const uint32_t len = (uint32_t)nbits + 1;
+    const uint64_t code = (((uint64_t)1 << nbits) - 1) << 1;
+    b->acc = (b->acc << len) | code;
+    b->nbits += len;
+    if (b->nbits >= 32) {
+        b->nbits -= 32;
+        write_N_bits(bitstream, (uint32_t)(b->acc >> b->nbits), 32);
+    }
+}
+
+static INLINE void vlc_batch_flush(bitstream_writer_t* bitstream, vlc_batch_t* b) {
+    if (b->nbits) {
+        write_N_bits(bitstream, (uint32_t)(b->acc & ((((uint64_t)1) << b->nbits) - 1)), (uint8_t)b->nbits);
+        b->nbits = 0;
+    }
+}
+
 /*Variable Length Coding
  * Params:
  * nbits - bits to coding

--- a/Source/Lib/Encoder/Codec/RateControl.c
+++ b/Source/Lib/Encoder/Codec/RateControl.c
@@ -16,6 +16,14 @@
 
 #define PRINT_RECALC_VPRED 0
 
+#ifndef NDEBUG
+/* Debug-only markers for the rate control cache tables that are filled only under
+ * a condition. Values no real sum can reach: the sign table holds bit counts for
+ * one band line, the significance table holds a count of groups in one band line. */
+#define RC_LUT_POISON_U32 0xFFFFFFFFu
+#define RC_LUT_POISON_U16 0xFFFFu
+#endif /*NDEBUG*/
+
 /* Histogram of GCLI values. The values lie in [0, TRUNCATION_MAX], so there are
  * exactly sixteen bins. The function fills the table completely, there is no
  * need to clear it from the outside.
@@ -54,7 +62,18 @@ static void rate_control_lut_fill(svt_jpeg_xs_encoder_common_t *enc_common,
                 /* Clearing the whole structure is gone: the histograms are written in
                  * full by their own kernels, and the derived tables below are filled
                  * for all sixteen indices. The sign table is left untouched in exactly
-                 * the branch where nobody reads it (coding_signs_handling == OFF). */
+                 * the branch where nobody reads it (coding_signs_handling == OFF).
+                 *
+                 * That makes the guard at each read site load bearing, so in debug
+                 * builds the two conditionally filled tables are poisoned here. A read
+                 * that is not covered by its guard then trips an assert instead of
+                 * silently using whatever the previous precinct left behind. */
+#ifndef NDEBUG
+                for (uint32_t i = 0; i <= TRUNCATION_MAX; ++i) {
+                    cache_line->gc_lookup_table_size_data_sign_handling[i] = RC_LUT_POISON_U32;
+                    cache_line->significance_max_lookup_table[i] = RC_LUT_POISON_U16;
+                }
+#endif /*NDEBUG*/
                 gc_histogram_16(gc_data, group_conding_width, gc_lookup_table);
 #if LUT_GC_SERIAL_SUMMATION
                 if (coding_signs_handling == SIGN_HANDLING_STRATEGY_OFF) {
@@ -176,6 +195,9 @@ static void rate_control_lut_summarize_non_significance_gc_and_data_code_sum(rc_
     if (coding_signs_handling) {
         uint32_t sum_non_significance_zero = table[gtli];
         uint32_t sum_data_no_signs = cache_line->gc_lookup_table_size_data_no_sign_handling[gtli];
+        /* Filled by rate_control_lut_fill() only when coding_signs_handling != OFF,
+         * which is the condition guarding this branch. */
+        assert(cache_line->gc_lookup_table_size_data_sign_handling[gtli] != RC_LUT_POISON_U32);
         uint32_t sum_data_signs = cache_line->gc_lookup_table_size_data_sign_handling[gtli];
         *out_sum_data = sum_data_signs;
         *sum_data_non_significance_code_gc = sum_data_no_signs + sum_non_significance_zero;
@@ -244,6 +266,9 @@ static void rate_control_lut_summarize_non_significance_gc_and_data_code_sum(rc_
 #if LUT_SIGNIFICANE
 static uint32_t rate_control_lut_significance_elements_less_equal_gtli(rc_cache_band_line_t *cache_line, int gtli) {
     uint16_t *table = cache_line->significance_max_lookup_table;
+    /* Filled by rate_control_lut_fill() only when coding_significance is set, which
+     * every caller of this function is required to have checked. */
+    assert(table[gtli] != RC_LUT_POISON_U16);
     /* Pseudo code unsigned significances:
      * GCLI value 0 is compressed by VLC on 1 bit so always can remove
      * from pack_size_gcli number of bits equal size significance group.

--- a/Source/Lib/Encoder/Codec/RateControl.c
+++ b/Source/Lib/Encoder/Codec/RateControl.c
@@ -16,6 +16,23 @@
 
 #define PRINT_RECALC_VPRED 0
 
+/* Histogram of GCLI values. The values lie in [0, TRUNCATION_MAX], so there are
+ * exactly sixteen bins. The function fills the table completely, there is no
+ * need to clear it from the outside.
+ * The scalar variant does a read-modify-write to memory per element, and when
+ * neighbouring values fall into the same bin (and GCLI is spatially correlated,
+ * so they often do) the processor stalls on store-to-load forwarding. The
+ * vector versions count all sixteen bins with compares and have no such
+ * dependency. */
+void gc_histogram_16_c(const uint8_t *data, uint32_t width, uint16_t *hist) {
+    memset(hist, 0, (TRUNCATION_MAX + 1) * sizeof(hist[0]));
+    for (uint32_t i = 0; i < width; i++) {
+        assert(data[i] <= TRUNCATION_MAX);
+        hist[data[i]]++;
+        assert(hist[data[i]] != 0);
+    }
+}
+
 static void rate_control_lut_fill(svt_jpeg_xs_encoder_common_t *enc_common,
 #if LUT_SIGNIFICANE
                                   uint8_t coding_significance,
@@ -32,14 +49,13 @@ static void rate_control_lut_fill(svt_jpeg_xs_encoder_common_t *enc_common,
             uint32_t height_lines = precinct->p_info->b_info[c][b].height;
             for (uint32_t line = 0; line < height_lines; ++line) {
                 rc_cache_band_line_t *cache_line = &precinct->bands[c][b].lines_common[line].rc_cache_line;
-                memset(cache_line, 0, sizeof(*cache_line));
                 uint8_t *gc_data = precinct->bands[c][b].lines_common[line].gcli_data_ptr;
                 uint16_t *gc_lookup_table = cache_line->gc_lookup_table;
-                for (uint32_t i = 0; i < group_conding_width; i++) {
-                    assert(gc_data[i] <= TRUNCATION_MAX);
-                    gc_lookup_table[gc_data[i]]++;
-                    assert(gc_lookup_table[gc_data[i]] != 0);
-                }
+                /* Clearing the whole structure is gone: the histograms are written in
+                 * full by their own kernels, and the derived tables below are filled
+                 * for all sixteen indices. The sign table is left untouched in exactly
+                 * the branch where nobody reads it (coding_signs_handling == OFF). */
+                gc_histogram_16(gc_data, group_conding_width, gc_lookup_table);
 #if LUT_GC_SERIAL_SUMMATION
                 if (coding_signs_handling == SIGN_HANDLING_STRATEGY_OFF) {
                     uint32_t *gc_lookup_table_size_data_no_sign_handling = cache_line->gc_lookup_table_size_data_no_sign_handling;
@@ -110,11 +126,7 @@ static void rate_control_lut_fill(svt_jpeg_xs_encoder_common_t *enc_common,
                     uint8_t *significance_data_max_ptr = precinct->bands[c][b].lines_common[line].significance_data_max_ptr;
                     const uint32_t full_group = group_conding_width / pi->significance_group_size;
                     uint16_t *significance_max_lookup_table = cache_line->significance_max_lookup_table;
-                    for (uint32_t i = 0; i < full_group; i++) {
-                        assert(significance_data_max_ptr[i] <= TRUNCATION_MAX);
-                        significance_max_lookup_table[significance_data_max_ptr[i]]++;
-                        assert(cache_line->significance_max_lookup_table[significance_data_max_ptr[i]] != 0);
-                    }
+                    gc_histogram_16(significance_data_max_ptr, full_group, significance_max_lookup_table);
 #if LUT_SIGNIFICANE_SERIAL_SUMMATION
                     uint16_t summary = 0;
                     for (uint32_t i = 0; i <= TRUNCATION_MAX; ++i) {

--- a/Source/Lib/Encoder/Codec/RateControl.h
+++ b/Source/Lib/Encoder/Codec/RateControl.h
@@ -12,6 +12,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+void gc_histogram_16_c(const uint8_t *data, uint32_t width, uint16_t *hist);
 
 struct PictureControlSet;
 

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -91,13 +91,25 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
 #ifdef ARCH_X86_64
     /** Should be done during library initialization,
       but for safe limiting cpu flags again. */
-    flags &= get_cpu_flags();
+    const CPU_FLAGS host_flags = get_cpu_flags();
+    flags &= host_flags;
     /* The AVX-512 kernels are built with -mpopcnt and -mbmi2 for the whole directory, so
      * the compiler is free to emit those instructions anywhere in them, not
      * only where an intrinsic asks for them. Without a processor to back
-     * them the whole tier has to stay unused. */
-    if ((flags & (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) != (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) {
+     * them the whole tier has to stay unused.
+     *
+     * The test is on the host, not on the caller's request: a caller built
+     * against an older header passes a mask with these bits clear, and it must
+     * not lose AVX-512 on hardware that supports it. */
+    if ((host_flags & (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) != (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) {
         flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX512F;
+    }
+    /* The AVX2 directory is built with -mpopcnt as well, and RateControl_avx2.c
+     * asks for POPCNT by intrinsic, so the same rule applies one tier down.
+     * Every processor with AVX2 also has POPCNT, so this only matters where a
+     * hypervisor or emulator masks the feature bits apart. */
+    if (!(host_flags & CPU_FLAGS_POPCNT)) {
+        flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX2;
     }
     // to use C: flags=0
 #else

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -19,6 +19,7 @@
 #include "Quant.h"
 #include "PackPrecinct.h"
 #include "Pack_avx512.h"
+#include "Pack_avx2.h"
 #include "group_coding_sse4_1.h"
 #include "RateControl.h"
 #include "RateControl_avx2.h"
@@ -152,7 +153,7 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
                     linear_input_scaling_line_16bit_msb_avx2,
                     linear_input_scaling_line_16bit_msb_avx512);
 
-    SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, NULL, pack_data_single_group_avx512);
+    SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, pack_data_single_group_avx2, pack_data_single_group_avx512);
     SET_SSE2(gc_precinct_stage_scalar_loop, gc_precinct_stage_scalar_loop_c, gc_precinct_stage_scalar_loop_ASM);
     SET_AVX2_AVX512(gc_histogram_16, gc_histogram_16_c, gc_histogram_16_avx2, gc_histogram_16_avx512);
     SET_SSE41(gc_precinct_sigflags_max, gc_precinct_sigflags_max_c, gc_precinct_sigflags_max_sse4_1);

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -91,6 +91,13 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
       but for safe limiting cpu flags again. */
     flags &= get_cpu_flags();
+    /* The AVX-512 kernels are built with -mpopcnt for the whole directory, so
+     * the compiler is free to emit those instructions anywhere in them, not
+     * only where an intrinsic asks for them. Without a processor to back
+     * them the whole tier has to stay unused. */
+    if (!(flags & CPU_FLAGS_POPCNT)) {
+        flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX512F;
+    }
     // to use C: flags=0
 #else
     (void)flags;
@@ -147,6 +154,7 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
 
     SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, NULL, pack_data_single_group_avx512);
     SET_SSE2(gc_precinct_stage_scalar_loop, gc_precinct_stage_scalar_loop_c, gc_precinct_stage_scalar_loop_ASM);
+    SET_AVX2_AVX512(gc_histogram_16, gc_histogram_16_c, gc_histogram_16_avx2, gc_histogram_16_avx512);
     SET_SSE41(gc_precinct_sigflags_max, gc_precinct_sigflags_max_c, gc_precinct_sigflags_max_sse4_1);
     SET_AVX2_AVX512(rate_control_calc_vpred_cost_nosigf,
                     rate_control_calc_vpred_cost_nosigf_c,

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -92,11 +92,11 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
       but for safe limiting cpu flags again. */
     flags &= get_cpu_flags();
-    /* The AVX-512 kernels are built with -mpopcnt for the whole directory, so
+    /* The AVX-512 kernels are built with -mpopcnt and -mbmi2 for the whole directory, so
      * the compiler is free to emit those instructions anywhere in them, not
      * only where an intrinsic asks for them. Without a processor to back
      * them the whole tier has to stay unused. */
-    if (!(flags & CPU_FLAGS_POPCNT)) {
+    if ((flags & (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) != (CPU_FLAGS_POPCNT | CPU_FLAGS_BMI2)) {
         flags &= ~(CPU_FLAGS)CPU_FLAGS_AVX512F;
     }
     // to use C: flags=0
@@ -155,7 +155,7 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
 
     SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, pack_data_single_group_avx2, pack_data_single_group_avx512);
     SET_SSE2(gc_precinct_stage_scalar_loop, gc_precinct_stage_scalar_loop_c, gc_precinct_stage_scalar_loop_ASM);
-    SET_AVX2(pack_data_groups, pack_data_groups_c, pack_data_groups_avx2);
+    SET_AVX2_AVX512(pack_data_groups, pack_data_groups_c, pack_data_groups_avx2, pack_data_groups_avx512);
     SET_AVX2_AVX512(gc_histogram_16, gc_histogram_16_c, gc_histogram_16_avx2, gc_histogram_16_avx512);
     SET_SSE41(gc_precinct_sigflags_max, gc_precinct_sigflags_max_c, gc_precinct_sigflags_max_sse4_1);
     SET_AVX2_AVX512(rate_control_calc_vpred_cost_nosigf,

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.c
@@ -155,6 +155,7 @@ void setup_encoder_rtcd_internal(CPU_FLAGS flags) {
 
     SET_AVX2_AVX512(pack_data_single_group, pack_data_single_group_c, pack_data_single_group_avx2, pack_data_single_group_avx512);
     SET_SSE2(gc_precinct_stage_scalar_loop, gc_precinct_stage_scalar_loop_c, gc_precinct_stage_scalar_loop_ASM);
+    SET_AVX2(pack_data_groups, pack_data_groups_c, pack_data_groups_avx2);
     SET_AVX2_AVX512(gc_histogram_16, gc_histogram_16_c, gc_histogram_16_avx2, gc_histogram_16_avx512);
     SET_SSE41(gc_precinct_sigflags_max, gc_precinct_sigflags_max_c, gc_precinct_sigflags_max_sse4_1);
     SET_AVX2_AVX512(rate_control_calc_vpred_cost_nosigf,

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
@@ -73,6 +73,9 @@ RTCD_EXTERN void (*transform_vertical_loop_lf_hf_hf_line_x)(uint32_t width, int3
 RTCD_EXTERN void (*transform_vertical_loop_lf_hf_hf_line_last_even)(uint32_t width, int32_t* out_lf, int32_t* out_hf,
                                                                     const int32_t* in_hf_prev, const int32_t* line_0,
                                                                     const int32_t* line_1);
+RTCD_EXTERN void (*pack_data_groups)(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups,
+                                     uint8_t gtli, uint8_t sign_flag);
+
 RTCD_EXTERN void (*gc_histogram_16)(const uint8_t* data, uint32_t width, uint16_t* hist);
 
 RTCD_EXTERN void (*gc_precinct_sigflags_max)(uint8_t* significance_data_max_ptr, uint8_t* gcli_data_ptr, uint32_t group_sign_size,

--- a/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/encoder_dsp_rtcd.h
@@ -73,6 +73,8 @@ RTCD_EXTERN void (*transform_vertical_loop_lf_hf_hf_line_x)(uint32_t width, int3
 RTCD_EXTERN void (*transform_vertical_loop_lf_hf_hf_line_last_even)(uint32_t width, int32_t* out_lf, int32_t* out_hf,
                                                                     const int32_t* in_hf_prev, const int32_t* line_0,
                                                                     const int32_t* line_1);
+RTCD_EXTERN void (*gc_histogram_16)(const uint8_t* data, uint32_t width, uint16_t* hist);
+
 RTCD_EXTERN void (*gc_precinct_sigflags_max)(uint8_t* significance_data_max_ptr, uint8_t* gcli_data_ptr, uint32_t group_sign_size,
                                              uint32_t gcli_width);
 RTCD_EXTERN uint32_t (*rate_control_calc_vpred_cost_nosigf)(uint32_t gcli_width, uint8_t* gcli_data_top_ptr,

--- a/tests/UnitTests/TestBitstreamReadWrite.cc
+++ b/tests/UnitTests/TestBitstreamReadWrite.cc
@@ -254,3 +254,175 @@ TEST(BitstreamReadWrite, update_N_bits) {
     }
     free(bitstream_mem);
 }
+
+/* The two accumulating writers of the packing path.
+ *
+ * Both exist only to spare the stream a call per bit or per nibble, so the one
+ * thing that has to hold is that they are indistinguishable from the generic
+ * writers they replace: the same bytes, the same offset, the same number of
+ * used bits - including when the line starts in the middle of a byte and when
+ * it ends there. */
+
+#define ACC_WRITER_BUF_SIZE 512
+
+/* Both streams are started the same way, so the state the accumulator picks up
+ * in its init is the state the reference writer left behind.
+ *
+ * The buffers are cleared after the init and not before it: a debug build fills
+ * them with 0xFF in there, and write_4_bits_align4 only ORs its nibble into the
+ * second half of a byte - what was left in the first half would then be part of
+ * the answer. */
+static void acc_writer_prepare(bitstream_writer_t* ref, bitstream_writer_t* cmp, uint8_t* mem_ref, uint8_t* mem_cmp,
+                               uint32_t prefix_bits, uint32_t prefix_value) {
+    bitstream_writer_init(ref, mem_ref, ACC_WRITER_BUF_SIZE);
+    bitstream_writer_init(cmp, mem_cmp, ACC_WRITER_BUF_SIZE);
+    memset(mem_ref, 0, ACC_WRITER_BUF_SIZE);
+    memset(mem_cmp, 0, ACC_WRITER_BUF_SIZE);
+    if (prefix_bits) {
+        /* write_N_bits takes exactly as many significant positions as it is told */
+        prefix_value &= (1u << prefix_bits) - 1;
+        write_N_bits(ref, prefix_value, (uint8_t)prefix_bits);
+        write_N_bits(cmp, prefix_value, (uint8_t)prefix_bits);
+    }
+}
+
+TEST(BitstreamWriteAccumulators, bit_writer_matches_write_N_bits) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t* mem_ref = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    uint8_t* mem_cmp = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL);
+
+    for (uint32_t prefix_bits = 0; prefix_bits < 8; prefix_bits++) {
+        for (uint32_t test_num = 0; test_num < 300; test_num++) {
+            const uint32_t portions = 1 + rnd->Rand8() % 40;
+            uint32_t lens[40];
+            uint32_t values[40];
+            for (uint32_t i = 0; i < portions; i++) {
+                lens[i] = 1 + rnd->Rand8() % 32;
+                const uint32_t raw = ((uint32_t)rnd->Rand16() << 16) | rnd->Rand16();
+                values[i] = lens[i] == 32 ? raw : (raw & ((1u << lens[i]) - 1));
+            }
+
+            bitstream_writer_t ref, cmp;
+            acc_writer_prepare(&ref, &cmp, mem_ref, mem_cmp, prefix_bits, rnd->Rand8());
+
+            for (uint32_t i = 0; i < portions; i++) {
+                write_N_bits(&ref, values[i], (uint8_t)lens[i]);
+            }
+
+            bit_writer_t w;
+            bitw_init(&w, &cmp);
+            for (uint32_t i = 0; i < portions; i++) {
+                bitw_put(&w, values[i], lens[i]);
+            }
+            bitw_finish(&w, &cmp);
+
+            ASSERT_EQ(ref.offset, cmp.offset);
+            ASSERT_EQ(ref.bits_used, cmp.bits_used);
+            ASSERT_EQ(memcmp(mem_ref, mem_cmp, ACC_WRITER_BUF_SIZE), 0);
+        }
+    }
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}
+
+TEST(BitstreamWriteAccumulators, nibble_writer_matches_write_4_bits_align4) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t* mem_ref = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    uint8_t* mem_cmp = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL);
+
+    /* write_4_bits_align4 is only defined on a nibble boundary, and so is the
+     * accumulator: a line always starts on one. */
+    for (uint32_t prefix_bits = 0; prefix_bits <= 4; prefix_bits += 4) {
+        for (uint32_t test_num = 0; test_num < 500; test_num++) {
+            const uint32_t count = rnd->Rand8() % 200;
+            uint8_t nibbles[200];
+            for (uint32_t i = 0; i < count; i++) {
+                nibbles[i] = (uint8_t)(rnd->Rand8() & 0xF);
+            }
+
+            bitstream_writer_t ref, cmp;
+            acc_writer_prepare(&ref, &cmp, mem_ref, mem_cmp, prefix_bits, rnd->Rand8() & 0xF);
+
+            for (uint32_t i = 0; i < count; i++) {
+                write_4_bits_align4(&ref, nibbles[i]);
+            }
+
+            nib_writer_t w;
+            nibw_init(&w, &cmp);
+            for (uint32_t i = 0; i < count; i++) {
+                nibw_put(&w, nibbles[i]);
+            }
+            nibw_finish(&w, &cmp);
+
+            ASSERT_EQ(ref.offset, cmp.offset);
+            ASSERT_EQ(ref.bits_used, cmp.bits_used);
+            ASSERT_EQ(memcmp(mem_ref, mem_cmp, ACC_WRITER_BUF_SIZE), 0);
+        }
+    }
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}
+
+/* The batch entries have to be the same as the nibbles fed one by one: the
+ * group packer hands over a whole group in a single call, up to fifteen planes
+ * and a sign. */
+TEST(BitstreamWriteAccumulators, nibble_writer_batches_match_single_nibbles) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t* mem_ref = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    uint8_t* mem_cmp = (uint8_t*)malloc(ACC_WRITER_BUF_SIZE);
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL);
+
+    for (uint32_t use_group = 0; use_group < 2; use_group++) {
+        const uint32_t max_count = use_group ? 16 : 8;
+        for (uint32_t prefix_bits = 0; prefix_bits <= 4; prefix_bits += 4) {
+            for (uint32_t test_num = 0; test_num < 500; test_num++) {
+                const uint32_t batches = 1 + rnd->Rand8() % 20;
+                uint32_t counts[20];
+                uint64_t words[20];
+                for (uint32_t i = 0; i < batches; i++) {
+                    counts[i] = 1 + rnd->Rand8() % max_count;
+                    uint64_t w = 0;
+                    for (uint32_t j = 0; j < counts[i]; j++) {
+                        w = (w << 4) | (rnd->Rand8() & 0xF);
+                    }
+                    words[i] = w;
+                }
+
+                bitstream_writer_t ref, cmp;
+                acc_writer_prepare(&ref, &cmp, mem_ref, mem_cmp, prefix_bits, rnd->Rand8() & 0xF);
+
+                nib_writer_t w_ref;
+                nibw_init(&w_ref, &ref);
+                for (uint32_t i = 0; i < batches; i++) {
+                    for (uint32_t j = counts[i]; j > 0; j--) {
+                        nibw_put(&w_ref, (uint32_t)((words[i] >> (4 * (j - 1))) & 0xF));
+                    }
+                }
+                nibw_finish(&w_ref, &ref);
+
+                nib_writer_t w_cmp;
+                nibw_init(&w_cmp, &cmp);
+                for (uint32_t i = 0; i < batches; i++) {
+                    if (use_group) {
+                        nibw_put_group(&w_cmp, words[i], counts[i]);
+                    }
+                    else {
+                        nibw_put_chunk(&w_cmp, words[i], counts[i]);
+                    }
+                }
+                nibw_finish(&w_cmp, &cmp);
+
+                ASSERT_EQ(ref.offset, cmp.offset);
+                ASSERT_EQ(ref.bits_used, cmp.bits_used);
+                ASSERT_EQ(memcmp(mem_ref, mem_cmp, ACC_WRITER_BUF_SIZE), 0);
+            }
+        }
+    }
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}

--- a/tests/UnitTests/TestPack.cc
+++ b/tests/UnitTests/TestPack.cc
@@ -11,6 +11,9 @@
 #include "PackPrecinct.h"
 #include "SvtUtility.h"
 #include "encoder_dsp_rtcd.h"
+#include "Pack_avx2.h"
+#include "pack_group_helper.h"
+#include "EncDec.h" /* TRUNCATION_MAX */
 
 TEST(pack_data_single_group, AVX512) {
     if (!(CPU_FLAGS_AVX512F & get_cpu_flags())) {
@@ -195,5 +198,370 @@ TEST(rate_control_calc_vpred_cost_sigf_nosigf_, AVX512) {
     free(out_bits_mod);
     free(out_sigf_ref);
     free(out_sigf_mod);
+    delete rnd;
+}
+
+/* Packing one group with the 128-bit implementation shared by AVX2 and
+ * AVX-512. The AVX-512 wrapper has had a test since the beginning; the AVX2 one
+ * is the same code behind a different name, and it had none. */
+TEST(pack_data_single_group, AVX2) {
+    const uint32_t max_buff_size = 50;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint8_t* mem_ref = (uint8_t*)malloc(max_buff_size);
+    uint8_t* mem_cmp = (uint8_t*)malloc(max_buff_size);
+    uint16_t* buf = (uint16_t*)malloc(max_buff_size * sizeof(uint16_t));
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL && buf != NULL);
+
+    for (uint32_t test_num = 0; test_num < 1000; test_num++) {
+        memset(mem_ref, 0xff, max_buff_size);
+        memset(mem_cmp, 0xff, max_buff_size);
+        bitstream_writer_t ref, cmp;
+        bitstream_writer_init(&ref, mem_ref, max_buff_size);
+        bitstream_writer_init(&cmp, mem_cmp, max_buff_size);
+        ref.bits_used = cmp.bits_used = rnd->Rand8() % 2 ? 0 : 4;
+
+        for (uint32_t i = 0; i < max_buff_size; i++) {
+            int32_t sign = rnd->Rand16() % 2;
+            buf[i] = (uint16_t)(sign ? rnd->Rand16() : -rnd->Rand16());
+        }
+
+        uint8_t gtli = rnd->Rand8() % 15;
+        uint8_t gcli = gtli + rnd->Rand8() % (15 - gtli);
+
+        pack_data_single_group_c(&ref, buf, gcli, gtli);
+        pack_data_single_group_avx2(&cmp, buf, gcli, gtli);
+
+        ASSERT_EQ(ref.offset, cmp.offset);
+        ASSERT_EQ(ref.bits_used, cmp.bits_used);
+        ASSERT_EQ(memcmp(mem_ref, mem_cmp, max_buff_size), 0);
+    }
+
+    free(mem_ref);
+    free(mem_cmp);
+    free(buf);
+    delete rnd;
+}
+
+/* The shared 128-bit implementation itself, reached by its own name rather
+ * than through either wrapper. */
+TEST(pack_group_helper, data_single_group_sse_matches_c) {
+    const uint32_t max_buff_size = 50;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint8_t* mem_ref = (uint8_t*)malloc(max_buff_size);
+    uint8_t* mem_cmp = (uint8_t*)malloc(max_buff_size);
+    uint16_t* buf = (uint16_t*)malloc(max_buff_size * sizeof(uint16_t));
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL && buf != NULL);
+
+    for (uint32_t test_num = 0; test_num < 1000; test_num++) {
+        memset(mem_ref, 0xff, max_buff_size);
+        memset(mem_cmp, 0xff, max_buff_size);
+        bitstream_writer_t ref, cmp;
+        bitstream_writer_init(&ref, mem_ref, max_buff_size);
+        bitstream_writer_init(&cmp, mem_cmp, max_buff_size);
+        ref.bits_used = cmp.bits_used = rnd->Rand8() % 2 ? 0 : 4;
+
+        for (uint32_t i = 0; i < max_buff_size; i++) {
+            buf[i] = (uint16_t)rnd->Rand16();
+        }
+
+        const uint8_t gtli = (uint8_t)(rnd->Rand8() % TRUNCATION_MAX);
+        const uint8_t gcli = (uint8_t)(gtli + rnd->Rand8() % (TRUNCATION_MAX - gtli));
+
+        pack_data_single_group_c(&ref, buf, gcli, gtli);
+        pack_data_single_group_sse(&cmp, buf, gcli, gtli);
+
+        ASSERT_EQ(ref.offset, cmp.offset);
+        ASSERT_EQ(ref.bits_used, cmp.bits_used);
+        ASSERT_EQ(memcmp(mem_ref, mem_cmp, max_buff_size), 0);
+    }
+
+    free(mem_ref);
+    free(mem_cmp);
+    free(buf);
+    delete rnd;
+}
+
+/* The nibble of a bit plane: bit (3 - k) belongs to coefficient k. */
+static uint32_t group_plane_nibble_ref(const uint16_t* buf, uint32_t plane) {
+    uint32_t nibble = 0;
+    for (uint32_t k = 0; k < GROUP_SIZE; k++) {
+        nibble |= ((buf[k] >> plane) & 1) << (3 - k);
+    }
+    return nibble;
+}
+
+/* The lane reversal and the sign mask that stand in for a horizontal fold. The
+ * sign nibble is the plane of weight 2^15, so one reference serves both. */
+TEST(pack_group_helper, load_reversed_and_nibble) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    for (uint32_t test_num = 0; test_num < 10000; test_num++) {
+        uint16_t buf[GROUP_SIZE];
+        for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+            buf[i] = (uint16_t)rnd->Rand16();
+        }
+        const __m128i reversed = pack_group_load_reversed(buf);
+        ASSERT_EQ(group_plane_nibble_ref(buf, 15), pack_group_nibble(reversed));
+
+        /* the reversal itself: lane k has to hold coefficient 3 - k */
+        uint16_t lanes[8];
+        _mm_storeu_si128((__m128i*)lanes, reversed);
+        for (uint32_t k = 0; k < GROUP_SIZE; k++) {
+            ASSERT_EQ(buf[GROUP_SIZE - 1 - k], lanes[k]);
+        }
+    }
+    delete rnd;
+}
+
+/* All the planes of a group in one word, the top plane in the top nibble. */
+TEST(pack_group_helper, planes_word_matches_reference) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    for (uint32_t gcli = 1; gcli <= TRUNCATION_MAX; gcli++) {
+        for (uint32_t gtli = 0; gtli < gcli; gtli++) {
+            for (uint32_t test_num = 0; test_num < 100; test_num++) {
+                uint16_t buf[GROUP_SIZE];
+                for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+                    buf[i] = (uint16_t)rnd->Rand16();
+                }
+                uint64_t ref = 0;
+                for (int32_t plane = (int32_t)gcli - 1; plane >= (int32_t)gtli; plane--) {
+                    ref = (ref << 4) | group_plane_nibble_ref(buf, (uint32_t)plane);
+                }
+                ASSERT_EQ(ref, pack_group_planes_word(pack_group_load_reversed(buf), (uint8_t)gcli, (uint8_t)gtli));
+            }
+        }
+    }
+    delete rnd;
+}
+
+/* The mask of non-empty groups, including a partial chunk at the end of a line:
+ * the padding must not add groups that do not exist. */
+TEST(pack_group_helper, nonempty_mask_matches_reference) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t gclis[32];
+    for (uint32_t chunk = 1; chunk <= 32; chunk++) {
+        for (uint32_t gtli = 0; gtli <= TRUNCATION_MAX; gtli++) {
+            for (uint32_t test_num = 0; test_num < 200; test_num++) {
+                uint64_t ref = 0;
+                for (uint32_t i = 0; i < chunk; i++) {
+                    gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+                    if (gclis[i] > gtli) {
+                        ref |= (uint64_t)1 << i;
+                    }
+                }
+                ASSERT_EQ(ref, pack_nonempty_mask(gclis, chunk, (uint8_t)gtli));
+            }
+        }
+    }
+    delete rnd;
+}
+
+#define PACK_GROUPS_MAX_GROUPS 70
+#define PACK_GROUPS_BUF_SIZE   1024
+
+typedef void (*pack_data_groups_fn)(bitstream_writer_t* bitstream, uint16_t* buf_16bit, uint8_t* gclis, uint32_t groups,
+                                    uint8_t gtli, uint8_t sign_flag);
+
+/* An independent reference: the definition of a packed line, nibble by nibble
+ * through the generic writer. Every implementation - the scalar one included -
+ * is checked against this rather than against another implementation, so the
+ * whole family cannot agree on a wrong answer.
+ *
+ * sign_flag zero means the signs travel with the data, as one more nibble in
+ * front of the planes of the group. */
+static void pack_data_groups_ref(bitstream_writer_t* bitstream, const uint16_t* buf_16bit, const uint8_t* gclis, uint32_t groups,
+                                 uint8_t gtli, uint8_t sign_flag) {
+    for (uint32_t group = 0; group < groups; group++) {
+        const uint8_t gcli = gclis[group];
+        const uint16_t* g = buf_16bit + (size_t)group * GROUP_SIZE;
+        if (gcli > gtli) {
+            if (sign_flag == 0) {
+                write_4_bits_align4(bitstream, (uint8_t)group_plane_nibble_ref(g, BITSTREAM_BIT_POSITION_SIGN));
+            }
+            for (int32_t plane = (int32_t)gcli - 1; plane >= (int32_t)gtli; plane--) {
+                write_4_bits_align4(bitstream, (uint8_t)group_plane_nibble_ref(g, (uint32_t)plane));
+            }
+        }
+    }
+}
+
+/* A line of full groups packed by the reference and by the implementation under
+ * test have to be the same bits.
+ *
+ * The line is walked in chunks of thirty-two groups, so seventy groups cover a
+ * full chunk, a second one and a partial third; the start is put on both halves
+ * of a byte because the nibble writer picks the stream up mid-byte. */
+static void pack_data_groups_test(pack_data_groups_fn pack_cmp) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint16_t* buf = (uint16_t*)malloc(PACK_GROUPS_MAX_GROUPS * GROUP_SIZE * sizeof(uint16_t));
+    uint8_t* gclis = (uint8_t*)malloc(PACK_GROUPS_MAX_GROUPS);
+    uint8_t* mem_ref = (uint8_t*)malloc(PACK_GROUPS_BUF_SIZE);
+    uint8_t* mem_cmp = (uint8_t*)malloc(PACK_GROUPS_BUF_SIZE);
+    ASSERT_TRUE(buf != NULL && gclis != NULL && mem_ref != NULL && mem_cmp != NULL);
+
+    for (uint32_t groups = 0; groups <= PACK_GROUPS_MAX_GROUPS; groups++) {
+        for (uint32_t test_num = 0; test_num < 20; test_num++) {
+            const uint8_t gtli = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            for (uint32_t i = 0; i < groups; i++) {
+                /* a mix of empty and non-empty groups, which is what the mask walk
+                 * is there for */
+                gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            }
+            for (uint32_t i = 0; i < groups * GROUP_SIZE; i++) {
+                buf[i] = (uint16_t)rnd->Rand16();
+            }
+            const uint8_t sign_flag = (uint8_t)(rnd->Rand8() % 2);
+
+            bitstream_writer_t ref, cmp;
+            bitstream_writer_init(&ref, mem_ref, PACK_GROUPS_BUF_SIZE);
+            bitstream_writer_init(&cmp, mem_cmp, PACK_GROUPS_BUF_SIZE);
+            /* after the init: a debug build fills the buffer with 0xFF in there,
+             * and the nibble written into the second half of a byte is ORed into
+             * whatever the first half holds */
+            memset(mem_ref, 0, PACK_GROUPS_BUF_SIZE);
+            memset(mem_cmp, 0, PACK_GROUPS_BUF_SIZE);
+            const uint8_t start_bits_used = (uint8_t)(rnd->Rand8() % 2 ? 4 : 0);
+            ref.bits_used = cmp.bits_used = start_bits_used;
+
+            pack_data_groups_ref(&ref, buf, gclis, groups, gtli, sign_flag);
+            pack_cmp(&cmp, buf, gclis, groups, gtli, sign_flag);
+
+            ASSERT_EQ(ref.offset, cmp.offset);
+            ASSERT_EQ(ref.bits_used, cmp.bits_used);
+            ASSERT_EQ(memcmp(mem_ref, mem_cmp, PACK_GROUPS_BUF_SIZE), 0);
+        }
+    }
+
+    free(buf);
+    free(gclis);
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}
+
+TEST(pack_data_groups, C) {
+    pack_data_groups_test(pack_data_groups_c);
+}
+
+TEST(pack_data_groups, AVX2) {
+    pack_data_groups_test(pack_data_groups_avx2);
+}
+
+TEST(pack_data_groups, AVX512) {
+    /* the same pair of conditions the encoder dispatch checks: the directory is
+     * built with -mbmi2 and -mpopcnt */
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2 | CPU_FLAGS_POPCNT;
+    if ((get_cpu_flags() & required) != required) {
+        GTEST_SKIP();
+    }
+    pack_data_groups_test(pack_data_groups_avx512);
+}
+
+/* The line packer that walks the mask, called directly rather than through the
+ * dispatched wrapper: the wrapper only owns the nibble writer around it. */
+TEST(pack_group_helper, groups_masked_matches_reference) {
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint16_t* buf = (uint16_t*)malloc(PACK_GROUPS_MAX_GROUPS * GROUP_SIZE * sizeof(uint16_t));
+    uint8_t* gclis = (uint8_t*)malloc(PACK_GROUPS_MAX_GROUPS);
+    uint8_t* mem_ref = (uint8_t*)malloc(PACK_GROUPS_BUF_SIZE);
+    uint8_t* mem_cmp = (uint8_t*)malloc(PACK_GROUPS_BUF_SIZE);
+    ASSERT_TRUE(buf != NULL && gclis != NULL && mem_ref != NULL && mem_cmp != NULL);
+
+    for (uint32_t groups = 0; groups <= PACK_GROUPS_MAX_GROUPS; groups += 3) {
+        for (uint32_t emit_signs = 0; emit_signs < 2; emit_signs++) {
+            for (uint32_t test_num = 0; test_num < 50; test_num++) {
+                const uint8_t gtli = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+                for (uint32_t i = 0; i < groups; i++) {
+                    gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+                }
+                for (uint32_t i = 0; i < groups * GROUP_SIZE; i++) {
+                    buf[i] = (uint16_t)rnd->Rand16();
+                }
+
+                bitstream_writer_t ref, cmp;
+                bitstream_writer_init(&ref, mem_ref, PACK_GROUPS_BUF_SIZE);
+                bitstream_writer_init(&cmp, mem_cmp, PACK_GROUPS_BUF_SIZE);
+                memset(mem_ref, 0, PACK_GROUPS_BUF_SIZE);
+                memset(mem_cmp, 0, PACK_GROUPS_BUF_SIZE);
+
+                /* sign_flag is inverted with respect to emit_signs: zero means the
+                 * signs are written here rather than by unpack_sign later */
+                pack_data_groups_ref(&ref, buf, gclis, groups, gtli, (uint8_t)(emit_signs ? 0 : 1));
+
+                nib_writer_t w;
+                nibw_init(&w, &cmp);
+                pack_groups_masked(&w, buf, gclis, groups, gtli, (int)emit_signs);
+                nibw_finish(&w, &cmp);
+
+                ASSERT_EQ(ref.offset, cmp.offset);
+                ASSERT_EQ(ref.bits_used, cmp.bits_used);
+                ASSERT_EQ(memcmp(mem_ref, mem_cmp, PACK_GROUPS_BUF_SIZE), 0);
+            }
+        }
+    }
+
+    free(buf);
+    free(gclis);
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}
+
+/* pack_data_groups_sse is what both wrappers call; it is reached here by its
+ * own name rather than through them. */
+TEST(pack_group_helper, data_groups_sse_matches_reference) {
+    pack_data_groups_test(pack_data_groups_sse);
+}
+
+/* A unary code through the accumulating bit writer must be the code the generic
+ * writer produces, at every starting alignment and at every length - including
+ * the two short cases the generic writer handles separately. */
+TEST(vlc_put_unary, matches_vlc_encode_pack_bits) {
+    const uint32_t buf_size = 512;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t* mem_ref = (uint8_t*)malloc(buf_size);
+    uint8_t* mem_cmp = (uint8_t*)malloc(buf_size);
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL);
+
+    for (uint32_t prefix_bits = 0; prefix_bits < 8; prefix_bits++) {
+        for (uint32_t test_num = 0; test_num < 500; test_num++) {
+            const uint32_t codes = 1 + rnd->Rand8() % 30;
+            uint8_t nbits[30];
+            for (uint32_t i = 0; i < codes; i++) {
+                nbits[i] = (uint8_t)(rnd->Rand8() % 32);
+            }
+
+            bitstream_writer_t ref, cmp;
+            bitstream_writer_init(&ref, mem_ref, buf_size);
+            bitstream_writer_init(&cmp, mem_cmp, buf_size);
+            memset(mem_ref, 0, buf_size);
+            memset(mem_cmp, 0, buf_size);
+            if (prefix_bits) {
+                const uint8_t prefix_value = (uint8_t)(rnd->Rand8() & ((1u << prefix_bits) - 1));
+                write_N_bits(&ref, prefix_value, (uint8_t)prefix_bits);
+                write_N_bits(&cmp, prefix_value, (uint8_t)prefix_bits);
+            }
+
+            for (uint32_t i = 0; i < codes; i++) {
+                vlc_encode_pack_bits(&ref, nbits[i]);
+            }
+
+            bit_writer_t w;
+            bitw_init(&w, &cmp);
+            for (uint32_t i = 0; i < codes; i++) {
+                vlc_put_unary(&w, nbits[i]);
+            }
+            bitw_finish(&w, &cmp);
+
+            ASSERT_EQ(ref.offset, cmp.offset);
+            ASSERT_EQ(ref.bits_used, cmp.bits_used);
+            ASSERT_EQ(memcmp(mem_ref, mem_cmp, buf_size), 0);
+        }
+    }
+    free(mem_ref);
+    free(mem_cmp);
     delete rnd;
 }

--- a/tests/UnitTests/TestReateControl.cc
+++ b/tests/UnitTests/TestReateControl.cc
@@ -6,6 +6,11 @@
 #include "gtest/gtest.h"
 #include <RateControl.h>
 #include <BinarySearch.h>
+#include "random.h"
+#include "RateControl_avx2.h"
+#include "Enc_avx512.h"
+#include "encoder_dsp_rtcd.h"
+#include "EncDec.h" /* TRUNCATION_MAX */
 
 TEST(RateControl, EqualSimple) {
     BinarySearch_t search;
@@ -332,4 +337,68 @@ TEST(RateControl, NotEqualSmallerFull) {
 TEST(RateControl, NotEqualBiggerFull) {
     Test_next_step_full(0, 1);
     Test_next_step_full(0, -1);
+}
+
+/* The histogram of GCLI values over one band line.
+ *
+ * The three implementations fill all sixteen bins themselves - nobody clears
+ * the table for them - so the test hands them a table pre-filled with a value
+ * no count can be: a bin left untouched shows up as a mismatch rather than as a
+ * lucky zero. Width zero is part of the contract as well: an empty line has to
+ * leave an all-zero histogram, not the previous one. */
+typedef void (*gc_histogram_16_fn)(const uint8_t* data, uint32_t width, uint16_t* hist);
+
+static void gc_histogram_16_test(gc_histogram_16_fn hist_fn) {
+    /* the widths around the vector step, plus a few long lines */
+    const uint32_t widths[] = {0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 480, 1920, 3840};
+    const uint32_t widths_num = sizeof(widths) / sizeof(widths[0]);
+    const uint32_t max_width = 3840;
+
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t* data = (uint8_t*)malloc(max_width);
+    ASSERT_TRUE(data != NULL);
+
+    for (uint32_t width_idx = 0; width_idx < widths_num; width_idx++) {
+        const uint32_t width = widths[width_idx];
+        for (uint32_t test_num = 0; test_num < 20; test_num++) {
+            uint16_t ref[TRUNCATION_MAX + 1];
+            uint16_t cmp[TRUNCATION_MAX + 1];
+            memset(ref, 0, sizeof(ref));
+            for (uint32_t i = 0; i <= TRUNCATION_MAX; i++) {
+                cmp[i] = 0xDEAD;
+            }
+
+            for (uint32_t i = 0; i < width; i++) {
+                /* the first round is the extreme case of a single bin: GCLI is
+                 * spatially correlated and whole lines of one value do occur */
+                data[i] = (uint8_t)(test_num == 0 ? TRUNCATION_MAX : rnd->Rand8() % (TRUNCATION_MAX + 1));
+                ref[data[i]]++;
+            }
+
+            hist_fn(data, width, cmp);
+            ASSERT_EQ(memcmp(ref, cmp, sizeof(ref)), 0) << "width " << width << " round " << test_num;
+        }
+    }
+
+    free(data);
+    delete rnd;
+}
+
+TEST(gc_histogram_16, C) {
+    gc_histogram_16_test(gc_histogram_16_c);
+}
+
+TEST(gc_histogram_16, AVX2) {
+    if (!(get_cpu_flags() & CPU_FLAGS_AVX2)) {
+        GTEST_SKIP();
+    }
+    gc_histogram_16_test(gc_histogram_16_avx2);
+}
+
+TEST(gc_histogram_16, AVX512) {
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2 | CPU_FLAGS_POPCNT;
+    if ((get_cpu_flags() & required) != required) {
+        GTEST_SKIP();
+    }
+    gc_histogram_16_test(gc_histogram_16_avx512);
 }

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -527,21 +527,37 @@ TEST(unpack_n_groups, AVX512_matches_AVX2) {
     const uint32_t mem_size = 1024;
     svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
 
-    uint8_t* mem = (uint8_t*)malloc(mem_size);
+    /* Two separately allocated source buffers, not one shared by both readers:
+     * a read that runs past the intended data reads past the end of a
+     * specific allocation, and two distinct allocations are never adjacent to
+     * the same bytes. A shared buffer would let such a read return identical
+     * garbage to both tiers, agree with itself, and hide the very thing this
+     * test exists to catch - the parser is trusted to stay in its lane, this
+     * is what checks that trust. */
+    uint8_t* mem_ref = (uint8_t*)malloc(mem_size);
+    uint8_t* mem_cmp = (uint8_t*)malloc(mem_size);
     uint8_t* gclis = (uint8_t*)malloc(max_groups);
     uint16_t* buf_ref = (uint16_t*)malloc(max_groups * GROUP_SIZE * sizeof(uint16_t));
     uint16_t* buf_cmp = (uint16_t*)malloc(max_groups * GROUP_SIZE * sizeof(uint16_t));
-    ASSERT_TRUE(mem != NULL && gclis != NULL && buf_ref != NULL && buf_cmp != NULL);
+    ASSERT_TRUE(mem_ref != NULL && mem_cmp != NULL && gclis != NULL && buf_ref != NULL && buf_cmp != NULL);
 
     for (uint32_t nosign = 0; nosign < 2; nosign++) {
         for (uint32_t test_num = 0; test_num < 400; test_num++) {
             for (uint32_t i = 0; i < mem_size; i++) {
-                mem[i] = rnd->Rand8();
+                mem_ref[i] = mem_cmp[i] = rnd->Rand8();
             }
             const uint32_t n_groups = 1 + rnd->Rand8() % max_groups;
             const uint8_t gtli = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            /* Half the runs keep GCLI legal, [0, TRUNCATION_MAX]; the other
+             * half let it be anything a byte can hold. The unary code that
+             * carries GCLI in the real stream yields up to thirty-one, and
+             * vertical prediction can wrap it further still, so a corrupt or
+             * adversarial stream can and does present values past fifteen -
+             * that is exactly the input this parser has to survive without
+             * the two tiers disagreeing or either one reading past its data. */
+            const bool corrupt_domain = (test_num % 2) != 0;
             for (uint32_t i = 0; i < n_groups; i++) {
-                gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+                gclis[i] = corrupt_domain ? rnd->Rand8() : (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
             }
             const uint8_t start_bits_used = (uint8_t)(rnd->Rand8() % 2 ? 4 : 0);
             /* zero, a boundary and a value that lets every group take the fast
@@ -553,9 +569,9 @@ TEST(unpack_n_groups, AVX512_matches_AVX2) {
             memset(buf_cmp, 0, max_groups * GROUP_SIZE * sizeof(uint16_t));
 
             reader_short_t r_ref, r_cmp;
-            r_ref.mem = mem;
-            r_ref.bits_used = start_bits_used;
-            r_cmp = r_ref;
+            r_ref.mem = mem_ref;
+            r_cmp.mem = mem_cmp;
+            r_ref.bits_used = r_cmp.bits_used = start_bits_used;
 
             if (nosign) {
                 unpack_n_groups_nosign(gclis, gtli, &r_ref, buf_ref, n_groups, safe_bytes);
@@ -566,13 +582,18 @@ TEST(unpack_n_groups, AVX512_matches_AVX2) {
                 unpack_n_groups_avx512(gclis, gtli, &r_cmp, buf_cmp, n_groups, safe_bytes);
             }
 
-            ASSERT_EQ(r_ref.mem - mem, r_cmp.mem - mem);
+            ASSERT_EQ(r_ref.mem - mem_ref, r_cmp.mem - mem_cmp)
+                << "n_groups=" << n_groups << " gtli=" << (int)gtli << " corrupt_domain=" << corrupt_domain
+                << " safe_bytes=" << safe_bytes;
             ASSERT_EQ(r_ref.bits_used, r_cmp.bits_used);
-            ASSERT_EQ(memcmp(buf_ref, buf_cmp, n_groups * GROUP_SIZE * sizeof(uint16_t)), 0);
+            ASSERT_EQ(memcmp(buf_ref, buf_cmp, n_groups * GROUP_SIZE * sizeof(uint16_t)), 0)
+                << "n_groups=" << n_groups << " gtli=" << (int)gtli << " corrupt_domain=" << corrupt_domain
+                << " safe_bytes=" << safe_bytes;
         }
     }
 
-    free(mem);
+    free(mem_ref);
+    free(mem_cmp);
     free(gclis);
     free(buf_ref);
     free(buf_cmp);

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -6,8 +6,10 @@
 #include "gtest/gtest.h"
 #include "random.h"
 #include "UnPack_avx2.h"
+#include "UnPack_avx512.h"
 #include "Packing.h"
 #include "BitstreamWriter.h"
+#include "common_dsp_rtcd.h"
 
 typedef SvtJxsErrorType_t (*unpack_data)(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
                                          uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
@@ -234,6 +236,102 @@ TEST(unpack_data_test, unpack_data_C) {
 
 TEST(unpack_data_test, unpack_data_AVX2) {
     unpack_test(unpack_data_avx2);
+}
+
+/* GCLI out of range is what a corrupt stream looks like: the unary code yields
+ * up to thirty-one, and vertical prediction can wrap the byte to any value at
+ * all. Two properties are checked here.
+ *
+ * The parsers have to stay inside the language. A group that large does not fit
+ * the single load the vector parsers use - it holds fifteen bit planes at most -
+ * and the shift that would extract it is undefined, so such a group has to be
+ * recognised and left to the sequential reader. This test is the one that walks
+ * that path; under the sanitizer builds it is also what proves the shift is
+ * gone.
+ *
+ * The vector levels have to agree with each other, so that a malformed stream
+ * cannot make the output depend on the processor the decoder happens to run on.
+ * The C implementation is deliberately not the reference here: on out-of-range
+ * GCLI it is a different algorithm (it keeps the lowest bits of every plane in
+ * a separate accumulator) and it has never matched the vector paths on such
+ * input, upstream included. */
+static void unpack_test_gcli_out_of_range(unpack_data unpack_ref, unpack_data unpack_cmp) {
+    const uint32_t gcli_size = 50;
+    const uint32_t bitstream_reader_size = 80;
+    const uint32_t out_buffer_size = 1024;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint8_t* bitstream_mem = (uint8_t*)malloc(bitstream_reader_size * sizeof(uint8_t));
+    uint16_t* buf_ref = (uint16_t*)malloc(out_buffer_size * sizeof(uint16_t));
+    uint16_t* buf_cmp = (uint16_t*)malloc(out_buffer_size * sizeof(uint16_t));
+    uint8_t* gclis = (uint8_t*)malloc(gcli_size * sizeof(uint8_t));
+
+    uint8_t leftover_ref[MAX_BAND_LINES] = {0};
+    uint8_t leftover_cmp[MAX_BAND_LINES] = {0};
+
+    ASSERT_TRUE(NULL != bitstream_mem);
+    ASSERT_TRUE(NULL != buf_ref);
+    ASSERT_TRUE(NULL != buf_cmp);
+    ASSERT_TRUE(NULL != gclis);
+
+    for (uint32_t test_num = 0; test_num < 200; test_num++) {
+        const uint8_t sign_flag = test_num % 2;
+        const uint8_t gtli = test_num % 15;
+        const uint32_t offset = rnd->Rand8() % 2 ? 0 : 4;
+
+        for (uint32_t i = 0; i < bitstream_reader_size; i++) {
+            bitstream_mem[i] = rnd->Rand8();
+        }
+        /* The whole byte range, not only the sixteen legal values: a difference
+         * above one hundred and twenty-seven is what tells a signed group mask
+         * from an unsigned one. */
+        for (uint32_t i = 0; i < gcli_size; i++) {
+            gclis[i] = rnd->Rand8();
+        }
+
+        for (uint32_t width = 1; width < 52; ++width) {
+            bitstream_reader_t bitstream_ref;
+            bitstream_reader_init(&bitstream_ref, bitstream_mem, bitstream_reader_size);
+            bitstream_reader_skip_bits(&bitstream_ref, offset);
+            bitstream_reader_t bitstream_cmp = bitstream_ref;
+
+            memset((void*)buf_ref, 0, out_buffer_size * sizeof(uint16_t));
+            memset((void*)buf_cmp, 0, out_buffer_size * sizeof(uint16_t));
+            memset((void*)leftover_ref, 0, MAX_BAND_LINES * sizeof(uint8_t));
+            memset((void*)leftover_cmp, 0, MAX_BAND_LINES * sizeof(uint8_t));
+
+            int32_t bits_left_ref = (int32_t)bitstream_reader_get_left_bits(&bitstream_ref);
+            int32_t bits_left_cmp = bits_left_ref;
+
+            SvtJxsErrorType_t ret_ref = unpack_ref(
+                &bitstream_ref, buf_ref, width, gclis, GROUP_SIZE, gtli, sign_flag, leftover_ref, &bits_left_ref);
+            if (unpack_cmp == NULL) {
+                continue;
+            }
+            SvtJxsErrorType_t ret_cmp = unpack_cmp(
+                &bitstream_cmp, buf_cmp, width, gclis, GROUP_SIZE, gtli, sign_flag, leftover_cmp, &bits_left_cmp);
+
+            /* A rejected stream promises nothing about the output, so there
+             * only the verdict itself is compared. */
+            ASSERT_EQ(ret_ref, ret_cmp);
+            if (ret_ref == SvtJxsErrorNone) {
+                ASSERT_EQ(bits_left_ref, bits_left_cmp);
+                ASSERT_EQ(memcmp(buf_ref, buf_cmp, out_buffer_size * sizeof(uint16_t)), 0);
+                ASSERT_EQ(memcmp(leftover_ref, leftover_cmp, MAX_BAND_LINES * sizeof(uint8_t)), 0);
+            }
+        }
+    }
+
+    free(bitstream_mem);
+    free(buf_ref);
+    free(buf_cmp);
+    free(gclis);
+    delete rnd;
+}
+
+TEST(unpack_data_test, unpack_data_out_of_range_gcli) {
+    const bool has_avx512 = (CPU_FLAGS_AVX512F & get_cpu_flags()) != 0;
+    unpack_test_gcli_out_of_range(unpack_data_avx2, has_avx512 ? unpack_data_avx512 : NULL);
 }
 
 TEST(unpack_data_test, unpack_sign) {

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -652,3 +652,56 @@ TEST(bit_scan, vlc_leading_run) {
     }
     delete rnd;
 }
+
+/* The budget precheck in unpack_data_common sums per-group bit costs in 16-bit
+ * SIMD lanes before widening to 32 bits. At group_num=1024 with every GCLI
+ * corrupted to 255 (gtli=0, sign_flag=0), each of the four values entering the
+ * last 16-bit hadd stage is exactly 32768, and 32768+32768 wraps to 0 - the
+ * computed bits_sum is 0 instead of the true 262144. precinct_bits_left is
+ * then reduced by zero instead of by 262144*4 bits, so a stream requesting a
+ * precinct with almost no declared budget left is accepted instead of
+ * rejected. This models an 8K+-class band line: level-1 band width for a
+ * >=8192-wide image - already an existing, named level - exceeds the
+ * ~1024-group threshold where this wrap starts.
+ *
+ * The backing buffer is sized for the fixed per-group read bound (at most one
+ * sign nibble plus TRUNCATION_MAX data nibbles, i.e. 8 bytes/group here) so
+ * that whichever way the budget check goes, the parser that follows it never
+ * runs past real data - this test is about the wrong verdict, not about
+ * re-triggering the over-read the bound already fixed.
+ *
+ * Currently fails: the wrap lets the stream through. Passes once the
+ * accumulation is widened to 32 bits, as the correct answer is rejection. */
+TEST(unpack_data_common, budget_precheck_does_not_wrap) {
+    const uint32_t n_groups = 1024;
+    const uint32_t width = n_groups * GROUP_SIZE;
+    uint8_t* gclis = (uint8_t*)malloc(n_groups + 1);
+    ASSERT_TRUE(gclis != NULL);
+    for (uint32_t i = 0; i < n_groups; i++) {
+        gclis[i] = 255; // corrupt: far above TRUNCATION_MAX
+    }
+
+    const uint32_t bitstream_buf_size = 16384; // >= 8 bytes/group * n_groups, see comment above
+    uint8_t* bitstream_mem = (uint8_t*)malloc(bitstream_buf_size);
+    ASSERT_TRUE(bitstream_mem != NULL);
+    memset(bitstream_mem, 0xAA, bitstream_buf_size);
+
+    uint16_t* buf = (uint16_t*)malloc((n_groups + 1) * GROUP_SIZE * sizeof(uint16_t));
+    ASSERT_TRUE(buf != NULL);
+    uint8_t leftover_signs_num = 0;
+
+    bitstream_reader_t bitstream;
+    bitstream_reader_init(&bitstream, bitstream_mem, bitstream_buf_size);
+
+    int32_t precinct_bits_left = 10; // far short of the true 262144*4-bit cost
+    SvtJxsErrorType_t ret =
+        unpack_data_avx2(&bitstream, buf, width, gclis, GROUP_SIZE, 0, 0, &leftover_signs_num, &precinct_bits_left);
+
+    /* 10 bits cannot possibly cover 1024 groups' worth of GCLI=255 data, so a
+     * correct budget computation must reject this stream. */
+    EXPECT_EQ(ret, SvtJxsErrorDecoderInvalidBitstream);
+
+    free(gclis);
+    free(bitstream_mem);
+    free(buf);
+}

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -705,3 +705,50 @@ TEST(unpack_data_common, budget_precheck_does_not_wrap) {
     free(bitstream_mem);
     free(buf);
 }
+
+/* unpack_data_single_group (Packing.c, the scalar/C group reader) never got the
+ * plane-count bound that bbe0e0f added to the AVX2/AVX512 sequential tail
+ * readers. Its caller, unpack_data_c, checks the budget per group before
+ * calling it - *precinct_bits_left -= 4 * (bitplanes_size + 1) - but that check
+ * only verifies the corrupt stream's *declared* cost fits the remaining
+ * budget; it does not bound how many planes a single group can really have.
+ * A single group with GCLI corrupted to 254 declares a cost of only
+ * 4*(254+1)=1020 bits, comfortably affordable by almost any real precinct's
+ * remaining budget, so the check passes and unpack_data_single_group then
+ * reads 254 planes with no cap - the same unbounded read bbe0e0f fixed in the
+ * two vector siblings, just reached through a per-group budget check that
+ * happens to be large enough, instead of a whole-line sum that wraps.
+ *
+ * The backing buffer here is sized generously so the read itself never runs
+ * past real memory regardless of which way this test goes - this is about the
+ * wrong bit count, not about re-triggering the over-read directly. */
+TEST(unpack_data_c, single_group_plane_read_is_bounded) {
+    const uint32_t bitstream_buf_size = 512; // >> worst case (1 sign + 254 planes) nibbles
+    uint8_t* bitstream_mem = (uint8_t*)malloc(bitstream_buf_size);
+    ASSERT_TRUE(bitstream_mem != NULL);
+    memset(bitstream_mem, 0xAA, bitstream_buf_size);
+
+    uint8_t gclis[1] = {254}; // corrupt: far above TRUNCATION_MAX
+    const uint8_t gtli = 0;
+    uint16_t buf[GROUP_SIZE];
+    uint8_t leftover_signs_num = 0;
+
+    bitstream_reader_t bitstream;
+    bitstream_reader_init(&bitstream, bitstream_mem, bitstream_buf_size);
+
+    // Comfortably covers this one group's declared cost (4*(254+1)=1020 bits);
+    // the point is that the check passes, same as it would for any real precinct.
+    int32_t precinct_bits_left = 2000;
+    SvtJxsErrorType_t ret =
+        unpack_data_c(&bitstream, buf, GROUP_SIZE, gclis, GROUP_SIZE, gtli, 0, &leftover_signs_num, &precinct_bits_left);
+    ASSERT_EQ(ret, SvtJxsErrorNone); // the budget check is not the bug; it correctly affords the declared cost
+
+    // The physical read must stay bounded to one sign nibble plus at most
+    // TRUNCATION_MAX plane nibbles, matching the bound already applied to the
+    // AVX2/AVX512 tail readers - not the full (corrupt) 254 planes.
+    const uint64_t bits_used = (uint64_t)bitstream_buf_size * 8 - bitstream_reader_get_left_bits(&bitstream);
+    const uint64_t max_expected_bits = 4ULL * (1 + TRUNCATION_MAX);
+    EXPECT_LE(bits_used, max_expected_bits) << "bits_used=" << bits_used << " max_expected=" << max_expected_bits;
+
+    free(bitstream_mem);
+}

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -330,7 +330,10 @@ static void unpack_test_gcli_out_of_range(unpack_data unpack_ref, unpack_data un
 }
 
 TEST(unpack_data_test, unpack_data_out_of_range_gcli) {
-    const bool has_avx512 = (CPU_FLAGS_AVX512F & get_cpu_flags()) != 0;
+    /* Same condition the decoder dispatch uses: the AVX-512 directory is built
+     * with -mbmi2, so the tier is only usable when the processor has BMI2 too. */
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2;
+    const bool has_avx512 = (get_cpu_flags() & required) == required;
     unpack_test_gcli_out_of_range(unpack_data_avx2, has_avx512 ? unpack_data_avx512 : NULL);
 }
 

--- a/tests/UnitTests/TestUnPack.cc
+++ b/tests/UnitTests/TestUnPack.cc
@@ -10,6 +10,9 @@
 #include "Packing.h"
 #include "BitstreamWriter.h"
 #include "common_dsp_rtcd.h"
+#include "unpack_common.h"
+#include "SvtUtility.h"
+#include "EncDec.h" /* TRUNCATION_MAX */
 
 typedef SvtJxsErrorType_t (*unpack_data)(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
                                          uint32_t group_size, uint8_t gtli, uint8_t sign_flag, uint8_t* leftover_signs_num,
@@ -426,5 +429,205 @@ TEST(unpack_data_test, unpack_sign) {
     free(bitstream_mem);
     free(buf);
     free(buf_expected);
+    delete rnd;
+}
+
+/* The AVX-512 parser on well-formed streams. Until now it was only reached by
+ * the corrupt-stream test above, so the ordinary path - the one that actually
+ * decodes pictures - had no test of its own on this tier. */
+TEST(unpack_data_test, unpack_data_AVX512) {
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2;
+    if ((get_cpu_flags() & required) != required) {
+        GTEST_SKIP();
+    }
+    unpack_test(unpack_data_avx512);
+}
+
+/* The logic shared by both vector parsers - counting the consumed bits, the end
+ * of the line, handing the position back to the common reader - with the group
+ * parser passed in. Both wrappers are nothing but a choice of that pair, so it
+ * is checked here on its own. */
+static SvtJxsErrorType_t unpack_data_common_avx2_parsers(bitstream_reader_t* bitstream, uint16_t* buf, uint32_t w, uint8_t* gclis,
+                                                         uint32_t group_size, uint8_t gtli, uint8_t sign_flag,
+                                                         uint8_t* leftover_signs_num, int32_t* precinct_bits_left) {
+    return unpack_data_common(bitstream,
+                              buf,
+                              w,
+                              gclis,
+                              group_size,
+                              gtli,
+                              sign_flag,
+                              leftover_signs_num,
+                              precinct_bits_left,
+                              unpack_n_groups,
+                              unpack_n_groups_nosign);
+}
+
+TEST(unpack_data_test, unpack_data_common) {
+    unpack_test(unpack_data_common_avx2_parsers);
+}
+
+/* Nibble n of the stream: bytes carry the high nibble first. */
+static uint32_t one_nibble_ref(const uint8_t* mem, uint32_t nib) {
+    return (nib & 1) ? (mem[nib >> 1] & 0xF) : (uint32_t)(mem[nib >> 1] >> 4);
+}
+
+/* The single load that takes a whole group has to give the same nibbles the
+ * per-nibble reader gives, at both halves of the starting byte and at every
+ * length the group can have - up to fifteen bit planes. */
+TEST(unpack_common, load_nibbles_matches_one_nibble) {
+    const uint32_t mem_size = 64;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    uint8_t mem[64];
+
+    for (uint32_t test_num = 0; test_num < 500; test_num++) {
+        for (uint32_t i = 0; i < mem_size; i++) {
+            mem[i] = rnd->Rand8();
+        }
+        /* the load reaches eight bytes past the start of the group */
+        for (uint32_t nib = 0; nib + 15 < 2 * (mem_size - 8); nib++) {
+            ASSERT_EQ(one_nibble_ref(mem, nib), unpack_one_nibble(mem, nib));
+            for (uint32_t count = 1; count <= 15; count++) {
+                uint64_t ref = 0;
+                for (uint32_t i = 0; i < count; i++) {
+                    ref = (ref << 4) | one_nibble_ref(mem, nib + i);
+                }
+                ASSERT_EQ(ref, unpack_load_nibbles(mem, nib, count)) << "nib " << nib << " count " << count;
+            }
+        }
+    }
+    delete rnd;
+}
+
+/* The right to make an over-reading load: eight bytes have to remain past the
+ * start of the group, and a count is returned so that zero means "not at all". */
+TEST(unpack_common, safe_byte_count) {
+    for (uint32_t bytes_left = 0; bytes_left < 8; bytes_left++) {
+        ASSERT_EQ(0u, unpack_safe_byte_count(bytes_left));
+    }
+    for (uint32_t bytes_left = 8; bytes_left < 100; bytes_left++) {
+        ASSERT_EQ(bytes_left - 7, unpack_safe_byte_count(bytes_left));
+    }
+}
+
+/* The two group parsers of a line, called by their own names rather than
+ * through the wrappers. Random memory is a legitimate input here: the parser is
+ * driven by the GCLI table, and both levels have to read the same nibbles out
+ * of it and leave the reader in the same place.
+ *
+ * safe_bytes is walked from zero upwards, because it is what splits the fast
+ * path from the sequential tail: at zero every group goes the slow way. */
+TEST(unpack_n_groups, AVX512_matches_AVX2) {
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2;
+    if ((get_cpu_flags() & required) != required) {
+        GTEST_SKIP();
+    }
+
+    const uint32_t max_groups = 40;
+    const uint32_t mem_size = 1024;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint8_t* mem = (uint8_t*)malloc(mem_size);
+    uint8_t* gclis = (uint8_t*)malloc(max_groups);
+    uint16_t* buf_ref = (uint16_t*)malloc(max_groups * GROUP_SIZE * sizeof(uint16_t));
+    uint16_t* buf_cmp = (uint16_t*)malloc(max_groups * GROUP_SIZE * sizeof(uint16_t));
+    ASSERT_TRUE(mem != NULL && gclis != NULL && buf_ref != NULL && buf_cmp != NULL);
+
+    for (uint32_t nosign = 0; nosign < 2; nosign++) {
+        for (uint32_t test_num = 0; test_num < 400; test_num++) {
+            for (uint32_t i = 0; i < mem_size; i++) {
+                mem[i] = rnd->Rand8();
+            }
+            const uint32_t n_groups = 1 + rnd->Rand8() % max_groups;
+            const uint8_t gtli = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            for (uint32_t i = 0; i < n_groups; i++) {
+                gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            }
+            const uint8_t start_bits_used = (uint8_t)(rnd->Rand8() % 2 ? 4 : 0);
+            /* zero, a boundary and a value that lets every group take the fast
+             * path; the parser never leaves the buffer either way */
+            const uint32_t safe_choice = rnd->Rand8() % 3;
+            const uint32_t safe_bytes = safe_choice == 0 ? 0 : (safe_choice == 1 ? 1 + rnd->Rand8() % 16 : mem_size - 8);
+
+            memset(buf_ref, 0, max_groups * GROUP_SIZE * sizeof(uint16_t));
+            memset(buf_cmp, 0, max_groups * GROUP_SIZE * sizeof(uint16_t));
+
+            reader_short_t r_ref, r_cmp;
+            r_ref.mem = mem;
+            r_ref.bits_used = start_bits_used;
+            r_cmp = r_ref;
+
+            if (nosign) {
+                unpack_n_groups_nosign(gclis, gtli, &r_ref, buf_ref, n_groups, safe_bytes);
+                unpack_n_groups_nosign_avx512(gclis, gtli, &r_cmp, buf_cmp, n_groups, safe_bytes);
+            }
+            else {
+                unpack_n_groups(gclis, gtli, &r_ref, buf_ref, n_groups, safe_bytes);
+                unpack_n_groups_avx512(gclis, gtli, &r_cmp, buf_cmp, n_groups, safe_bytes);
+            }
+
+            ASSERT_EQ(r_ref.mem - mem, r_cmp.mem - mem);
+            ASSERT_EQ(r_ref.bits_used, r_cmp.bits_used);
+            ASSERT_EQ(memcmp(buf_ref, buf_cmp, n_groups * GROUP_SIZE * sizeof(uint16_t)), 0);
+        }
+    }
+
+    free(mem);
+    free(gclis);
+    free(buf_ref);
+    free(buf_cmp);
+    delete rnd;
+}
+
+/* The two bit scans that replaced dispatched calls on the hot paths. Both are
+ * undefined on zero and neither is asked for it. */
+TEST(bit_scan, svt_first_set_bit) {
+    for (uint32_t bit = 0; bit < 64; bit++) {
+        const uint64_t mask = (uint64_t)1 << bit;
+        ASSERT_EQ(bit, svt_first_set_bit(mask));
+        /* the higher bits must not shift the answer */
+        ASSERT_EQ(bit, svt_first_set_bit(mask | (mask << 1)));
+        ASSERT_EQ(bit, svt_first_set_bit(~(uint64_t)0 << bit));
+    }
+
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    for (uint32_t test_num = 0; test_num < 10000; test_num++) {
+        uint64_t mask = 0;
+        for (uint32_t i = 0; i < 4; i++) {
+            mask = (mask << 16) | rnd->Rand16();
+        }
+        if (mask == 0) {
+            continue;
+        }
+        uint32_t ref = 0;
+        while (!((mask >> ref) & 1)) {
+            ref++;
+        }
+        ASSERT_EQ(ref, svt_first_set_bit(mask));
+    }
+    delete rnd;
+}
+
+TEST(bit_scan, vlc_leading_run) {
+    for (uint32_t bit = 0; bit < 32; bit++) {
+        /* the length of a unary code is the number of leading zeroes plus one */
+        const uint32_t v = 1u << bit;
+        ASSERT_EQ((int8_t)(32 - bit), vlc_leading_run(v));
+        /* the lower bits must not shift the answer */
+        ASSERT_EQ((int8_t)(32 - bit), vlc_leading_run(v | (v - 1)));
+    }
+
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+    for (uint32_t test_num = 0; test_num < 10000; test_num++) {
+        const uint32_t v = ((uint32_t)rnd->Rand16() << 16) | rnd->Rand16();
+        if (v == 0) {
+            continue;
+        }
+        uint32_t top = 31;
+        while (!((v >> top) & 1)) {
+            top--;
+        }
+        ASSERT_EQ((int8_t)(32 - top), vlc_leading_run(v));
+    }
     delete rnd;
 }

--- a/tests/UnitTests/UnitTest_AVX512/CMakeLists.txt
+++ b/tests/UnitTests/UnitTest_AVX512/CMakeLists.txt
@@ -5,9 +5,23 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+#gtest needs C++14; the main test target gets it by linking gtest, an object
+#library has to ask for it itself.
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include_directories(
+    ${gtest_SOURCE_DIR}/include
+    ${gtest_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/tests/UnitTests
     ${PROJECT_SOURCE_DIR}/Source/API
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Common/Codec
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Encoder/Codec
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Encoder/ASM_AVX2
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Encoder/ASM_AVX512
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Decoder/Codec
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Decoder/ASM_AVX2
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Decoder/ASM_AVX512
 )
 
 #UT TESTS SOURCES
@@ -17,12 +31,16 @@ file(GLOB all_files
     "*.cpp")
 
 #Support AVX2 and AVX512
+#BMI2 and POPCNT match the flags of the production AVX-512 directories: the
+#helpers tested here use PDEP and PEXT.
 check_both_flags_add(
     -mavx2
     -mavx512f
     -mavx512bw
     -mavx512dq
-    -mavx512vl)
+    -mavx512vl
+    -mpopcnt
+    -mbmi2)
 
 if(MSVC)
     check_both_flags_add(/arch:AVX2)

--- a/tests/UnitTests/UnitTest_AVX512/TestPackUnpackHelpers_avx512.cc
+++ b/tests/UnitTests/UnitTest_AVX512/TestPackUnpackHelpers_avx512.cc
@@ -1,0 +1,178 @@
+/*
+* Copyright(c) 2024 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+/* The helpers of the AVX-512 pack and unpack paths.
+ *
+ * They live here rather than next to the other unit tests because PDEP and PEXT
+ * need BMI2, and this directory is the only one built with the same flags as the
+ * production AVX-512 directories. */
+
+#include "gtest/gtest.h"
+#include "random.h"
+#include "pack_group_helper_avx512.h"
+#include "unpack_common.h"
+#include "unpack_common_avx512.h"
+#include "common_dsp_rtcd.h"
+#include "EncDec.h" /* TRUNCATION_MAX */
+
+/* The whole translation unit is compiled with AVX-512 enabled, so the compiler
+ * may put those instructions anywhere in it, not only where an intrinsic asks.
+ * BMI2 comes along for PDEP and PEXT - the same pair of conditions the runtime
+ * dispatch checks before it hands work to this tier. */
+/* The generator hands out sixteen bits at a time. */
+static uint64_t rand64(svt_jxs_test_tool::SVTRandom* rnd) {
+    uint64_t v = 0;
+    for (uint32_t i = 0; i < 4; i++) {
+        v = (v << 16) | rnd->Rand16();
+    }
+    return v;
+}
+
+static bool avx512_usable(void) {
+    const CPU_FLAGS required = CPU_FLAGS_AVX512F | CPU_FLAGS_BMI2;
+    return (get_cpu_flags() & required) == required;
+}
+
+/* Bit j of coefficient k is bit (3 - k) of nibble j: the plane of weight 2^j
+ * contributes one nibble, and inside it the coefficients run from the first in
+ * the top bit to the last in the bottom one. */
+static uint64_t planes_to_lanes_ref(uint64_t acc, uint8_t gtli) {
+    uint64_t res = 0;
+    for (uint32_t k = 0; k < 4; k++) {
+        uint64_t lane = 0;
+        for (uint32_t j = 0; j < 16; j++) {
+            lane |= ((acc >> (4 * j + (3 - k))) & 1) << j;
+        }
+        res |= lane << (16 * k);
+    }
+    return res << gtli;
+}
+
+/* Both parsers spread the nibbles of a group over four coefficients, one with
+ * PEXT and one with byte shuffles and sign masks. They have to agree with each
+ * other and with the definition. */
+TEST(unpack_planes_to_lanes, avx512_matches_sse_and_reference) {
+    if (!avx512_usable()) {
+        GTEST_SKIP();
+    }
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    /* count nibbles plus the truncation level have to stay inside a coefficient,
+     * which is exactly the range the parser is called on. */
+    for (uint32_t count = 1; count <= 15; count++) {
+        for (uint8_t gtli = 0; gtli + count <= 16; gtli++) {
+            for (uint32_t test_num = 0; test_num < 200; test_num++) {
+                /* nibbles past count are zero, the way the group reader leaves them */
+                uint64_t acc = rand64(rnd);
+                if (4 * count < 64) {
+                    acc &= ((uint64_t)1 << (4 * count)) - 1;
+                }
+
+                const uint64_t ref = planes_to_lanes_ref(acc, gtli);
+                ASSERT_EQ(ref, unpack_planes_to_lanes_sse(acc, gtli));
+                ASSERT_EQ(ref, unpack_planes_to_lanes(acc, gtli));
+            }
+        }
+    }
+    delete rnd;
+}
+
+/* Nibble j of the word holds bit j of the four coefficients, the first of them
+ * in the top bit. */
+static uint64_t group_planes_ref(const uint16_t* buf) {
+    uint64_t res = 0;
+    for (uint32_t j = 0; j < 16; j++) {
+        for (uint32_t k = 0; k < 4; k++) {
+            res |= (uint64_t)((buf[k] >> j) & 1) << (4 * j + (3 - k));
+        }
+    }
+    return res;
+}
+
+/* The transposition of a whole group in four PDEPs. */
+TEST(pack_group_planes_pdep, matches_reference) {
+    if (!avx512_usable()) {
+        GTEST_SKIP();
+    }
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    for (uint32_t test_num = 0; test_num < 10000; test_num++) {
+        uint16_t buf[GROUP_SIZE];
+        for (uint32_t i = 0; i < GROUP_SIZE; i++) {
+            buf[i] = (uint16_t)rnd->Rand16();
+        }
+        ASSERT_EQ(group_planes_ref(buf), pack_group_planes_pdep(buf));
+    }
+
+    /* The corners the random values practically never reach. */
+    const uint16_t corners[][GROUP_SIZE] = {
+        {0, 0, 0, 0},
+        {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF},
+        {0x8000, 0, 0, 1},
+        {1, 0x8000, 0x0001, 0x8000},
+    };
+    for (uint32_t i = 0; i < sizeof(corners) / sizeof(corners[0]); i++) {
+        ASSERT_EQ(group_planes_ref(corners[i]), pack_group_planes_pdep(corners[i]));
+    }
+    delete rnd;
+}
+
+/* The two line packers - the PDEP one and the 128-bit one shared with AVX2 -
+ * write the same bits for the same line, signs on and off. */
+TEST(pack_groups_masked_pdep, matches_pack_groups_masked) {
+    if (!avx512_usable()) {
+        GTEST_SKIP();
+    }
+    const uint32_t max_groups = 70; /* more than two chunks of the 32-group mask */
+    const uint32_t mem_size = max_groups * 16 + 32;
+    svt_jxs_test_tool::SVTRandom* rnd = new svt_jxs_test_tool::SVTRandom(32, false);
+
+    uint16_t* buf = (uint16_t*)malloc(max_groups * GROUP_SIZE * sizeof(uint16_t));
+    uint8_t* gclis = (uint8_t*)malloc(max_groups * sizeof(uint8_t));
+    uint8_t* mem_ref = (uint8_t*)malloc(mem_size);
+    uint8_t* mem_cmp = (uint8_t*)malloc(mem_size);
+    ASSERT_TRUE(buf && gclis && mem_ref && mem_cmp);
+
+    for (uint32_t groups = 0; groups <= max_groups; groups += 7) {
+        for (uint32_t test_num = 0; test_num < 200; test_num++) {
+            const uint8_t gtli = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            for (uint32_t i = 0; i < groups; i++) {
+                gclis[i] = (uint8_t)(rnd->Rand8() % (TRUNCATION_MAX + 1));
+            }
+            for (uint32_t i = 0; i < groups * GROUP_SIZE; i++) {
+                buf[i] = (uint16_t)rnd->Rand16();
+            }
+            const int emit_signs = (int)(rnd->Rand8() % 2);
+            /* the line may start on either half of a byte */
+            const uint8_t start_bits_used = (uint8_t)(rnd->Rand8() % 2 ? 4 : 0);
+
+            bitstream_writer_t wr_ref, wr_cmp;
+            bitstream_writer_init(&wr_ref, mem_ref, mem_size);
+            bitstream_writer_init(&wr_cmp, mem_cmp, mem_size);
+            /* after the init, which fills the buffer itself in a debug build */
+            memset(mem_ref, 0xA5, mem_size);
+            memset(mem_cmp, 0xA5, mem_size);
+            wr_ref.bits_used = wr_cmp.bits_used = start_bits_used;
+
+            nib_writer_t nw_ref, nw_cmp;
+            nibw_init(&nw_ref, &wr_ref);
+            nibw_init(&nw_cmp, &wr_cmp);
+            pack_groups_masked(&nw_ref, buf, gclis, groups, gtli, emit_signs);
+            pack_groups_masked_pdep(&nw_cmp, buf, gclis, groups, gtli, emit_signs);
+            nibw_finish(&nw_ref, &wr_ref);
+            nibw_finish(&nw_cmp, &wr_cmp);
+
+            ASSERT_EQ(wr_ref.offset, wr_cmp.offset);
+            ASSERT_EQ(wr_ref.bits_used, wr_cmp.bits_used);
+            ASSERT_EQ(memcmp(mem_ref, mem_cmp, mem_size), 0);
+        }
+    }
+
+    free(buf);
+    free(gclis);
+    free(mem_ref);
+    free(mem_cmp);
+    delete rnd;
+}


### PR DESCRIPTION
Optimization of the hot paths of the encoder and the decoder for AVX2 and AVX-512. 

## Result

Ryzen 9 7900X, 1080p yuv422p8, bpp 4, interleaved A/B of two builds against upstream 0.10 (the machine drifts by up to 3%, so best-of-N over a single build lies).

| | AVX-512 | AVX2 | C |
|---|---|---|---|
| encoder, one thread | 244.2 fps, **+51.3%** | 196.8, +32.4% | 95.6, +4.5% |
| encoder, eight threads | 1257.9, **+41.5%** | 1063.8, +30.8% | 543.5, +3.8% |
| decoder, one thread | 442.1, **+37.7%** | 410.3, +36.1% | 141.3, +6.6% |
| decoder, eight threads | 1876.2, **+26.6%** | 1766.8, +33.4% | 614.6, +4.2% |

## What was done

**Common to both sides: the skew towards empty groups.** Measuring the distribution showed that 87% of the coefficient groups are empty (GCLI does not exceed the truncation level), so there is nothing to write and nothing to read for them. With such a skew the per-group "is there any work" branch predicts badly and costs more than the work itself. Both the packer and the parser now build a mask of the non-empty groups for 32/64 groups at a time and walk only its set bits; in the decoder the output is zeroed up front in one pass, so an empty group costs nothing at all.

Encoder:
- the GCLI histogram (`rate_control_lut_fill`, formerly the hottest function at 17.8%) is computed with vectors: `cmpeq` plus `popcount` over 32/64 bytes. The tail is taken by a masked load padded with `0xFF` - such bytes match no bin, so no separate scalar tail is needed, and it would be needed often: 52.6% of the calls arrive with a width below 16;
- transposing the bit planes of a group on AVX-512 is done with four `PDEP`: the mask `0x8888…` lays the positions of the first value exactly on the top bits of all sixteen nibbles. The cost stops depending on the number of planes (there can be up to fifteen), and the sign nibble falls out of the same computation for free. AVX2 keeps the `packs`+`movemask` assembly - `PDEP` is microcoded on Zen 1/2;
- packing a group needs no horizontal sums: the lanes are reversed once, after which the required nibble is exactly the mask of sign bits rather than two `hadd_epi16` per plane;
- the nibbles of a group reach the writer in a single call instead of one by one;
- GCLI unary codes and significance flags are written by an inline bit writer whose flush is a direct four-byte store. Every thirty-two bits used to go through `write_N_bits` with a branch on alignment and a per-byte loop, and every significance flag through a separate `write_1_bit`;
- the boundary sample of the forward wavelet stays in a vector: it used to be re-read from the very cell the vector had just been stored to;
- input scaling runs sixty-four pixels per turn: a body of three operations also paid for two pointer bumps and a branch.

Decoder:
- the over-reading load of a group is bounded by the end of the buffer rather than by the length of the line. The extra bytes of the word were masked off by the plane count anyway, so the parser never left its own data before either; the per-line bound pushed 40% of the groups onto the slow sequential path, because bands of the upper decomposition levels are shorter than eight bytes in their entirety;
- a group is read by one 64-bit load with `bswap` instead of nibble-by-nibble accesses;
- splitting the bit planes into lanes: `PEXT` on AVX-512, a `movemask` equivalent on AVX2;
- refilling the VLC register is one eight-byte load instead of "32 bits, then a loop of 16-bit top-ups";
- the seam between inverse wavelet blocks stays in a vector: the last even sample used to travel into the next block through a general purpose register (an extract plus a broadcast per iteration), now `valignd` takes it, or `vperm2i128` with `vpalignr` on AVX2;
- the length of a unary code is computed with an inline `clz` instead of a dispatched indirect call.

**Malformed streams.** The parsers now state and enforce what they assume about
GCLI. A group whose GCLI exceeds the truncation maximum holds more bit planes
than the single load can take - fifteen - and the shift that would extract it is
undefined; the unary code, however, yields up to thirty-one, and vertical
prediction can wrap the byte to any value at all. Such a group is recognised and
left to the sequential reader. The AVX2 group mask was also made an exact
unsigned comparison (`subs_epu8`, compare with zero for equality, invert) rather
than a signed compare against zero, so that the two vector levels classify a
group the same way for every byte value, at no extra instruction. `TestUnPack`
gained a case that feeds the whole byte range as GCLI: on the code before this
change it fails, and under `-DSANITIZER=Undefined` it reports the shift.

**CPU detection.** The AVX-512 kernels are compiled with `-mpopcnt` and
`-mbmi2` for the whole directory, so the compiler may emit those instructions
anywhere in them, not only where an intrinsic asks. The dispatcher used to
select that tier on AVX-512F alone. `CPU_FLAGS_POPCNT` and `CPU_FLAGS_BMI2` were
added, filled from cpuinfo like every other flag, and the tier is claimed only
when the processor backs all three. (`--asm avx512` keeps its meaning: it maps
to `CPU_FLAGS_ALL`, which is the same value it had before the two bits were
added.)

## Verification

- bit-exact output across all ISA levels (`c`/`sse4_1`/`avx2`/`avx512`) over five option sets and two sources;
- comparison against an upstream build: changes in the shared C code are invisible between ISA levels and can only be caught by comparing with a reference binary - encoder and decoder output match byte for byte;
- the stock unit tests plus the new out-of-range GCLI case: 12038 passed, 2 skipped;
- `-DSANITIZER=Undefined` over the decoder tests: clean, and the same build of
  the code without the GCLI guard reports `shift exponent 4294967096 is too
  large for 64-bit type`;
- every commit of the series builds on its own, and the parser tests pass at
  every commit, not only at the tip.

## How this was measured

**Machine.** AMD Ryzen 9 7900X (Zen 4, 12 cores / 24 threads, native 512-bit
datapath), Ubuntu 26.04, gcc 15.2, CMake 4.2.3. Stock upstream build, `Release`,
no extra compiler flags and no `-march=native` — the point is an apples-to-apples
comparison with 0.10, not the fastest possible binary. Nothing else runs on the
machine during a measurement, and benchmarks are never run in parallel.

**Material.** 1920x1080 yuv422p 8-bit, generated with `ffmpeg -f lavfi -i
testsrc2` (gradients, motion, noise) plus a pure-noise clip. A flat colour fill
was rejected on purpose: it leaves the precincts unrealistically empty and
flatters exactly the paths this series touches. Encoder: 200 frames, bpp 4.

**Encoder.** `SvtJpegxsEncApp -n 200 --no-progress 1 -b /dev/null --asm <isa>
--lp <n>`; the figure is the `average N[fps]` the application prints itself.

**Decoder.** Measured only on a long bitstream. 200 frames of 1080p decode in
0.14 s at `--lp 8`, which is measurement noise, not a measurement; the file is
concatenated five times (1000 frames) — JPEG XS frames are independent, so
concatenation yields a valid stream.

**Both ISA levels and both thread counts.** `--asm c|sse4_1|avx2|avx512` and
`--lp 0|8`. One thread shows what happened to the kernel; eight threads show how
much of it survives once the pipeline is bound by memory and scheduling.

**Interleaved A/B, always.** Two builds sit side by side and their runs
alternate, best-of-5 each. The machine drifts by up to 3% over a session (boost,
thermals), so best-of-N taken over a single build at one point in time and
compared with a number taken an hour earlier is not a measurement. `best`, not
mean: interference only ever pushes a run down, so the maximum is the cleanest
estimate of the ceiling.

**The reference build is rebuilt at every step.** Each change was measured
against a build of the immediately preceding commit, not against a stale
reference — otherwise a step is credited with the sum of several changes.

**Correctness gates every measurement.** Before a number is believed, the build
must (a) produce bit-identical output across `c`/`sse4_1`/`avx2`/`avx512` over
five option sets and two sources, and (b) match a reference build of upstream
0.10 byte for byte — changes in the shared C code are invisible in an
ISA-vs-ISA comparison and can only be caught against an external reference. A
speed-up that changes the output is not a speed-up.

**Profiling.** `perf record -F 1999` plus `perf report --no-children -g none`
for the flat profile, `perf annotate -l` and `--sort srcline` to attribute time
inside a kernel. Where the question was about the data rather than the code, the
distribution was instrumented directly: a histogram of coefficient-group sizes
is what turned up the 87% of empty groups and the 40% of groups that were
falling onto the sequential path.

## Measured and reverted

So that nobody replays them:

- branchless `write_4_bits_align4` and `read_4_bits_align4_fast` - −12% (a memory read appears where there used to be a pure store);
- batching the packing nibbles through the generic `write_N_bits` - −8 pp;
- a branchless "group is empty" mask in the decoder, with the work computed unconditionally - −26.6%;
- **parsing GCLI codes in batches** (the positions of all terminators in a 32-bit window are taken by a `w &= w - 1` chain at one cycle per symbol, symbols accumulate in a queue) - **−8…−12%**. The "find the top bit, shift" chain turned out not to be the bottleneck, and the look-ahead is wasted: the callers take four to eight codes and close the reader;
- interleaving the inverse wavelet output with a single `vpermt2d` instead of two unpacks and two permutes - a wash: the instruction destroys its operand and the compiler adds exactly as many copies;
- assembling the decoder output sixty-four pixels at a time with pairs of packs instead of `vpmovdb` - −2…−4% on one thread (the same change on the encoder input gave +3%, where there are no neighbouring permutes competing for the same port);
- expanding significance flags from a byte into eight bytes by a multiply - a wash: the significance bands are too narrow for a batched expansion to pay off.

The general conclusion: attempts to break a data dependency lose systematically in this code - both the branchless variants and the look-ahead parsing. The branches here guard a substantial amount of work and predict better than the profile suggests; what wins is not removing the dependency but removing the work itself, as with the empty groups.
