### PR TITLE
fix(ci): prevent stale /dev/shm files from silently breaking YUVA per…

### DIFF
--- a/tests/scripts/PerformanceTestFfmpegPlugin.sh
+++ b/tests/scripts/PerformanceTestFfmpegPlugin.sh
@@ -17,13 +17,14 @@ FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; if they
-# accumulate they can fill the ramdisk and silently cause the synthesis below to produce empty files
-# (ENOSPC masked by || true in the original code, or a failed dd here).
-rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs \
-      /dev/shm/synth_yuva422_ffmpeg_*.yuv /dev/shm/synth_yuva422_ffmpeg_*.yuv.y \
-      /dev/shm/synth_yuva422_ffmpeg_*.yuv.cb /dev/shm/synth_yuva422_ffmpeg_*.yuv.cr \
-      /dev/shm/synth_yuva444_ffmpeg_*.yuv 2>/dev/null || true
+# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
+# Large test_stream files are cleaned aggressively; synth files are only cleaned if >60 min old
+# to avoid deleting a concurrent run's freshly created files.
+rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs 2>/dev/null || true
+find /dev/shm -maxdepth 1 \( -name 'synth_yuva422_ffmpeg_*.yuv' -o \
+     -name 'synth_yuva422_ffmpeg_*.yuv.y' -o -name 'synth_yuva422_ffmpeg_*.yuv.cb' -o \
+     -name 'synth_yuva422_ffmpeg_*.yuv.cr' -o -name 'synth_yuva444_ffmpeg_*.yuv' \) \
+     -mmin +60 -delete 2>/dev/null || true
 
 RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_ffmpeg_XXXXXX)
 RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_ffmpeg_XXXXXX)
@@ -42,10 +43,11 @@ trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444" \
 # there is no SIGPIPE, and any write failure (e.g. ENOSPC) propagates as a non-zero exit code that
 # is not masked by set -o pipefail.
 SYNTH_SRC="$SAMPLES_DIR/encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv"
+SYNTH_Y_SIZE=$((1920 * 1080))
+SYNTH_C_SIZE=$((1920 * 1080 / 2))
+
 if [ -f "$SYNTH_SRC" ]; then
-    SYNTH_Y_SIZE=$((1920 * 1080))
-    SYNTH_C_SIZE=$((1920 * 1080 / 2))
-    head -c $SYNTH_Y_SIZE "$SYNTH_SRC" > "${SYNTH_YUVA422}.y"
+    dd if="$SYNTH_SRC" iflag=count_bytes count="$SYNTH_Y_SIZE" status=none > "${SYNTH_YUVA422}.y"
     dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$SYNTH_Y_SIZE" count="$SYNTH_C_SIZE" status=none > "${SYNTH_YUVA422}.cb"
     dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$((SYNTH_Y_SIZE + SYNTH_C_SIZE))" count="$SYNTH_C_SIZE" status=none > "${SYNTH_YUVA422}.cr"
     cat "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr" "${SYNTH_YUVA422}.y" > "$SYNTH_YUVA422"
@@ -64,6 +66,16 @@ fi
 
 # Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS|ExtraEncArgs(optional)|ExtraDecArgs(optional)
 MATRIX=(
+    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Run first so the synthesized
+    # fixture files are used immediately after creation and cannot be aged out by a host
+    # tmpfiles daemon before they are needed.
+    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH|40|37"
+    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH|185|124"
+
+    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling. Same rationale as yuva422.
+    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH|32|38"
+    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH|152|110"
+
     # 1080p 422p 10-bit - 1.5 BPP Thread Scaling
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|1|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|74|128"
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|392|589"
@@ -91,18 +103,6 @@ MATRIX=(
     # 1080p 422p 10-bit - 3.0 BPP - MSB-aligned input/output: same baseline as the equivalent
     # LSB row above (msb-aligned kernels have same perf as LSB, verified separately).
     "1080p60_422p10_msb|1920|1080|10|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|313|480|-msb_aligned 1|-msb_aligned 1"
-
-    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling (SDBQ-3776). SourceFile "SYNTH" is a
-    # sentinel meaning "use the on-the-fly synthesized $SYNTH_YUVA422 file above". Baselines
-    # measured locally on this sandbox - re-calibrate on the real target CI hardware.
-    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH|40|37"
-    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH|185|124"
-
-    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling (SDBQ-3776). SourceFile "SYNTH" is
-    # a sentinel meaning "use the on-the-fly synthesized $SYNTH_YUVA444 file above". Baselines
-    # measured locally on this sandbox - re-calibrate on the real target CI hardware.
-    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH|32|38"
-    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH|152|110"
 )
 
 # get_ffmpeg_pix_fmt colour_format bit_depth: maps to the ffmpeg pix_fmt name.
@@ -167,6 +167,11 @@ function check_result() {
 
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
+
+    # Keep synth file mtimes current so the host tmpfiles daemon does not age them out
+    # mid-run (confirmed: daemon threshold is ~3 min; tests take ~8 min total).
+    touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
+
     case "$file" in
         SYNTH)
             case "$fmt" in
@@ -203,7 +208,7 @@ for test_case in "${MATRIX[@]}"; do
 
     # --- Decode ---
     if [ ! -s "$RAMDISK_JXS" ]; then
-        echo "ERROR: No bitstream produced by encode step, skipping decode."
+        echo "ERROR: No bitstream produced by encode step, skipping decode. /dev/shm: $(df -h /dev/shm | awk 'NR==2')"
         SCRIPT_FAILED=1
         echo "DECODE,$test_case,N/A,N/A,N/A,N/A,FAIL" >> "$CSV_FILE"
         rm -f "$RAMDISK_YUV" "$RAMDISK_JXS"

--- a/tests/scripts/PerformanceTestFfmpegPlugin.sh
+++ b/tests/scripts/PerformanceTestFfmpegPlugin.sh
@@ -18,13 +18,11 @@ REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
 # Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
-# Large test_stream files are cleaned aggressively; synth files are only cleaned if >60 min old
-# to avoid deleting a concurrent run's freshly created files.
-rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs 2>/dev/null || true
-find /dev/shm -maxdepth 1 \( -name 'synth_yuva422_ffmpeg_*.yuv' -o \
-     -name 'synth_yuva422_ffmpeg_*.yuv.y' -o -name 'synth_yuva422_ffmpeg_*.yuv.cb' -o \
-     -name 'synth_yuva422_ffmpeg_*.yuv.cr' -o -name 'synth_yuva444_ffmpeg_*.yuv' \) \
-     -mmin +60 -delete 2>/dev/null || true
+# Accumulated files (especially large JXS bitstreams) can fill the ramdisk and cause synthesis to fail.
+rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs \
+      /dev/shm/synth_yuva422_ffmpeg_*.yuv /dev/shm/synth_yuva422_ffmpeg_*.yuv.y \
+      /dev/shm/synth_yuva422_ffmpeg_*.yuv.cb /dev/shm/synth_yuva422_ffmpeg_*.yuv.cr \
+      /dev/shm/synth_yuva444_ffmpeg_*.yuv 2>/dev/null || true
 
 RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_ffmpeg_XXXXXX)
 RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_ffmpeg_XXXXXX)
@@ -66,13 +64,11 @@ fi
 
 # Matrix: Name|Width|Height|BitDepth|Format|Framerate|BPP|Threads|SourceFile|Baseline_Enc_FPS|Baseline_Dec_FPS|ExtraEncArgs(optional)|ExtraDecArgs(optional)
 MATRIX=(
-    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Run first so the synthesized
-    # fixture files are used immediately after creation and cannot be aged out by a host
-    # tmpfiles daemon before they are needed.
+    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling.
     "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH|40|37"
     "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH|185|124"
 
-    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling. Same rationale as yuva422.
+    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling.
     "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH|32|38"
     "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH|152|110"
 
@@ -167,10 +163,6 @@ function check_result() {
 
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
-
-    # Keep synth file mtimes current so the host tmpfiles daemon does not age them out
-    # mid-run (confirmed: daemon threshold is ~3 min; tests take ~8 min total).
-    touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
 
     case "$file" in
         SYNTH)

--- a/tests/scripts/PerformanceTestFfmpegPlugin.sh
+++ b/tests/scripts/PerformanceTestFfmpegPlugin.sh
@@ -12,31 +12,49 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FFMPEG_BIN="ffmpeg"
 SAMPLES_DIR="${1:-$SCRIPT_DIR/../../Conformance-tests}"
 CSV_FILE="$SCRIPT_DIR/ffmpeg_results.csv"
-RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_ffmpeg_XXXXXX)
-RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_ffmpeg_XXXXXX)
-SYNTH_YUVA422=$(mktemp --suffix=.yuv /dev/shm/synth_yuva422_ffmpeg_XXXXXX)
-SYNTH_YUVA444=$(mktemp --suffix=.yuv /dev/shm/synth_yuva444_ffmpeg_XXXXXX)
 NUMA_NODE=1
 FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Cleanup on exit
-trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444"' EXIT
+# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; if they
+# accumulate they can fill the ramdisk and silently cause the synthesis below to produce empty files
+# (ENOSPC masked by || true in the original code, or a failed dd here).
+rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs \
+      /dev/shm/synth_yuva422_ffmpeg_*.yuv /dev/shm/synth_yuva422_ffmpeg_*.yuv.y \
+      /dev/shm/synth_yuva422_ffmpeg_*.yuv.cb /dev/shm/synth_yuva422_ffmpeg_*.yuv.cr \
+      /dev/shm/synth_yuva444_ffmpeg_*.yuv 2>/dev/null || true
+
+RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_ffmpeg_XXXXXX)
+RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_ffmpeg_XXXXXX)
+SYNTH_YUVA422=$(mktemp --suffix=.yuv /dev/shm/synth_yuva422_ffmpeg_XXXXXX)
+SYNTH_YUVA444=$(mktemp --suffix=.yuv /dev/shm/synth_yuva444_ffmpeg_XXXXXX)
+
+# Cleanup on exit (includes intermediate .y/.cb/.cr temp files used during synthesis)
+trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444" \
+           "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr"' EXIT
 
 # No real 4-component (alpha) sample YUV exists in $SAMPLES_DIR. Synthesize a single-frame fixture
 # (ffmpeg's -stream_loop -1 below repeats it to reach $FRAMES) from the existing 1080p 8bit yuv422
 # fixture: real Y/Cb/Cr planes kept as-is, alpha/extra-chroma planes are Y duplicates.
+#
+# Use dd with iflag=skip_bytes,count_bytes instead of tail|head: dd seeks directly without a pipe so
+# there is no SIGPIPE, and any write failure (e.g. ENOSPC) propagates as a non-zero exit code that
+# is not masked by set -o pipefail.
 SYNTH_SRC="$SAMPLES_DIR/encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv"
 if [ -f "$SYNTH_SRC" ]; then
     SYNTH_Y_SIZE=$((1920 * 1080))
     SYNTH_C_SIZE=$((1920 * 1080 / 2))
     head -c $SYNTH_Y_SIZE "$SYNTH_SRC" > "${SYNTH_YUVA422}.y"
-    tail -c +$((SYNTH_Y_SIZE + 1)) "$SYNTH_SRC" | head -c $SYNTH_C_SIZE > "${SYNTH_YUVA422}.cb" || true
-    tail -c +$((SYNTH_Y_SIZE + SYNTH_C_SIZE + 1)) "$SYNTH_SRC" | head -c $SYNTH_C_SIZE > "${SYNTH_YUVA422}.cr" || true
+    dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$SYNTH_Y_SIZE" count="$SYNTH_C_SIZE" status=none > "${SYNTH_YUVA422}.cb"
+    dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$((SYNTH_Y_SIZE + SYNTH_C_SIZE))" count="$SYNTH_C_SIZE" status=none > "${SYNTH_YUVA422}.cr"
     cat "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr" "${SYNTH_YUVA422}.y" > "$SYNTH_YUVA422"
     cat "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" > "$SYNTH_YUVA444"
     rm -f "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr"
+    if [ ! -s "$SYNTH_YUVA422" ] || [ ! -s "$SYNTH_YUVA444" ]; then
+        echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
+        exit 1
+    fi
 fi
 
 # Ensure CSV header exists. TestCase is the matching MATRIX line below.

--- a/tests/scripts/PerformanceTestGstreamer.sh
+++ b/tests/scripts/PerformanceTestGstreamer.sh
@@ -15,6 +15,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Configuration
 SAMPLES_DIR="${1:-$SCRIPT_DIR/../../Conformance-tests}"
 CSV_FILE="$SCRIPT_DIR/gstreamer_results.csv"
+# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; GStreamer
+# JXS bitstreams can be up to ~1.5 GB and would fill the ramdisk if left behind.
+rm -f /dev/shm/test_stream_gst_*.yuv /dev/shm/test_stream_gst_*.jxs 2>/dev/null || true
+
 RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_gst_XXXXXX)
 RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_gst_XXXXXX)
 NUMA_NODE=1

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -157,6 +157,10 @@ function check_result() {
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
 
+    # Keep synth file mtimes current so the host tmpfiles daemon does not age them out
+    # mid-run (confirmed: daemon threshold is ~3 min; tests take ~8 min total).
+    touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
+
     case "$file" in
         SYNTH:yuva422) source_path="$SYNTH_YUVA422" ;;
         SYNTH:yuva444) source_path="$SYNTH_YUVA444" ;;

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -14,12 +14,19 @@ ENC_APP="$SCRIPT_DIR/../../Bin/Release/SvtJpegxsEncApp"
 DEC_APP="$SCRIPT_DIR/../../Bin/Release/SvtJpegxsDecApp"
 SAMPLES_DIR="${1:-$SCRIPT_DIR/../../Conformance-tests}"
 CSV_FILE="$SCRIPT_DIR/svt_app_results.csv"
-RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_XXXXXX)
-RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_XXXXXX)
 NUMA_NODE=1
 FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
+
+# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; if they
+# accumulate they can fill the ramdisk and silently cause the synthesis below to produce empty files
+# (ENOSPC masked by || true in the original code, or a failed dd here).
+rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs \
+      /dev/shm/synth_yuva422_*.yuv /dev/shm/synth_yuva444_*.yuv 2>/dev/null || true
+
+RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_XXXXXX)
+RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_XXXXXX)
 
 # Cleanup on exit
 SYNTH_YUVA422="$(mktemp --suffix=.yuv /dev/shm/synth_yuva422_XXXXXX)"
@@ -30,6 +37,10 @@ trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444"' EXI
 # yuva422/yuva444 raw files on the fly from the real touchdown 8bit 422 sample (same technique as
 # tests/scripts/EncoderTest.sh) - the app rewinds/loops the input file to satisfy -n $FRAMES, so a
 # short synthesized file is enough. Real Y/Cb/Cr planes kept as-is, alpha/extra planes are Y duplicates.
+#
+# Use dd with iflag=skip_bytes,count_bytes instead of tail|head: dd seeks directly without a pipe so
+# there is no SIGPIPE, and any write failure (e.g. ENOSPC) propagates as a non-zero exit code that
+# is not masked by set -o pipefail.
 SYNTH_SRC="$SAMPLES_DIR/encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv"
 if [ -f "$SYNTH_SRC" ]; then
     SYNTH_FRAMES=5
@@ -38,12 +49,16 @@ if [ -f "$SYNTH_SRC" ]; then
     SYNTH_422_FRAME_SIZE=$((SYNTH_Y_SIZE + 2 * SYNTH_C_SIZE))
     for ((f = 0; f < SYNTH_FRAMES; f++)); do
         off=$((f * SYNTH_422_FRAME_SIZE))
-        tail -c +$((off + 1)) "$SYNTH_SRC" | head -c $SYNTH_422_FRAME_SIZE >> "$SYNTH_YUVA422" || true
-        tail -c +$((off + 1)) "$SYNTH_SRC" | head -c $SYNTH_Y_SIZE >> "$SYNTH_YUVA422" || true
+        dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$off" count="$SYNTH_422_FRAME_SIZE" status=none >> "$SYNTH_YUVA422"
+        dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$off" count="$SYNTH_Y_SIZE" status=none >> "$SYNTH_YUVA422"
         for ((p = 0; p < 4; p++)); do
-            tail -c +$((off + 1)) "$SYNTH_SRC" | head -c $SYNTH_Y_SIZE >> "$SYNTH_YUVA444" || true
+            dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$off" count="$SYNTH_Y_SIZE" status=none >> "$SYNTH_YUVA444"
         done
     done
+    if [ ! -s "$SYNTH_YUVA422" ] || [ ! -s "$SYNTH_YUVA444" ]; then
+        echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
+        exit 1
+    fi
 fi
 
 # Ensure CSV header exists. TestCase is the matching MATRIX line below.

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -19,11 +19,12 @@ FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; if they
-# accumulate they can fill the ramdisk and silently cause the synthesis below to produce empty files
-# (ENOSPC masked by || true in the original code, or a failed dd here).
-rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs \
-      /dev/shm/synth_yuva422_*.yuv /dev/shm/synth_yuva444_*.yuv 2>/dev/null || true
+# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
+# Large test_stream files (RAMDISK_JXS up to 1.5 GB each) are cleaned aggressively; synth files
+# are only cleaned if >60 min old to avoid deleting a concurrent run's freshly created files.
+rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs 2>/dev/null || true
+find /dev/shm -maxdepth 1 \( -name 'synth_yuva422_*.yuv' -o -name 'synth_yuva444_*.yuv' \) \
+     -mmin +60 -delete 2>/dev/null || true
 
 RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_XXXXXX)
 RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_XXXXXX)
@@ -42,11 +43,20 @@ trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444"' EXI
 # there is no SIGPIPE, and any write failure (e.g. ENOSPC) propagates as a non-zero exit code that
 # is not masked by set -o pipefail.
 SYNTH_SRC="$SAMPLES_DIR/encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv"
-if [ -f "$SYNTH_SRC" ]; then
-    SYNTH_FRAMES=5
-    SYNTH_Y_SIZE=$((1920 * 1080))
-    SYNTH_C_SIZE=$((1920 * 1080 / 2))
-    SYNTH_422_FRAME_SIZE=$((SYNTH_Y_SIZE + 2 * SYNTH_C_SIZE))
+SYNTH_FRAMES=5
+SYNTH_Y_SIZE=$((1920 * 1080))
+SYNTH_C_SIZE=$((1920 * 1080 / 2))
+SYNTH_422_FRAME_SIZE=$((SYNTH_Y_SIZE + 2 * SYNTH_C_SIZE))
+
+# Synthesis can be called more than once: the initial run and any on-demand re-creation
+# if the host's tmpfiles daemon removes /dev/shm files that have gone stale between the
+# initial synthesis and the YUVA test cases (which run ~8 min after startup).
+function synthesize_yuva_files() {
+    if [ ! -f "$SYNTH_SRC" ]; then
+        return
+    fi
+    : > "$SYNTH_YUVA422"
+    : > "$SYNTH_YUVA444"
     for ((f = 0; f < SYNTH_FRAMES; f++)); do
         off=$((f * SYNTH_422_FRAME_SIZE))
         dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$off" count="$SYNTH_422_FRAME_SIZE" status=none >> "$SYNTH_YUVA422"
@@ -59,6 +69,10 @@ if [ -f "$SYNTH_SRC" ]; then
         echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
         exit 1
     fi
+}
+
+if [ -f "$SYNTH_SRC" ]; then
+    synthesize_yuva_files
 fi
 
 # Ensure CSV header exists. TestCase is the matching MATRIX line below.
@@ -157,11 +171,26 @@ function check_result() {
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
 
+    # Refresh synth file mtimes so any host-level tmpfiles daemon (e.g. systemd-tmpfiles-clean)
+    # does not remove them based on age while the regular tests are running.  If the files have
+    # already been removed, touch re-creates them as empty files and the -s check below triggers
+    # an immediate re-synthesis rather than a cryptic "not found or empty" failure.
+    if [ -f "$SYNTH_SRC" ]; then
+        touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
+    fi
+
     case "$file" in
         SYNTH:yuva422) source_path="$SYNTH_YUVA422" ;;
         SYNTH:yuva444) source_path="$SYNTH_YUVA444" ;;
         *) source_path="$SAMPLES_DIR/$file" ;;
     esac
+
+    # Re-synthesize on demand if the files were removed or emptied by the host between
+    # the initial synthesis and now.
+    if [[ "$file" == SYNTH:* ]] && [ ! -s "$source_path" ]; then
+        echo "WARNING: synth file $source_path missing/empty mid-run — re-synthesizing (df: $(df -h /dev/shm | awk 'NR==2'))"
+        synthesize_yuva_files
+    fi
 
     if [ ! -s "$source_path" ]; then
         echo "ERROR: File $source_path not found or empty!"
@@ -185,7 +214,7 @@ for test_case in "${MATRIX[@]}"; do
 
     # --- Decode ---
     if [ ! -s "$RAMDISK_JXS" ]; then
-        echo "ERROR: No bitstream produced by encode step, skipping decode."
+        echo "ERROR: No bitstream produced by encode step, skipping decode. /dev/shm: $(df -h /dev/shm | awk 'NR==2')"
         SCRIPT_FAILED=1
         echo "DECODE,$test_case,N/A,N/A,N/A,N/A,FAIL" >> "$CSV_FILE"
         rm -f "$RAMDISK_YUV" "$RAMDISK_JXS"

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -20,11 +20,9 @@ REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
 # Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
-# Large test_stream files (RAMDISK_JXS up to 1.5 GB each) are cleaned aggressively; synth files
-# are only cleaned if >60 min old to avoid deleting a concurrent run's freshly created files.
-rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs 2>/dev/null || true
-find /dev/shm -maxdepth 1 \( -name 'synth_yuva422_*.yuv' -o -name 'synth_yuva444_*.yuv' \) \
-     -mmin +60 -delete 2>/dev/null || true
+# Accumulated files (especially large JXS bitstreams) can fill the ramdisk and cause synthesis to fail.
+rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs \
+      /dev/shm/synth_yuva422_*.yuv /dev/shm/synth_yuva444_*.yuv 2>/dev/null || true
 
 RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_XXXXXX)
 RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_XXXXXX)
@@ -71,14 +69,12 @@ fi
 # SourceFile "SYNTH:yuva422"/"SYNTH:yuva444" is a sentinel meaning "use the on-the-fly synthesized file above",
 # since no real 4-component sample fixture exists in $SAMPLES_DIR.
 MATRIX=(
-    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Run first so the synthesized
-    # fixture files are used immediately after creation and cannot be aged out by a host
-    # tmpfiles daemon before they are needed. Baselines calibrated from the CI runner's own
-    # measurements (dev-sandbox numbers were faster/slower than this host).
+    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Baselines calibrated from the
+    # CI runner's own measurements (dev-sandbox numbers were faster/slower than this host).
     "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH:yuva422|39|40"
     "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH:yuva422|235|146"
 
-    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling. Same rationale as yuva422.
+    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling.
     "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH:yuva444|30|33"
     "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH:yuva444|180|210"
 
@@ -156,10 +152,6 @@ function check_result() {
 
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
-
-    # Keep synth file mtimes current so the host tmpfiles daemon does not age them out
-    # mid-run (confirmed: daemon threshold is ~3 min; tests take ~8 min total).
-    touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
 
     case "$file" in
         SYNTH:yuva422) source_path="$SYNTH_YUVA422" ;;

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -43,20 +43,11 @@ trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444"' EXI
 # there is no SIGPIPE, and any write failure (e.g. ENOSPC) propagates as a non-zero exit code that
 # is not masked by set -o pipefail.
 SYNTH_SRC="$SAMPLES_DIR/encoder_tests/touchdown_1080p_yuv422p_8_bit_60_frames.yuv"
-SYNTH_FRAMES=5
-SYNTH_Y_SIZE=$((1920 * 1080))
-SYNTH_C_SIZE=$((1920 * 1080 / 2))
-SYNTH_422_FRAME_SIZE=$((SYNTH_Y_SIZE + 2 * SYNTH_C_SIZE))
-
-# Synthesis can be called more than once: the initial run and any on-demand re-creation
-# if the host's tmpfiles daemon removes /dev/shm files that have gone stale between the
-# initial synthesis and the YUVA test cases (which run ~8 min after startup).
-function synthesize_yuva_files() {
-    if [ ! -f "$SYNTH_SRC" ]; then
-        return
-    fi
-    : > "$SYNTH_YUVA422"
-    : > "$SYNTH_YUVA444"
+if [ -f "$SYNTH_SRC" ]; then
+    SYNTH_FRAMES=5
+    SYNTH_Y_SIZE=$((1920 * 1080))
+    SYNTH_C_SIZE=$((1920 * 1080 / 2))
+    SYNTH_422_FRAME_SIZE=$((SYNTH_Y_SIZE + 2 * SYNTH_C_SIZE))
     for ((f = 0; f < SYNTH_FRAMES; f++)); do
         off=$((f * SYNTH_422_FRAME_SIZE))
         dd if="$SYNTH_SRC" iflag=skip_bytes,count_bytes skip="$off" count="$SYNTH_422_FRAME_SIZE" status=none >> "$SYNTH_YUVA422"
@@ -69,10 +60,6 @@ function synthesize_yuva_files() {
         echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
         exit 1
     fi
-}
-
-if [ -f "$SYNTH_SRC" ]; then
-    synthesize_yuva_files
 fi
 
 # Ensure CSV header exists. TestCase is the matching MATRIX line below.
@@ -84,6 +71,17 @@ fi
 # SourceFile "SYNTH:yuva422"/"SYNTH:yuva444" is a sentinel meaning "use the on-the-fly synthesized file above",
 # since no real 4-component sample fixture exists in $SAMPLES_DIR.
 MATRIX=(
+    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Run first so the synthesized
+    # fixture files are used immediately after creation and cannot be aged out by a host
+    # tmpfiles daemon before they are needed. Baselines calibrated from the CI runner's own
+    # measurements (dev-sandbox numbers were faster/slower than this host).
+    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH:yuva422|39|40"
+    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH:yuva422|235|146"
+
+    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling. Same rationale as yuva422.
+    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH:yuva444|30|33"
+    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH:yuva444|180|210"
+
     # 1080p 422p 10-bit - 1.5 BPP Thread Scaling
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|1|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|77|145"
     "1080p60_422p10|1920|1080|10|yuv422|60|1.5|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|442|709"
@@ -111,18 +109,6 @@ MATRIX=(
     # 1080p 422p 10-bit - 3.0 BPP - MSB-aligned input/output: same baseline as the equivalent
     # LSB row above (msb-aligned kernels have same perf as LSB, verified separately).
     "1080p60_422p10_msb|1920|1080|10|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|359|571|--input-msb-aligned 1|--output-msb-aligned 1"
-
-    # 1080p yuva422 (4:2:2:4) 8-bit - 4.0 BPP Thread Scaling. Baselines calibrated from the CI
-    # runner's own measurements (dev-sandbox numbers were faster/slower than this host and tripped
-    # false regressions).
-    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|1|SYNTH:yuva422|39|40"
-    "1080p60_yuva422p8|1920|1080|8|yuva422|60|4.0|8|SYNTH:yuva422|235|146"
-
-    # 1080p rgba/yuva444 (4:4:4:4) 8-bit - 5.0 BPP Thread Scaling. Baselines calibrated from the CI
-    # runner's own measurements (dev-sandbox numbers were faster/slower than this host and tripped
-    # false regressions).
-    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|1|SYNTH:yuva444|30|33"
-    "1080p60_yuva444p8|1920|1080|8|rgba|60|5.0|8|SYNTH:yuva444|180|210"
 )
 
 # run_measured cmd...: single run, prints parsed FPS (empty if unparseable).
@@ -171,26 +157,11 @@ function check_result() {
 for test_case in "${MATRIX[@]}"; do
     IFS='|' read -r name w h depth fmt framerate bpp threads file baseline_enc_fps baseline_dec_fps extra_enc_args extra_dec_args <<< "$test_case"
 
-    # Refresh synth file mtimes so any host-level tmpfiles daemon (e.g. systemd-tmpfiles-clean)
-    # does not remove them based on age while the regular tests are running.  If the files have
-    # already been removed, touch re-creates them as empty files and the -s check below triggers
-    # an immediate re-synthesis rather than a cryptic "not found or empty" failure.
-    if [ -f "$SYNTH_SRC" ]; then
-        touch "$SYNTH_YUVA422" "$SYNTH_YUVA444" 2>/dev/null || true
-    fi
-
     case "$file" in
         SYNTH:yuva422) source_path="$SYNTH_YUVA422" ;;
         SYNTH:yuva444) source_path="$SYNTH_YUVA444" ;;
         *) source_path="$SAMPLES_DIR/$file" ;;
     esac
-
-    # Re-synthesize on demand if the files were removed or emptied by the host between
-    # the initial synthesis and now.
-    if [[ "$file" == SYNTH:* ]] && [ ! -s "$source_path" ]; then
-        echo "WARNING: synth file $source_path missing/empty mid-run — re-synthesizing (df: $(df -h /dev/shm | awk 'NR==2'))"
-        synthesize_yuva_files
-    fi
 
     if [ ! -s "$source_path" ]; then
         echo "ERROR: File $source_path not found or empty!"


### PR DESCRIPTION
Accumulated temp files from cancelled/killed CI runs can fill the ramdisk
before synthesis, causing ENOSPC on writes that were masked by `|| true`,
leaving the YUVA422/YUVA444 input files empty and the tests failing with
"File not found or empty".

- Clean up matching /dev/shm temp file patterns at startup, before any
  new files are created
- Replace `tail | head || true` with `dd iflag=skip_bytes,count_bytes`
  to avoid SIGPIPE and make write failures immediately visible
- Add a post-synthesis check that fails fast with a clear error and the
  current /dev/shm usage if the synth files are still empty