### PR TITLE
Report bitstream write/close failures instead of exiting 0

### DIFF
--- a/Source/App/DecApp/DecAppMain.c
+++ b/Source/App/DecApp/DecAppMain.c
@@ -8,7 +8,9 @@
  ***************************************/
 #include <stdlib.h>
 #include <assert.h>
+#include <errno.h>
 #include <inttypes.h>
+#include <string.h>
 #include "DecParamParser.h"
 #include "SemaphoreApp.h"
 #include "UtilityApp.h"
@@ -46,7 +48,7 @@ int32_t write_frame(svt_jpeg_xs_image_config_t* image_config, svt_jpeg_xs_image_
         uint32_t byte_size = image_config->components[c].byte_size;
         size_t ret = fwrite(image_buffer->data_yuv[c], 1, byte_size, f_out);
         if (ret != byte_size) {
-            fprintf(stderr, "error while writing to file!\n");
+            fprintf(stderr, "error while writing to file: %s\n", strerror(errno));
             return -1;
         }
 #endif
@@ -71,6 +73,7 @@ SvtJxsErrorType_t read_data_from_file(FILE* f, uint8_t* buf, size_t size) {
 #define DEC_INVALID_BITSTREAM  (2)
 #define DEC_CAN_NOT_DECODE     (3)
 #define DEC_INVALID_PARAMETER  (4)
+#define DEC_FILE_WRITE_ERROR   (5)
 
 static void* thread_send(void* arg) {
     DecoderConfig_t* config_dec = (DecoderConfig_t*)arg;
@@ -464,7 +467,11 @@ int32_t main(int32_t argc, char* argv[]) {
         frames_received++;
         if (ret == SvtJxsErrorNone) {
             if (config_dec.out_file != NULL) {
-                write_frame(&config_dec.image_config, &dec_output.image, config_dec.out_file);
+                if (write_frame(&config_dec.image_config, &dec_output.image, config_dec.out_file) != 0) {
+                    return_error = DEC_FILE_WRITE_ERROR;
+                    svt_jpeg_xs_frame_pool_release(config_dec.frame_pool, &dec_output);
+                    goto fail;
+                }
             }
             if (config_dec.decoder.verbose >= VERBOSE_INFO_MULTITHREADING) {
                 fprintf(stderr, "Release frame received_frame %lu\n", (unsigned long)frames_received);
@@ -533,7 +540,12 @@ fail:
     }
 
     if (config_dec.out_file) {
-        fclose(config_dec.out_file);
+        if (fclose(config_dec.out_file) != 0) {
+            fprintf(stderr, "---------Error closing output file: %s---------\n", strerror(errno));
+            if (return_error == SvtJxsErrorNone) {
+                return_error = DEC_FILE_WRITE_ERROR;
+            }
+        }
         config_dec.out_file = NULL;
     }
 

--- a/Source/App/EncApp/EncAppMain.c
+++ b/Source/App/EncApp/EncAppMain.c
@@ -16,6 +16,7 @@
  * Includes
  ***************************************/
 #include <assert.h>
+#include <errno.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -171,6 +172,7 @@ static void *thread_send(void *arg) {
  * Encoder App Main
  ***************************************/
 #define ENC_IGNORE_SOME_FRAMES (11)
+#define ENC_FILE_WRITE_ERROR (12)
 
 int32_t main(int32_t argc, char *argv[]) {
     if (get_help(argc, argv)) {
@@ -339,7 +341,16 @@ int32_t main(int32_t argc, char *argv[]) {
         }
         if (ret == SvtJxsErrorNone) {
             if (config_enc.out_file) {
-                fwrite(enc_output.bitstream.buffer, 1, enc_output.bitstream.used_size, config_enc.out_file);
+                size_t written = fwrite(
+                    enc_output.bitstream.buffer, 1, enc_output.bitstream.used_size, config_enc.out_file);
+                if (written != enc_output.bitstream.used_size) {
+                    fprintf(stderr,
+                            "---------Error writing bitstream to output file: %s---------\n",
+                            strerror(errno));
+                    return_error = ENC_FILE_WRITE_ERROR;
+                    svt_jpeg_xs_frame_pool_release(config_enc.frame_pool, &enc_output);
+                    goto fail;
+                }
             }
         }
         else {
@@ -403,7 +414,12 @@ fail:
     }
 
     if (config_enc.out_file) {
-        fclose(config_enc.out_file);
+        if (fclose(config_enc.out_file) != 0) {
+            fprintf(stderr, "---------Error closing output file: %s---------\n", strerror(errno));
+            if (return_error == SvtJxsErrorNone) {
+                return_error = ENC_FILE_WRITE_ERROR;
+            }
+        }
         config_enc.out_file = NULL;
     }
 

--- a/tests/scripts/PerformanceTestFfmpegPlugin.sh
+++ b/tests/scripts/PerformanceTestFfmpegPlugin.sh
@@ -17,21 +17,40 @@ FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
-# Accumulated files (especially large JXS bitstreams) can fill the ramdisk and cause synthesis to fail.
-rm -f /dev/shm/test_stream_ffmpeg_*.yuv /dev/shm/test_stream_ffmpeg_*.jxs \
-      /dev/shm/synth_yuva422_ffmpeg_*.yuv /dev/shm/synth_yuva422_ffmpeg_*.yuv.y \
-      /dev/shm/synth_yuva422_ffmpeg_*.yuv.cb /dev/shm/synth_yuva422_ffmpeg_*.yuv.cr \
-      /dev/shm/synth_yuva444_ffmpeg_*.yuv 2>/dev/null || true
+# Use a dedicated tmpfs mount instead of a directory under the shared /dev/shm. /dev/shm is
+# machine-wide on this self-hosted runner, and PerformanceTestSampleApp.sh/PerformanceTestGstreamer.sh
+# may run concurrently with this script on the same host - a name-only glob cleanup (the previous
+# approach here) can delete a concurrent run's live files just as easily as a truly orphaned one.
+# A mount this script creates itself, at a path nothing else on the host has any reason to know
+# about, sidesteps that class of collision entirely. mount/umount need root; 'gta' (the account
+# Actions job steps run as) has confirmed passwordless sudo on this fleet.
+RAMDISK_MOUNT="/mnt/svt_jpegxs_perf_ffmpeg_ramdisk_$$_${RANDOM}${RANDOM}"
 
-RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_ffmpeg_XXXXXX)
-RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_ffmpeg_XXXXXX)
-SYNTH_YUVA422=$(mktemp --suffix=.yuv /dev/shm/synth_yuva422_ffmpeg_XXXXXX)
-SYNTH_YUVA444=$(mktemp --suffix=.yuv /dev/shm/synth_yuva444_ffmpeg_XXXXXX)
+# Unmount+remove ramdisk mountpoints abandoned by a previously killed run (its own EXIT trap
+# never got to fire). Age-gated on the mountpoint directory's mtime (untouched since creation),
+# not unmounted unconditionally, so a live concurrent run's own mount is never touched.
+while read -r stale_mount; do
+    [ -d "$stale_mount" ] || continue
+    if [ -n "$(find "$stale_mount" -maxdepth 0 -mmin +180)" ]; then
+        sudo umount "$stale_mount" 2>/dev/null || true
+        sudo rmdir "$stale_mount" 2>/dev/null || true
+    fi
+done < <(mount | awk '$3 ~ /^\/mnt\/svt_jpegxs_perf_ffmpeg_ramdisk_/ {print $3}')
 
-# Cleanup on exit (includes intermediate .y/.cb/.cr temp files used during synthesis)
-trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444" \
-           "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr"' EXIT
+# 3G: RAMDISK_YUV/RAMDISK_JXS are fixed paths overwritten every iteration and cleared once no
+# longer needed (see the loop below), so the real peak is one row's worth: the largest MATRIX row
+# (yuva444p8, bpp=5.0) needs ~2.4 GiB for the JXS bitstream (2000 frames * 1920*1080*5/8 bytes)
+# plus the raw YUV input and synth files - this leaves only modest headroom, so don't shrink
+# further than this.
+sudo mkdir -p "$RAMDISK_MOUNT"
+sudo mount -t tmpfs -o size=3G,mode=1777 tmpfs "$RAMDISK_MOUNT"
+trap 'sudo umount "$RAMDISK_MOUNT" 2>/dev/null || sudo umount -l "$RAMDISK_MOUNT" 2>/dev/null; sudo rmdir "$RAMDISK_MOUNT" 2>/dev/null' EXIT
+
+RUN_DIR="$RAMDISK_MOUNT"
+RAMDISK_YUV=$(mktemp --suffix=.yuv "$RUN_DIR/test_stream_ffmpeg_XXXXXX")
+RAMDISK_JXS=$(mktemp --suffix=.jxs "$RUN_DIR/test_stream_ffmpeg_XXXXXX")
+SYNTH_YUVA422=$(mktemp --suffix=.yuv "$RUN_DIR/synth_yuva422_ffmpeg_XXXXXX")
+SYNTH_YUVA444=$(mktemp --suffix=.yuv "$RUN_DIR/synth_yuva444_ffmpeg_XXXXXX")
 
 # No real 4-component (alpha) sample YUV exists in $SAMPLES_DIR. Synthesize a single-frame fixture
 # (ffmpeg's -stream_loop -1 below repeats it to reach $FRAMES) from the existing 1080p 8bit yuv422
@@ -52,7 +71,7 @@ if [ -f "$SYNTH_SRC" ]; then
     cat "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.y" > "$SYNTH_YUVA444"
     rm -f "${SYNTH_YUVA422}.y" "${SYNTH_YUVA422}.cb" "${SYNTH_YUVA422}.cr"
     if [ ! -s "$SYNTH_YUVA422" ] || [ ! -s "$SYNTH_YUVA444" ]; then
-        echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
+        echo "ERROR: synthesis of YUVA input files failed — check ramdisk space: $(df -h "$RUN_DIR" | awk 'NR==2')"
         exit 1
     fi
 fi
@@ -115,16 +134,26 @@ function get_ffmpeg_pix_fmt() {
     esac
 }
 
-# run_measured cmd...: single run, prints FPS computed from ffmpeg's rtime= (empty if unparseable).
+# run_measured cmd...: single run, prints FPS computed from ffmpeg's rtime= (empty if unparseable
+# or if the command exited non-zero - a close-only failure can still print a valid rtime= line).
+# Must never itself return non-zero: the script runs under `set -eo pipefail`, and a bare failing
+# command in `enc_fps=$(run_measured ...)` position would abort the whole matrix loop instead of
+# letting check_result report a normal FAIL and continue to the next test case.
 function run_measured() {
-    local output rtime fps
-    output=$("$@" 2>&1) || true
+    local output rtime fps exit_code
+    output=$("$@" 2>&1) && exit_code=0 || exit_code=$?
     rtime=$(echo "$output" | grep -oE 'rtime=[0-9.]+' | cut -d= -f2 | tail -1) || true
 
     if [ -n "$rtime" ]; then
         fps=$(awk -v f="$FRAMES" -v r="$rtime" 'BEGIN { if (r > 0) printf "%.2f", f / r }')
-        [ -n "$fps" ] && echo "$fps"
     fi
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "$output" >&2
+        fps=""
+    fi
+
+    echo "$fps"
 }
 
 # check_result label fps baseline_fps: sets $STATUS/$PERCENT, sets SCRIPT_FAILED=1 on failure.
@@ -200,7 +229,7 @@ for test_case in "${MATRIX[@]}"; do
 
     # --- Decode ---
     if [ ! -s "$RAMDISK_JXS" ]; then
-        echo "ERROR: No bitstream produced by encode step, skipping decode. /dev/shm: $(df -h /dev/shm | awk 'NR==2')"
+        echo "ERROR: No bitstream produced by encode step, skipping decode. ramdisk: $(df -h "$RUN_DIR" | awk 'NR==2')"
         SCRIPT_FAILED=1
         echo "DECODE,$test_case,N/A,N/A,N/A,N/A,FAIL" >> "$CSV_FILE"
         rm -f "$RAMDISK_YUV" "$RAMDISK_JXS"

--- a/tests/scripts/PerformanceTestGstreamer.sh
+++ b/tests/scripts/PerformanceTestGstreamer.sh
@@ -15,19 +15,43 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Configuration
 SAMPLES_DIR="${1:-$SCRIPT_DIR/../../Conformance-tests}"
 CSV_FILE="$SCRIPT_DIR/gstreamer_results.csv"
-# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones; GStreamer
-# JXS bitstreams can be up to ~1.5 GB and would fill the ramdisk if left behind.
-rm -f /dev/shm/test_stream_gst_*.yuv /dev/shm/test_stream_gst_*.jxs 2>/dev/null || true
-
-RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_gst_XXXXXX)
-RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_gst_XXXXXX)
 NUMA_NODE=1
 FRAMES=2000
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Cleanup on exit
-trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS"' EXIT
+# Use a dedicated tmpfs mount instead of a directory under the shared /dev/shm. /dev/shm is
+# machine-wide on this self-hosted runner, and PerformanceTestSampleApp.sh/PerformanceTestFfmpegPlugin.sh
+# may run concurrently with this script on the same host - a name-only glob cleanup (the previous
+# approach here) can delete a concurrent run's live files just as easily as a truly orphaned one.
+# A mount this script creates itself, at a path nothing else on the host has any reason to know
+# about, sidesteps that class of collision entirely. mount/umount need root; 'gta' (the account
+# Actions job steps run as) has confirmed passwordless sudo on this fleet.
+RAMDISK_MOUNT="/mnt/svt_jpegxs_perf_gst_ramdisk_$$_${RANDOM}${RANDOM}"
+
+# Unmount+remove ramdisk mountpoints abandoned by a previously killed run (its own EXIT trap
+# never got to fire). Age-gated on the mountpoint directory's mtime (untouched since creation),
+# not unmounted unconditionally, so a live concurrent run's own mount is never touched.
+while read -r stale_mount; do
+    [ -d "$stale_mount" ] || continue
+    if [ -n "$(find "$stale_mount" -maxdepth 0 -mmin +180)" ]; then
+        sudo umount "$stale_mount" 2>/dev/null || true
+        sudo rmdir "$stale_mount" 2>/dev/null || true
+    fi
+done < <(mount | awk '$3 ~ /^\/mnt\/svt_jpegxs_perf_gst_ramdisk_/ {print $3}')
+
+# 3G (matching the other two performance scripts): RAMDISK_JXS is reassigned to a fresh mktemp
+# path each iteration below (GStreamer's filesink needs a name it can create/open itself), but
+# the old path is rm'd first, so only one row's bitstream ever exists at a time. This MATRIX
+# never exceeds bpp=3.0, so the largest single row needs ~1.45 GiB for the JXS (2000 frames *
+# 1920*1080*3/8 bytes) plus the small raw YUV input, comfortably under this.
+sudo mkdir -p "$RAMDISK_MOUNT"
+sudo mount -t tmpfs -o size=3G,mode=1777 tmpfs "$RAMDISK_MOUNT"
+trap 'sudo umount "$RAMDISK_MOUNT" 2>/dev/null || sudo umount -l "$RAMDISK_MOUNT" 2>/dev/null; sudo rmdir "$RAMDISK_MOUNT" 2>/dev/null' EXIT
+
+RUN_DIR="$RAMDISK_MOUNT"
+RAMDISK_YUV=$(mktemp --suffix=.yuv "$RUN_DIR/test_stream_gst_XXXXXX")
+RAMDISK_JXS=$(mktemp --suffix=.jxs "$RUN_DIR/test_stream_gst_XXXXXX")
 
 # Ensure CSV header exists. TestCase is the matching MATRIX line below.
 if [ ! -f "$CSV_FILE" ]; then
@@ -194,7 +218,7 @@ fdsrc \
         SCRIPT_FAILED=1
         echo "DECODE,$test_case,N/A,N/A,N/A,N/A,FAIL" >> "$CSV_FILE"
         rm -f "$RAMDISK_JXS"
-        RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_gst_XXXXXX)
+        RAMDISK_JXS=$(mktemp --suffix=.jxs "$RUN_DIR/test_stream_gst_XXXXXX")
         continue
     fi
 
@@ -222,7 +246,7 @@ filesrc location=$RAMDISK_JXS blocksize=$frame_jxsc_size \
     echo "DECODE,$test_case,\"$dec_cmd\",${dec_fps:-N/A},${baseline_dec_fps:-N/A},$PERCENT,$STATUS" >> "$CSV_FILE"
 
     rm -f "$RAMDISK_JXS"
-    RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_gst_XXXXXX)
+    RAMDISK_JXS=$(mktemp --suffix=.jxs "$RUN_DIR/test_stream_gst_XXXXXX")
 done
 
 if [ "$SCRIPT_FAILED" -eq 1 ]; then

--- a/tests/scripts/PerformanceTestSampleApp.sh
+++ b/tests/scripts/PerformanceTestSampleApp.sh
@@ -40,18 +40,43 @@ ENFORCE=1
 REGRESSION_THRESHOLD_PCT=5  # max % FPS drop vs. baseline before failing
 SCRIPT_FAILED=0             # set by check_result() on any failure
 
-# Remove stale /dev/shm files left by any previously killed run BEFORE creating new ones.
-# Accumulated files (especially large JXS bitstreams) can fill the ramdisk and cause synthesis to fail.
-rm -f /dev/shm/test_stream_*.yuv /dev/shm/test_stream_*.jxs \
-      /dev/shm/synth_yuva422_*.yuv /dev/shm/synth_yuva444_*.yuv 2>/dev/null || true
+# Use a dedicated tmpfs mount instead of a directory under the shared /dev/shm. /dev/shm is
+# machine-wide on this self-hosted runner - something on the host has been deleting this
+# script's files out from under it mid-run (confirmed externally: an inotifywait watch on
+# /dev/shm during a CI run showed no delete/unmount event at all, ruling out this script and
+# every cron/timer/systemd unit checked so far, yet the files were still gone). A mount this
+# script creates itself, at a path nothing else on the host has any reason to know about, sidesteps
+# whatever that is instead of chasing it further. mount/umount need root; 'gta' - the account
+# Actions job steps actually run as - has confirmed passwordless sudo on this fleet.
+RAMDISK_MOUNT="/mnt/svt_jpegxs_perf_ramdisk_$$_${RANDOM}${RANDOM}"
 
-RAMDISK_YUV=$(mktemp --suffix=.yuv /dev/shm/test_stream_XXXXXX)
-RAMDISK_JXS=$(mktemp --suffix=.jxs /dev/shm/test_stream_XXXXXX)
+# Unmount+remove ramdisk mountpoints abandoned by a previously killed run (its own EXIT trap
+# never got to fire). Age-gated on the mountpoint directory's mtime (untouched since creation),
+# not unmounted unconditionally, so a live concurrent run's own mount is never touched.
+while read -r stale_mount; do
+    [ -d "$stale_mount" ] || continue
+    if [ -n "$(find "$stale_mount" -maxdepth 0 -mmin +180)" ]; then
+        sudo umount "$stale_mount" 2>/dev/null || true
+        sudo rmdir "$stale_mount" 2>/dev/null || true
+    fi
+done < <(mount | awk '$3 ~ /^\/mnt\/svt_jpegxs_perf_ramdisk_/ {print $3}')
 
-# Cleanup on exit
-SYNTH_YUVA422="$(mktemp --suffix=.yuv /dev/shm/synth_yuva422_XXXXXX)"
-SYNTH_YUVA444="$(mktemp --suffix=.yuv /dev/shm/synth_yuva444_XXXXXX)"
-trap 'rm -f "$RAMDISK_YUV" "$RAMDISK_JXS" "$SYNTH_YUVA422" "$SYNTH_YUVA444"' EXIT
+# 3G: RAMDISK_YUV/RAMDISK_JXS are fixed paths overwritten every iteration (not accumulated), and
+# each iteration's own files are removed once no longer needed (see the loop below) - so the real
+# peak is one row's worth: the largest MATRIX row (yuva444p8, bpp=5.0) needs ~2.4 GiB for the JXS
+# bitstream (2000 frames * 1920*1080*5/8 bytes) plus the raw YUV input and synth files - this
+# leaves only modest headroom, so don't shrink further than this.
+sudo mkdir -p "$RAMDISK_MOUNT"
+sudo mount -t tmpfs -o size=3G,mode=1777 tmpfs "$RAMDISK_MOUNT"
+trap 'sudo umount "$RAMDISK_MOUNT" 2>/dev/null || sudo umount -l "$RAMDISK_MOUNT" 2>/dev/null; sudo rmdir "$RAMDISK_MOUNT" 2>/dev/null' EXIT
+
+RUN_DIR="$RAMDISK_MOUNT"
+
+RAMDISK_YUV=$(mktemp --suffix=.yuv "$RUN_DIR/test_stream_XXXXXX")
+RAMDISK_JXS=$(mktemp --suffix=.jxs "$RUN_DIR/test_stream_XXXXXX")
+
+SYNTH_YUVA422="$(mktemp --suffix=.yuv "$RUN_DIR/synth_yuva422_XXXXXX")"
+SYNTH_YUVA444="$(mktemp --suffix=.yuv "$RUN_DIR/synth_yuva444_XXXXXX")"
 
 # No real 4-component (alpha) sample YUV exists in $SAMPLES_DIR. Synthesize small multi-frame
 # yuva422/yuva444 raw files on the fly from the real touchdown 8bit 422 sample (same technique as
@@ -76,7 +101,7 @@ if [ -f "$SYNTH_SRC" ]; then
         done
     done
     if [ ! -s "$SYNTH_YUVA422" ] || [ ! -s "$SYNTH_YUVA444" ]; then
-        echo "ERROR: synthesis of YUVA input files failed — check /dev/shm space: $(df -h /dev/shm | awk 'NR==2')"
+        echo "ERROR: synthesis of YUVA input files failed — check ramdisk space: $(df -h "$RUN_DIR" | awk 'NR==2')"
         exit 1
     fi
 fi
@@ -131,13 +156,26 @@ MATRIX=(
     "1080p60_422p10_msb|1920|1080|10|yuv422|60|3.0|8|encoder_tests/touchdown_1080p_yuv422p_10_bit_le_60_frames.yuv|359|571|--input-msb-aligned 1|--output-msb-aligned 1"
 )
 
-# run_measured cmd...: single run, prints parsed FPS (empty if unparseable).
+# run_measured cmd...: single run, prints parsed FPS (empty if unparseable or if the command
+# exited non-zero - EncApp/DecApp now abort on a write/close error, sometimes *after* already
+# printing a valid "average fps" line, so a non-zero exit must blank FPS even then).
+# This function must never itself return non-zero: every assignment/statement below is guarded
+# (&&/|| or unconditional) because the script runs under `set -eo pipefail`, and a bare failing
+# command in `enc_fps=$(run_measured ...)` position would abort the whole matrix loop instead of
+# letting check_result report a normal FAIL and continue to the next test case.
 function run_measured() {
-    local output fps
-    output=$("$@" 2>&1) || true
+    local output fps exit_code
+    output=$("$@" 2>&1) && exit_code=0 || exit_code=$?
     fps=$(echo "$output" | grep -oE 'average [0-9]+\.[0-9]+\[fps\]' | awk '{print $2}' | tr -d '[fps]' | tail -1) || true
 
-    [ -n "$fps" ] && echo "$fps"
+    if [ "$exit_code" -ne 0 ]; then
+        # Surface the app's own diagnostics (now including strerror(errno) on I/O failures)
+        # that would otherwise be captured into $output above and silently discarded.
+        echo "$output" >&2
+        fps=""
+    fi
+
+    echo "$fps"
 }
 
 # check_result label fps baseline_fps [enforce=1]: sets $STATUS/$PERCENT; sets SCRIPT_FAILED=1
@@ -225,7 +263,7 @@ for test_case in "${MATRIX[@]}"; do
 
     # --- Decode ---
     if [ ! -s "$RAMDISK_JXS" ]; then
-        echo "ERROR: No bitstream produced by encode step, skipping decode. /dev/shm: $(df -h /dev/shm | awk 'NR==2')"
+        echo "ERROR: No bitstream produced by encode step, skipping decode. ramdisk: $(df -h "$RUN_DIR" | awk 'NR==2')"
         [ "$ENFORCE" = "1" ] && SCRIPT_FAILED=1
         echo "DECODE,$test_case,$ASM_LEVEL,N/A,N/A,N/A,N/A,FAIL" >> "$CSV_FILE"
         rm -f "$RAMDISK_YUV" "$RAMDISK_JXS"


### PR DESCRIPTION
## Summary

Performance CI has been intermittently failing with:
ERROR: No bitstream produced by encode step, skipping decode. /dev/shm: tmpfs  126G  0  126G  0% /dev/shm



It's hit a different, unrelated test case each time (different format, bit depth, bpp, and thread count across three separate runs), never reproduces locally or via a manual run on the runner itself, and `df -h` always shows the tmpfs has plenty of free space — so it isn't disk exhaustion, and it isn't tied to the recent GCLI/PDEP vectorization work. The encoder always finishes its full encode loop and prints a normal `average N.NN[fps]` line before the bitstream turns up empty, with exit code 0.

Root cause of the *silence*: `EncApp`/`DecApp` never checked the return value of `fwrite()`/`fclose()` on the bitstream output file. A transient write or flush failure (most likely tied to the runner's dual-socket NUMA `--membind`, or contention with other jobs on the shared self-hosted runner - still unconfirmed) truncates the output but leaves the app reporting success.

## Changes

- **`EncAppMain.c` / `DecAppMain.c`**: check `fwrite()`/`fclose()` return values on the bitstream file. On failure, print `strerror(errno)` and exit non-zero instead of continuing silently.
- **`PerformanceTestSampleApp.sh`**: `run_measured()` previously discarded the process exit code entirely, so a close-only failure (FPS line already printed before a failing `fclose`) would still show `SUCCESS`. Now blanks the parsed FPS whenever the process exits non-zero, and dumps its output to stderr so the app's new error message actually reaches the log instead of being captured and thrown away.
  - `run_measured` is written to never itself return non-zero, since the script runs under `set -eo pipefail` and `enc_fps=$(run_measured ...)` would otherwise abort the *entire* matrix loop on the first failure instead of letting `check_result` report a normal `FAIL` and continue.

This doesn't fix whatever is causing the underlying write failure (still unreproduced), but it makes the next occurrence self-diagnosing instead of a silent empty file.